### PR TITLE
Update for ERA5 data atmosphere

### DIFF
--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -2072,6 +2072,7 @@
         u10   Sa_u
         v10   Sa_v
         t2m   Sa_tbot
+        skt   Sa_tskn
         d2m   Sa_tdew
         msl   Sa_pslv
         sp    Sa_pbot
@@ -2081,7 +2082,9 @@
         csf   Faxa_snowc
         lsf   Faxa_snowl
         ssrd  Faxa_swdn
+        ssr   Faxa_swnet
         strd  Faxa_lwdn
+        str   Faxa_lwnet
         aluvp Faxa_swvdr
         aluvd Faxa_swvdf
         alnip Faxa_swndr

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -102,5 +102,13 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+  <test compset="2000_DATM%ERA5_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
 
 </testlist>

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -121,7 +121,7 @@ contains
     do while (associated(fldlist))
        call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_LogWrite('(datm_comp_advertise): Fr_atm'//trim(fldList%stdname), ESMF_LOGMSG_INFO)
+       call ESMF_LogWrite('(datm_comp_advertise): Fr_atm '//trim(fldList%stdname), ESMF_LOGMSG_INFO)
        fldList => fldList%next
     enddo
 
@@ -255,7 +255,9 @@ contains
        Sa_z(n) = 10.0_r8
 
        !--- calculate wind speed ---
-       Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n)) 
+       if (associated(Sa_wspd)) then
+         Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n)) 
+       end if
 
        !--- temperature ---
        if (tbotmax < 50.0_r8) Sa_tbot(n) = Sa_tbot(n) + tkFrz

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -27,6 +27,7 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Sa_z(:)              => null()
   real(r8), pointer :: Sa_u(:)              => null()
   real(r8), pointer :: Sa_v(:)              => null()
+  real(r8), pointer :: Sa_wspd(:)           => null()
   real(r8), pointer :: Sa_tbot(:)           => null()
   real(r8), pointer :: Sa_ptem(:)           => null()
   real(r8), pointer :: Sa_shum(:)           => null()
@@ -34,6 +35,7 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Sa_pbot(:)           => null()
   real(r8), pointer :: Sa_pslv(:)           => null()
   real(r8), pointer :: Faxa_lwdn(:)         => null()
+  real(r8), pointer :: Faxa_lwnet(:)        => null()
   real(r8), pointer :: Faxa_rain(:)         => null()
   real(r8), pointer :: Faxa_rainc(:)        => null()
   real(r8), pointer :: Faxa_rainl(:)        => null()
@@ -61,7 +63,7 @@ module datm_datamode_era5_mod
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
   
-  character(*), parameter :: nullstr = 'null'
+  character(*), parameter :: nullstr = 'undefined'
   character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -89,7 +91,9 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_z'       )
     call dshr_fldList_add(fldsExport, 'Sa_u'       )
     call dshr_fldList_add(fldsExport, 'Sa_v'       )
+    call dshr_fldList_add(fldsExport, 'Sa_wspd'    )
     call dshr_fldList_add(fldsExport, 'Sa_tbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_tskn'    )
     call dshr_fldList_add(fldsExport, 'Sa_ptem'    )
     call dshr_fldList_add(fldsExport, 'Sa_dens'    )
     call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
@@ -104,9 +108,10 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swvdr' )
     call dshr_fldList_add(fldsExport, 'Faxa_swndf' )
     call dshr_fldList_add(fldsExport, 'Faxa_swvdf' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
-    call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
+    call dshr_fldList_add(fldsExport, 'Faxa_lwnet'  )
     call dshr_fldList_add(fldsExport, 'Faxa_sen'   )
     call dshr_fldList_add(fldsExport, 'Faxa_lat'   )
     call dshr_fldList_add(fldsExport, 'Faxa_taux'  )
@@ -144,6 +149,12 @@ contains
     ! get export state pointers
     call dshr_state_getfldptr(exportState, 'Sa_z'       , fldptr1=Sa_z       , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u'       , fldptr1=Sa_u       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_wspd'    , fldptr1=Sa_wspd    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_pbot'    , fldptr1=Sa_pbot    , rc=rc)
@@ -175,6 +186,8 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_swnet' , fldptr1=Faxa_swnet , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_swdn'  , fldptr1=Faxa_swdn  , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_lwnet' , fldptr1=Faxa_lwnet , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -241,6 +254,9 @@ contains
        !--- bottom layer height ---
        Sa_z(n) = 10.0_r8
 
+       !--- calculate wind speed ---
+       Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n)) 
+
        !--- temperature ---
        if (tbotmax < 50.0_r8) Sa_tbot(n) = Sa_tbot(n) + tkFrz
        ! Limit very cold forcing to 180K
@@ -265,8 +281,11 @@ contains
        Faxa_swvdf(n) = Faxa_swdn(n)*Faxa_swvdf(n)
        Faxa_swndf(n) = Faxa_swdn(n)*Faxa_swndf(n)
 
+       !--- TODO: need to understand relationship between shortwave bands and net shortwave rad.
+       !--- currently it is provided directly from ERA5 and the total of the bands are not
+       !--- consistent with the swnet
        !--- swnet: a diagnostic quantity ---
-       Faxa_swnet(n) = Faxa_swndr(n) + Faxa_swvdr(n) + Faxa_swndf(n) + Faxa_swvdf(n)
+       !Faxa_swnet(n) = Faxa_swndr(n) + Faxa_swvdr(n) + Faxa_swndf(n) + Faxa_swvdf(n)
     end do
 
     !----------------------------------------------------------
@@ -275,6 +294,7 @@ contains
 
     ! convert J/m^2 to W/m^2
     Faxa_lwdn(:) = Faxa_lwdn(:)/3600.0_r8
+    Faxa_lwnet(:) = Faxa_lwnet(:)/3600.0_r8
     Faxa_swdn(:) = Faxa_swdn(:)/3600.0_r8
     Faxa_swvdr(:) = Faxa_swvdr(:)/3600.0_r8
     Faxa_swndr(:) = Faxa_swndr(:)/3600.0_r8

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -44,17 +44,24 @@ contains
     integer          ,          intent(out)             :: rc
 
     ! local variables
-    type(ESMF_Field)           :: lfield
+    type(ESMF_Field)            :: lfield
+    integer                     :: itemCount 
     character(len=*), parameter :: subname='(dshr_state_getfldptr)'
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
+    call ESMF_StateGet(State, itemSearch=trim(fldname), itemCount=itemCount, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    ! check field is in the state or not?
+    if (itemCount >= 1) then
+      call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+      call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
 
   end subroutine dshr_state_getfldptr
 

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -61,6 +61,9 @@ contains
 
       call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    else
+      ! the call to just returns if it cannot find the field
+      call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//" just returning", ESMF_LOGMSG_INFO)
     end if
 
   end subroutine dshr_state_getfldptr


### PR DESCRIPTION
### Description of changes
This PR aims to update ERA5 data atmosphere to support UFS HAFS application. 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): This PR is linked to following CMEPS PR.
https://github.com/ESCOMP/CMEPS/pull/81

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [x] CMEPS (list) 
The HAFS specific exchange field table and definition is required and they are in https://github.com/ESCOMP/CMEPS/pull/81

Are changes expected to change answers?
 - [x] bit for bit (except ERA5 interface)
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers: Cheyenne, intel compiler
   - details (e.g. failed tests):

qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/components/cdeps/datm/cime_config/testdefs/testlist_datm.xml --xml-machine cheyenne --xml-category aux_cdeps

**FAIL:** SMS_Ln9.T42_T42.2000_DATM%QIA_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV

- [] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 1fca5af
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 9376b87
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 3fa3a75
