### PR TITLE
Simple python-3  fix, fixing #24

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def buildlib(bldroot, libroot, case, compname=None):
     if bldroot.endswith("obj") and not compname:
         compname = os.path.basename(os.path.abspath(os.path.join(bldroot,os.pardir)))
-    print "HERE compname is {} libroot={} bldroot={}".format(compname, libroot, bldroot)
+    print( "HERE compname is {} libroot={} bldroot={}".format(compname, libroot, bldroot) )
 
     if case.get_value("DEBUG"):
         strdebug = "debug"


### PR DESCRIPTION
### Description of changes

Simple python-3 fix

### Specific notes

Contributors other than yourself, if any: None

CMEPS Issues Fixed (include github issue #):
  Fixes #24

Are there dependencies on other component PRs: No
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers? No
 - [ x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ x] No

Testing performed:
 Just ran a single test:

  SMS_D_P720x1_Vnuopc_Ld10.f19_g17_r05.I2000Clm50SpGs.cheyenne_intel.rtm-default

Ran preview_namelist with both python-2.7 and python-3

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ekluzek/CESM.git
  - describe: cime5.8.26-27-g4b3af5508
  - branch: mizuRoute
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:70b5daa
- [ ] CTSM
  - repository to check out: https://github.com/ESCOMP/CTSM.git
  - branch: add_mizuRoute
  - hash:
