### PR TITLE
improve the build, remove hardcoded path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(NUOPC_DATA_MODELS LANGUAGES Fortran VERSION 0.1)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+message("CMAKE_C_COMPILER is ${CMAKE_C_COMPILER}")
 include(ExternalProject)
 find_package(ESMF REQUIRED)
 if (DEFINED PIO)

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -53,18 +53,18 @@ def buildlib(bldroot, libroot, case, compname=None):
             expect(False, "ERROR in {} build {} {}".format(compname,o,e))
     else:
         logger.info("Running cmake for CDEPS")
-        srcpath = os.path.join(case.get_value("SRCROOT"),"components","cdeps")
+        srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__),os.pardir))
 
         cmake_flags = get_standard_cmake_args(case, os.path.join(sharedpath,"cdeps"), shared_lib=True)
         ccomp, cxxcomp, fcomp = get_compiler_names(case)
 
         cmake_flags += " -DCMAKE_C_COMPILER={} -DCMAKE_CXX_COMPILER={} -DCMAKE_Fortran_COMPILER={}".format(ccomp, cxxcomp, fcomp)
         cmake_flags += " -DCMAKE_INSTALL_PREFIX={} ".format(libroot)
-        cmake_flags += " -DLIBROOT={} ".format(libroot) + srcpath
+        cmake_flags += " -DLIBROOT={} ".format(libroot)
         cmake_flags += " -DMPILIB={} ".format(mpilib)
         cmake_flags += " -DPIO_C_LIBRARY={path}/lib -DPIO_C_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
         cmake_flags += " -DPIO_Fortran_LIBRARY={path}/lib -DPIO_Fortran_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
-
+        cmake_flags += srcpath
         logger.info("cmake_flags {}".format(cmake_flags))
         s,o,e = run_cmd("cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True)
         expect(not s,"ERROR from cmake output={}, error={}".format(o,e))


### PR DESCRIPTION
### Description of changes
Replace hard coded paths
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs NO
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [x ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x ] No

Testing performed:
- [x ] (required) aux_cdeps
   - machines and compilers: cheyenne intel
   - details (e.g. failed tests):
All tests pass except SMS_Ln9.T42_T42.2000_DATM%QIA_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV.cheyenne_intel.datm-scam
which is required to be on 1 pe but is currently using 36, passes after setting NTASKS=1

- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash: 19c9e54d0
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash:01dfe9a
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
