### PR TITLE
fix for fldptr return mode

### DIFF
--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -153,7 +153,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Sa_wspd'    , fldptr1=Sa_wspd    , rc=rc)
+    call dshr_state_getfldptr(exportState, 'Sa_wspd'    , fldptr1=Sa_wspd    , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -187,7 +187,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_swdn'  , fldptr1=Faxa_swdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Faxa_lwnet' , fldptr1=Faxa_lwnet , rc=rc)
+    call dshr_state_getfldptr(exportState, 'Faxa_lwnet' , fldptr1=Faxa_lwnet , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -296,7 +296,9 @@ contains
 
     ! convert J/m^2 to W/m^2
     Faxa_lwdn(:) = Faxa_lwdn(:)/3600.0_r8
-    Faxa_lwnet(:) = Faxa_lwnet(:)/3600.0_r8
+    if (associated(Faxa_lwnet)) then
+      Faxa_lwnet(:) = Faxa_lwnet(:)/3600.0_r8
+    end if
     Faxa_swdn(:) = Faxa_swdn(:)/3600.0_r8
     Faxa_swvdr(:) = Faxa_swvdr(:)/3600.0_r8
     Faxa_swndr(:) = Faxa_swndr(:)/3600.0_r8

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -30,7 +30,7 @@ module dshr_methods_mod
 contains
 !===============================================================================
 
-  subroutine dshr_state_getfldptr(State, fldname, fldptr1, fldptr2, rc)
+  subroutine dshr_state_getfldptr(State, fldname, fldptr1, fldptr2, allowNullReturn, rc)
 
     ! ----------------------------------------------
     ! Get pointer to a state field
@@ -41,6 +41,7 @@ contains
     character(len=*) ,          intent(in)              :: fldname
     real(R8)         , pointer, intent(inout), optional :: fldptr1(:)
     real(R8)         , pointer, intent(inout), optional :: fldptr2(:,:)
+    logical          ,          intent(in),optional     :: allowNullReturn        
     integer          ,          intent(out)             :: rc
 
     ! local variables
@@ -51,19 +52,27 @@ contains
 
     rc = ESMF_SUCCESS
 
-    call ESMF_StateGet(State, itemSearch=trim(fldname), itemCount=itemCount, rc=rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    if (present(allowNullReturn)) then
+      call ESMF_StateGet(State, itemSearch=trim(fldname), itemCount=itemCount, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! check field is in the state or not?
-    if (itemCount >= 1) then
+      ! check field is in the state or not?
+      if (itemCount >= 1) then
+        call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+        call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      else
+        ! the call to just returns if it cannot find the field
+        call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//" just returning", ESMF_LOGMSG_INFO)
+      end if
+    else
       call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
-    else
-      ! the call to just returns if it cannot find the field
-      call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//" just returning", ESMF_LOGMSG_INFO)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return      
     end if
 
   end subroutine dshr_state_getfldptr


### PR DESCRIPTION
### Description of changes

This PR aims to fix the behavior of dshr_state_getfldptr in streams/dshr_methods_mod.F90

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../src/components/cdeps/datm/cime_config/testdefs/testlist_datm.xml --xml-machine cheyenne --xml-category aux_cdeps

FAIL: SMS_Ln9.T42_T42.2000_DATM%QIA_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 1fca5af
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: d1d06c1
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 3fa3a75
