### PR TITLE
try to remove all warnings

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -110,6 +110,6 @@ jobs:
           git submodule update
           mkdir build-cdeps
           pushd build-cdeps
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-g -Wall -ffree-form -ffree-line-length-none -Werror " ../
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-g -Wall -ffree-form -ffree-line-length-none  " ../
           make VERBOSE=1
           popd

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -110,6 +110,6 @@ jobs:
           git submodule update
           mkdir build-cdeps
           pushd build-cdeps
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-g -Wall -ffree-form -ffree-line-length-none" ../
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-g -Wall -ffree-form -ffree-line-length-none -Werror " ../
           make VERBOSE=1
           popd

--- a/share/shr_assert_mod.F90.in
+++ b/share/shr_assert_mod.F90.in
@@ -80,9 +80,11 @@ subroutine shr_assert(var, msg, file, line)
   integer         , intent(in), optional :: line
 
   character(len=:), allocatable :: full_msg
-  
-  full_msg = ''
+  integer :: mlen = 0
+
   if (.not. var) then
+     if(present(msg)) mlen=len(msg)
+     allocate(full_msg(mlen+80))
      full_msg = 'ERROR'
      if (present(file)) then
         full_msg = full_msg // ' in ' // trim(file)

--- a/share/shr_assert_mod.F90.in
+++ b/share/shr_assert_mod.F90.in
@@ -84,7 +84,7 @@ subroutine shr_assert(var, msg, file, line)
 
   if (.not. var) then
      if(present(msg)) mlen=len(msg)
-     allocate(full_msg(mlen+80))
+     allocate(full_msg(1:mlen+80))
      full_msg = 'ERROR'
      if (present(file)) then
         full_msg = full_msg // ' in ' // trim(file)

--- a/share/shr_assert_mod.F90.in
+++ b/share/shr_assert_mod.F90.in
@@ -84,7 +84,7 @@ subroutine shr_assert(var, msg, file, line)
 
   if (.not. var) then
      if(present(msg)) mlen=len(msg)
-     allocate(full_msg(1:mlen+80))
+     allocate(character(len=mlen+80) :: full_msg)
      full_msg = 'ERROR'
      if (present(file)) then
         full_msg = full_msg // ' in ' // trim(file)


### PR DESCRIPTION
### Description of changes
Use github actions to remove and avoid gfortran compiler warnings.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
