### PR TITLE
fix for performance slowdown and new dynamic fraction/mask capability

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -99,8 +99,12 @@ class StreamCDEPS(GenericXML):
                         stream_datafiles = child.xml_element.text
                         stream_datafiles = self._resolve_values(case, stream_datafiles)
                         if 'first_year' in child.xml_element.attrib and 'last_year' in child.xml_element.attrib:
-                            stream_year_first= int(child.xml_element.get('first_year'))
-                            stream_year_last = int(child.xml_element.get('last_year'))
+                            value = child.xml_element.get('first_year') 
+                            value = self._resolve_values(case, value)
+                            stream_year_first= int(value)
+                            value = child.xml_element.get('last_year') 
+                            value = self._resolve_values(case, value)
+                            stream_year_last = int(value)
                             year_first = max(stream_year_first, data_year_first)
                             year_last = min(stream_year_last, data_year_last)
                             stream_datafiles = self._sub_paths(stream_datafiles, year_first, year_last)
@@ -117,6 +121,7 @@ class StreamCDEPS(GenericXML):
                       or node_name == 'stream_taxmode' 
                       or node_name == 'stream_dtlimit'):
                     attributes['model_grid'] = case.get_value("GRID")
+                    attributes['compset'] = case.get_value("COMPSET")
                     value = self._get_value_match(node, node_name[7:], attributes=attributes)
                     value = self._resolve_values(case, value)
                     value = value.strip()

--- a/cime_config/streams_v2.0.xsd
+++ b/cime_config/streams_v2.0.xsd
@@ -6,9 +6,10 @@
   <!-- ======================== -->
 
   <xs:attribute name="name"       type="xs:string"/>
-  <xs:attribute name="first_year" type="xs:integer"/>
-  <xs:attribute name="last_year"  type="xs:integer"/>
+  <xs:attribute name="first_year" type="xs:string"/>
+  <xs:attribute name="last_year"  type="xs:string"/>
   <xs:attribute name="model_grid" type="xs:string"/>
+  <xs:attribute name="compset"    type="xs:string"/>
   <xs:attribute name="version"    type="xs:string"/>
 
   <!-- ======================== -->
@@ -16,9 +17,9 @@
   <!-- ======================== -->
 
   <xs:element name="stream_lev_dimname" type="xs:string"/>
-  <xs:element name="stream_year_first"  type="xs:string"/> 
-  <xs:element name="stream_year_last"   type="xs:string"/> 
-  <xs:element name="stream_year_align"  type="xs:string"/> 
+  <xs:element name="stream_year_first"  type="xs:string"/>
+  <xs:element name="stream_year_last"   type="xs:string"/>
+  <xs:element name="stream_year_align"  type="xs:string"/>
   <xs:element name="stream_offset"      type="xs:integer"/>
 
   <xs:element name="stream_readmode">
@@ -32,13 +33,13 @@
 
   <xs:element name="stream_vectors">
     <xs:simpleType>
-      <xs:list itemType="xs:string"/> 
+      <xs:list itemType="xs:string"/>
     </xs:simpleType>
   </xs:element>
 
   <xs:element name="var">
     <xs:simpleType>
-      <xs:list itemType="xs:string"/> 
+      <xs:list itemType="xs:string"/>
     </xs:simpleType>
   </xs:element>
 
@@ -76,6 +77,7 @@
       <xs:simpleContent>
         <xs:extension base="xs:string">
           <xs:attribute name="model_grid" type="xs:string" />
+          <xs:attribute name="compset" type="xs:string" />
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -100,6 +102,7 @@
       <xs:simpleContent>
         <xs:extension base="taxmodeType">
           <xs:attribute ref="model_grid"/>
+          <xs:attribute ref="compset"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -125,6 +128,7 @@
       <xs:simpleContent>
         <xs:extension base="mapalgoType">
           <xs:attribute ref="model_grid"/>
+          <xs:attribute ref="compset"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -142,6 +146,7 @@
       <xs:simpleContent>
         <xs:extension base="xs:string">
           <xs:attribute ref="model_grid"/>
+          <xs:attribute ref="compset"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>

--- a/datm/CMakeLists.txt
+++ b/datm/CMakeLists.txt
@@ -2,6 +2,7 @@ project(datm Fortran)
 
 add_library(datm atm_comp_nuopc.F90
 		 datm_datamode_clmncep_mod.F90
+		 datm_datamode_cplhist_mod.F90
 		 datm_datamode_core2_mod.F90
 		 datm_datamode_jra_mod.F90
 		 datm_datamode_era5_mod.F90)

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -26,21 +26,31 @@ module atm_comp_nuopc
   use dshr_mod         , only : dshr_orbital_init, dshr_orbital_update
   use dshr_dfield_mod  , only : dfield_type, dshr_dfield_add, dshr_dfield_copy
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add, dshr_fldlist_realize
+
   use datm_datamode_core2_mod   , only : datm_datamode_core2_advertise
   use datm_datamode_core2_mod   , only : datm_datamode_core2_init_pointers
   use datm_datamode_core2_mod   , only : datm_datamode_core2_advance
   use datm_datamode_core2_mod   , only : datm_datamode_core2_restart_write
   use datm_datamode_core2_mod   , only : datm_datamode_core2_restart_read
+
   use datm_datamode_jra_mod     , only : datm_datamode_jra_advertise
   use datm_datamode_jra_mod     , only : datm_datamode_jra_init_pointers
   use datm_datamode_jra_mod     , only : datm_datamode_jra_advance
   use datm_datamode_jra_mod     , only : datm_datamode_jra_restart_write
   use datm_datamode_jra_mod     , only : datm_datamode_jra_restart_read
+
   use datm_datamode_clmncep_mod , only : datm_datamode_clmncep_advertise
   use datm_datamode_clmncep_mod , only : datm_datamode_clmncep_init_pointers
   use datm_datamode_clmncep_mod , only : datm_datamode_clmncep_advance
   use datm_datamode_clmncep_mod , only : datm_datamode_clmncep_restart_write
   use datm_datamode_clmncep_mod , only : datm_datamode_clmncep_restart_read
+
+  use datm_datamode_cplhist_mod , only : datm_datamode_cplhist_advertise
+  use datm_datamode_cplhist_mod , only : datm_datamode_cplhist_init_pointers
+  use datm_datamode_cplhist_mod , only : datm_datamode_cplhist_advance
+  use datm_datamode_cplhist_mod , only : datm_datamode_cplhist_restart_write
+  use datm_datamode_cplhist_mod , only : datm_datamode_cplhist_restart_read
+
   use datm_datamode_era5_mod    , only : datm_datamode_era5_advertise
   use datm_datamode_era5_mod    , only : datm_datamode_era5_init_pointers
   use datm_datamode_era5_mod    , only : datm_datamode_era5_advance
@@ -284,6 +294,7 @@ contains
          trim(datamode) == 'CORE2_IAF'    .or. &
          trim(datamode) == 'CORE_IAF_JRA' .or. &
          trim(datamode) == 'CLMNCEP'      .or. &
+         trim(datamode) == 'CPLHIST'      .or. &
          trim(datamode) == 'ERA5') then
     else
        call shr_sys_abort(' ERROR illegal datm datamode = '//trim(datamode))
@@ -300,6 +311,10 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CLMNCEP')
        call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, &
+            flds_co2, flds_wiso, flds_presaero, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case ('CPLHIST')
+       call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, &
             flds_co2, flds_wiso, flds_presaero, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('ERA5')
@@ -538,6 +553,9 @@ contains
        case('CLMNCEP')
           call datm_datamode_clmncep_init_pointers(importState, exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case('CPLHIST')
+          call datm_datamode_cplhist_init_pointers(importState, exportState, sdat, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('ERA5')
           call datm_datamode_era5_init_pointers(exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -552,6 +570,8 @@ contains
              call datm_datamode_jra_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           case('CLMNCEP')
              call datm_datamode_clmncep_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
+          case('CPLHIST')
+             call datm_datamode_cplhist_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           case('ERA5')
              call datm_datamode_era5_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           end select
@@ -594,6 +614,9 @@ contains
     case('CLMNCEP')
        call datm_datamode_clmncep_advance(masterproc, logunit, mpicom,  rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case('CPLHIST')
+       call datm_datamode_cplhist_advance(masterproc, logunit, mpicom,  rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('ERA5')
        call datm_datamode_era5_advance(exportstate, masterproc, logunit, mpicom, target_ymd, &
             target_tod, sdat%model_calendar, rc)
@@ -613,6 +636,10 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('CLMNCEP')
           call datm_datamode_clmncep_restart_write(case_name, inst_suffix, target_ymd, target_tod, &
+               logunit, my_task, sdat)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case('CPLHIST')
+          call datm_datamode_cplhist_restart_write(case_name, inst_suffix, target_ymd, target_tod, &
                logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('ERA5')

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -18,6 +18,11 @@
   %ym   => year-month from the range yearfirst to yearlast with all 12 months
   %ymd  => year-month-day from the range yearfirst to yearlast with all 12 months
 
+  ****** 
+  NOTE:
+  any <file></file> entry that has %y, %ym or %ymd MUST have first_year and last_year syntax
+  ****** 
+
   Each mode below, except for presaero, has a set of streams associated with it
   The presaero stream, is associated with all modes
 
@@ -538,7 +543,7 @@
       <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/clmforc.Qian.c2006.T62.ESMFmesh_120620.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/datm7/atm_forcing_iso.datm7.Qian.T62.c080727/Precip6Hrly/clmforc.Qian.c2006.T62.Prec.%ym.nc</file>
+      <file  first_year="1948" last_year="2004">$DIN_LOC_ROOT/atm/datm7/atm_forcing_iso.datm7.Qian.T62.c080727/Precip6Hrly/clmforc.Qian.c2006.T62.Prec.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>PRECTmms Faxa_precn</var>
@@ -710,7 +715,7 @@
       <meshfile>none</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file >$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/mexicocityMEX.c080124/clm1pt-1993-12.nc</file>
+      <file>$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/mexicocityMEX.c080124/clm1pt-1993-12.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>ZBOT     Sa_z</var>
@@ -846,10 +851,10 @@
 
   <stream_entry name="BC.QIAN.Precip">
     <stream_meshfile>
-      <meshfile><!-- $DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian/bias_correction.Prec.%y.nc --></meshfile>
+      <meshfile>$DIN_LOC_ROOT/share/meshes/bias_correction_gpcp_qian.Prec_ESMFmesh_cdf5_110121.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian/bias_correction.Prec.%y.nc</file>
+      <file first_year="1979" last_year="2004">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian/bias_correction.Prec.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>BC_PREC  Faxa_precsf</var>
@@ -878,10 +883,10 @@
 
   <stream_entry name="BC.CRUNCEP.GPCP.Precip">
     <stream_meshfile>
-      <meshfile><!-- $DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction/bias_correction.Prec.%y.nc --></meshfile>
+      <meshfile>$DIN_LOC_ROOT/share/meshes/bias_correction_gpcp_cruncep.Prec_ESMFmesh_cdf5_110121.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction/bias_correction.Prec.%y.nc</file>
+      <file first_year="1979" last_year="2012">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction/bias_correction.Prec.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>BC_PREC  Faxa_precsf</var>
@@ -910,10 +915,10 @@
 
   <stream_entry name="BC.CRUNCEP.CMAP.Precip">
     <stream_meshfile>
-      <meshfile><!-- $DIN_LOC_ROOT/atm/datm7/bias_correction/precip/cmap/cruncep/bias_correction.Prec.%y.nc --></meshfile>
+      <meshfile>$DIN_LOC_ROOT/share/meshes/bias_correction_gpcp_cmap.Prec_ESMFmesh_cdf5_110121.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/cmap/cruncep/bias_correction.Prec.%y.nc</file>
+      <file first_year="1979" last_year="2010">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/cmap/cruncep/bias_correction.Prec.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>BC_PREC  Faxa_precsf</var>
@@ -3422,7 +3427,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
    </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Sa_topo  Sa_topo</var>
@@ -3453,7 +3458,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1d_Faxa_bcphiwet  Faxa_bcphiwet</var>
@@ -3498,7 +3503,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1hi_Faxa_swndr Faxa_swndr</var>
@@ -3533,7 +3538,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Faxa_rainc Faxa_rainc</var>
@@ -3569,7 +3574,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Sa_z       Sa_z</var>
@@ -3609,7 +3614,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1h.%ym.nc</file>
+      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1h_Sa_u  Sa_u</var>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -627,7 +627,7 @@
   </stream_entry>
 
   <!-- ===================-->
-  <!-- datm_mode CLMNLDAS2-->
+  <!-- datm_mode CLMNLDAS2 - ASSUME that model grid must be the forcing data grid-->
   <!-- ===================-->
 
   <stream_entry name="CLMNLDAS2.Solar">
@@ -642,8 +642,7 @@
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
-      <mapalgo>bilinear</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
+      <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
@@ -655,11 +654,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -676,8 +673,7 @@
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
-      <mapalgo>bilinear</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
+      <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
@@ -689,11 +685,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -714,8 +708,7 @@
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
-      <mapalgo>bilinear</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
+      <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
@@ -727,11 +720,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -218,11 +218,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -252,11 +250,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -290,11 +286,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -316,7 +310,6 @@
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
       <mapalgo>bilinear</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
@@ -328,11 +321,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -350,7 +341,6 @@
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
       <mapalgo>bilinear</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
@@ -362,11 +352,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -399,11 +387,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -437,11 +423,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -471,11 +455,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -508,11 +490,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -546,11 +526,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -580,11 +558,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -617,11 +593,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -895,11 +869,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -929,11 +901,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -963,11 +933,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1001,11 +969,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1035,11 +1001,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1069,11 +1033,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1103,11 +1065,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1137,11 +1097,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1171,11 +1129,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1205,11 +1161,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1239,11 +1193,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1279,11 +1231,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1313,11 +1263,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1352,11 +1300,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1390,11 +1336,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1424,11 +1368,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1458,11 +1400,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1492,11 +1432,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1526,11 +1464,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1560,11 +1496,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1594,11 +1528,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1628,11 +1560,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1662,11 +1592,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1696,11 +1624,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1731,11 +1657,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1766,11 +1690,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1801,11 +1723,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1836,11 +1756,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1873,11 +1791,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1910,11 +1826,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1947,11 +1861,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -1984,11 +1896,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2021,11 +1931,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2058,11 +1966,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2092,7 +1998,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2137,11 +2042,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2171,11 +2074,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2205,11 +2106,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2239,11 +2138,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2273,11 +2170,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2307,11 +2202,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2341,11 +2234,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2375,11 +2266,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2409,7 +2298,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2481,11 +2369,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2509,7 +2395,6 @@
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
       <mapalgo>none</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>1850</stream_year_align>
@@ -2521,7 +2406,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2542,7 +2426,6 @@
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
       <mapalgo>none</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>213</stream_year_align> <!-- 6*(2009-1948+1)-(2009-1850) -->
@@ -2553,12 +2436,10 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode>extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2576,7 +2457,6 @@
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
       <mapalgo>none</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>198</stream_year_align> <!-- 6*(2018-1958+1)-(2018-1850) -->
@@ -2587,12 +2467,10 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode>extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -2622,7 +2500,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2655,7 +2532,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2688,7 +2564,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2721,7 +2596,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2754,7 +2628,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2787,7 +2660,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2820,7 +2692,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2853,7 +2724,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2886,7 +2756,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2919,7 +2788,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2952,7 +2820,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -2985,7 +2852,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -3018,7 +2884,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -3051,7 +2916,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -3084,7 +2948,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -3117,7 +2980,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>extend</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>
@@ -3156,7 +3018,6 @@
     <stream_mapalgo>
       <mapalgo>bilinear</mapalgo>
       <mapalgo model_grid="1x1">nn</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>1</stream_year_align>
@@ -3168,11 +3029,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3204,7 +3065,6 @@
     <stream_mapalgo>
       <mapalgo>bilinear</mapalgo>
       <mapalgo model_grid="1x1">nn</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>1</stream_year_align>
@@ -3216,11 +3076,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3252,7 +3112,6 @@
     <stream_mapalgo>
       <mapalgo>bilinear</mapalgo>
       <mapalgo model_grid="1x1">nn</mapalgo>
-      <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
     <stream_year_align>1</stream_year_align>
@@ -3264,11 +3123,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3311,11 +3170,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3358,11 +3217,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3405,11 +3264,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3452,10 +3311,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3498,11 +3358,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
+      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
+      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3582,7 +3442,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3627,7 +3486,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3663,7 +3521,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3700,7 +3557,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3741,7 +3597,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3775,7 +3630,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>3.0</dtlimit>
@@ -3816,11 +3670,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit model_grid="1x1">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -1,0 +1,233 @@
+module datm_datamode_cplhist_mod
+
+  use ESMF
+  use NUOPC            , only : NUOPC_Advertise
+  use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_sys_mod      , only : shr_sys_abort
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_mod         , only : dshr_restart_read, dshr_restart_write
+  use dshr_strdata_mod , only : shr_strdata_type
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private ! except
+
+  public  :: datm_datamode_cplhist_advertise
+  public  :: datm_datamode_cplhist_init_pointers
+  public  :: datm_datamode_cplhist_advance
+  public  :: datm_datamode_cplhist_restart_write
+  public  :: datm_datamode_cplhist_restart_read
+
+  ! export state data
+  real(r8), pointer :: Sa_z(:)              => null()
+  real(r8), pointer :: Sa_u(:)              => null()
+  real(r8), pointer :: Sa_v(:)              => null()
+  real(r8), pointer :: Sa_tbot(:)           => null()
+  real(r8), pointer :: Sa_ptem(:)           => null()
+  real(r8), pointer :: Sa_shum(:)           => null()
+  real(r8), pointer :: Sa_shum_wiso(:,:)    => null() ! water isotopes
+  real(r8), pointer :: Sa_dens(:)           => null()
+  real(r8), pointer :: Sa_pbot(:)           => null()
+  real(r8), pointer :: Sa_pslv(:)           => null()
+  real(r8), pointer :: Faxa_lwdn(:)         => null()
+  real(r8), pointer :: Faxa_rainc(:)        => null()
+  real(r8), pointer :: Faxa_rainl(:)        => null()
+  real(r8), pointer :: Faxa_snowc(:)        => null()
+  real(r8), pointer :: Faxa_snowl(:)        => null()
+  real(r8), pointer :: Faxa_swndr(:)        => null()
+  real(r8), pointer :: Faxa_swndf(:)        => null()
+  real(r8), pointer :: Faxa_swvdr(:)        => null()
+  real(r8), pointer :: Faxa_swvdf(:)        => null()
+  real(r8), pointer :: Faxa_swnet(:)        => null()
+
+  character(*), parameter :: nullstr = 'null'
+  character(*), parameter :: rpfile  = 'rpointer.atm'
+  character(*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, &
+       flds_co2, flds_wiso, presaero, rc)
+
+    ! input/output variables
+    type(esmf_State)   , intent(inout) :: exportState
+    type(fldlist_type) , pointer       :: fldsexport
+    logical            , intent(in)    :: flds_co2
+    logical            , intent(in)    :: flds_wiso
+    logical            , intent(in)    :: presaero
+    character(len=*)   , intent(in)    :: flds_scalar_name
+    integer            , intent(out)   :: rc
+
+    ! local variables
+    type(fldlist_type), pointer :: fldList
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call dshr_fldList_add(fldsExport, trim(flds_scalar_name))
+    call dshr_fldList_add(fldsExport, 'Sa_topo'    )
+    call dshr_fldList_add(fldsExport, 'Sa_z'       )
+    call dshr_fldList_add(fldsExport, 'Sa_u'       )
+    call dshr_fldList_add(fldsExport, 'Sa_v'       )
+    call dshr_fldList_add(fldsExport, 'Sa_ptem'    )
+    call dshr_fldList_add(fldsExport, 'Sa_dens'    )
+    call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
+    call dshr_fldList_add(fldsExport, 'Sa_tbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_pbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_shum'    )
+    call dshr_fldList_add(fldsExport, 'Faxa_rainc' )
+    call dshr_fldList_add(fldsExport, 'Faxa_rainl' )
+    call dshr_fldList_add(fldsExport, 'Faxa_snowc' )
+    call dshr_fldList_add(fldsExport, 'Faxa_snowl' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swndr' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swvdr' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swndf' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swvdf' )
+    call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
+    call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
+    call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
+    if (flds_co2) then
+       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
+       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
+    end if
+    if (presaero) then
+       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
+       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
+    end if
+    if (flds_wiso) then
+       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
+       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
+    end if
+
+    fldlist => fldsExport ! the head of the linked list
+    do while (associated(fldlist))
+       call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite('(datm_comp_advertise): Fr_atm'//trim(fldList%stdname), ESMF_LOGMSG_INFO)
+       fldList => fldList%next
+    enddo
+
+  end subroutine datm_datamode_cplhist_advertise
+
+  !===============================================================================
+  subroutine datm_datamode_cplhist_init_pointers(importState, exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: importState
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    type(ESMF_StateItem_Flag) :: itemFlag
+    character(len=*), parameter :: subname='(datm_init_pointers): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! get export state pointers
+    call dshr_state_getfldptr(exportState, 'Sa_z'       , fldptr1=Sa_z       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u'       , fldptr1=Sa_u       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_pbot'    , fldptr1=Sa_pbot    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_pslv'    , fldptr1=Sa_pslv    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_ptem'    , fldptr1=Sa_ptem    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_shum'    , fldptr1=Sa_shum    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_dens'    , fldptr1=Sa_dens    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_rainc' , fldptr1=Faxa_rainc , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_rainl' , fldptr1=Faxa_rainl , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_snowc' , fldptr1=Faxa_snowc , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_snowl' , fldptr1=Faxa_snowl , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_swvdr' , fldptr1=Faxa_swvdr , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_swvdf' , fldptr1=Faxa_swvdf , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_swndr' , fldptr1=Faxa_swndr , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_swndf' , fldptr1=Faxa_swndf , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_swnet' , fldptr1=Faxa_swnet , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine datm_datamode_cplhist_init_pointers
+
+  !===============================================================================
+  subroutine datm_datamode_cplhist_advance(masterproc, logunit, mpicom, rc)
+
+    ! input/output variables
+    logical                , intent(in)    :: masterproc
+    integer                , intent(in)    :: logunit
+    integer                , intent(in)    :: mpicom
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_datamode_cplhist_advance): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! For now - do nothing special
+
+  end subroutine datm_datamode_cplhist_advance
+
+  !===============================================================================
+  subroutine datm_datamode_cplhist_restart_write(case_name, inst_suffix, ymd, tod, &
+       logunit, my_task, sdat)
+    
+    ! input/output variables
+    character(len=*)            , intent(in)    :: case_name
+    character(len=*)            , intent(in)    :: inst_suffix
+    integer                     , intent(in)    :: ymd       ! model date
+    integer                     , intent(in)    :: tod       ! model sec into model date
+    integer                     , intent(in)    :: logunit
+    integer                     , intent(in)    :: my_task
+    type(shr_strdata_type)      , intent(inout) :: sdat
+    !-------------------------------------------------------------------------------
+
+    call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, ymd, tod, &
+         logunit, my_task, sdat)
+
+  end subroutine datm_datamode_cplhist_restart_write
+
+  !===============================================================================
+  subroutine datm_datamode_cplhist_restart_read(rest_filem, inst_suffix, logunit, my_task, mpicom, sdat)
+
+    ! input/output arguments
+    character(len=*)            , intent(inout) :: rest_filem
+    character(len=*)            , intent(in)    :: inst_suffix
+    integer                     , intent(in)    :: logunit
+    integer                     , intent(in)    :: my_task
+    integer                     , intent(in)    :: mpicom
+    type(shr_strdata_type)      , intent(inout) :: sdat
+    !-------------------------------------------------------------------------------
+
+    call dshr_restart_read(rest_filem, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
+
+  end subroutine datm_datamode_cplhist_restart_read
+
+end module datm_datamode_cplhist_mod

--- a/dlnd/cime_config/buildnml
+++ b/dlnd/cime_config/buildnml
@@ -61,7 +61,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config = {}
     config['dlnd_mode'] = dlnd_mode
     config['create_mesh'] = 'true' if case.get_value("LND_DOMAIN_MESH") == 'create_mesh' else 'false'
-    config['set_model_maskfile'] = 'true' if dlnd_mode == 'SCPL' or dlnd_mode == 'LCPL' else 'false'
 
     # Do not allow single column mode for drof
     scol_mode = True if case.get_value('PTS_MODE') else False

--- a/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -56,11 +56,10 @@
     <input_pathname>abs</input_pathname>
     <group>dlnd_nml</group>
     <desc>
-      file specifying model mask if not obtained from input model mesh
+      file specifying file to use to obtain model mask
     </desc>
     <values>
-      <value>$LND_DOMAIN_MESH</value>
-      <value set_model_maskfile='true'>$LND_DOMAIN_PATH/$LND_DOMAIN_FILE</value>
+      <value>$MASK_MESH</value>
     </values>
   </entry>
 

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -206,7 +206,6 @@ contains
           write(logunit,F00)' model_maskfile = ',trim(model_maskfile)
        end if
        write(logunit ,*)' datamode              = ',datamode
-       write(logunit ,*)' model_meshfile        = ',trim(model_meshfile)
        write(logunit ,*)' nx_global             = ',nx_global
        write(logunit ,*)' ny_global             = ',ny_global
        write(logunit ,*)' restfilm              = ',trim(restfilm)

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -52,6 +52,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     atm_nx = case.get_value("ATM_NX")
     atm_ny = case.get_value("ATM_NY")
     model_grid = case.get_value("GRID")
+    mask_grid = case.get_value('MASK_GRID')
 
     # Check for incompatible options.
     expect(ocn_grid != "null",
@@ -64,12 +65,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     # Initialize namelist defaults
     config = {}
     config['model_grid'] = model_grid
+    config['mask_grid'] = mask_grid
     config['ocn_grid'] = ocn_grid
     config['docn_mode'] = docn_mode
     config['create_mesh'] = 'true' if case.get_value("OCN_DOMAIN_MESH") == 'create_mesh' else 'false'
-    aquaplanet_mode = True if 'AQ' in case.get_value('COMPSET') else False
     scol_mode = True if case.get_value('PTS_MODE') else False
-    config['set_model_maskfile'] = 'true' if scol_mode or (ocn_nx==atm_nx and ocn_ny==atm_ny and not aquaplanet_mode) else 'false'
 
     nmlgen.init_defaults(infile, config)
 

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -85,7 +85,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     #endif
     if generate_stream_file:
         streamlist = nmlgen.get_streams()
-        print "DEBUG: streamlist is ",streamlist
         stream_file = os.path.join(_CDEPS_CONFIG,os.pardir, "docn","cime_config","stream_definition_docn.xml")
         schema_file = os.path.join(_CDEPS_CONFIG,"streams_v2.0.xsd")
         streams = StreamCDEPS(stream_file, schema_file)

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -65,10 +65,10 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     # Initialize namelist defaults
     config = {}
     config['model_grid'] = model_grid
-    config['mask_grid'] = mask_grid
     config['ocn_grid'] = ocn_grid
     config['docn_mode'] = docn_mode
     config['create_mesh'] = 'true' if case.get_value("OCN_DOMAIN_MESH") == 'create_mesh' else 'false'
+    config['aqua_planet'] = 'true' if 'aquap' in docn_mode else 'false'
     scol_mode = True if case.get_value('PTS_MODE') else False
 
     nmlgen.init_defaults(infile, config)

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -133,12 +133,8 @@
       MESH for ocn mask
     </desc>
     <values>
-      <!-- TODO: need to move these to config_grids.xml -->
-      <value>$OCN_DOMAIN_MESH</value>
-      <value mask_grid="gx3v7">$DIN_LOC_ROOT/share/meshes/gx1v6_090205_ESMFmesh.nc</value>
-      <value mask_grid="gx1v7">$DIN_LOC_ROOT/share/meshes/gx1v7_151008_ESMFmesh.nc</value>
-      <value mask_grid="tx0.66v1">$DIN_LOC_ROOT/share/meshes/tx0.66v1_190314_ESMFmesh.nc</value>
-      <value mask_grid="tx0.1v2">$DIN_LOC_ROOT/share/meshes/tx0.25v1_190204_ESMFmesh.nc</value>
+      <value>$MASK_MESH</value>
+      <value aqua_planet="true">$ATM_DOMAIN_MESH</value>
     </values>
   </entry>
 

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -133,7 +133,7 @@
       MESH for ocn mask
     </desc>
     <values>
-      <!-- TODO: need to move thes to config_grids.xml -->
+      <!-- TODO: need to move these to config_grids.xml -->
       <value>$OCN_DOMAIN_MESH</value>
       <value mask_grid="gx3v7">$DIN_LOC_ROOT/share/meshes/gx1v6_090205_ESMFmesh.nc</value>
       <value mask_grid="gx1v7">$DIN_LOC_ROOT/share/meshes/gx1v7_151008_ESMFmesh.nc</value>

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -124,19 +124,21 @@
     </values>
   </entry>
 
-  <entry id="model_maskfile">
+  <entry id="model_maskfile"> 
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>
     <group>docn_nml</group>
     <desc>
-      file specifying model mask if not obtained from input model mesh
+      MESH for ocn mask
     </desc>
     <values>
+      <!-- TODO: need to move thes to config_grids.xml -->
       <value>$OCN_DOMAIN_MESH</value>
-      <value scol_mode='true'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
-      <value create_mesh='true'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
-      <value set_model_maskfile='true'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
+      <value mask_grid="gx3v7">$DIN_LOC_ROOT/share/meshes/gx1v6_090205_ESMFmesh.nc</value>
+      <value mask_grid="gx1v7">$DIN_LOC_ROOT/share/meshes/gx1v7_151008_ESMFmesh.nc</value>
+      <value mask_grid="tx0.66v1">$DIN_LOC_ROOT/share/meshes/tx0.66v1_190314_ESMFmesh.nc</value>
+      <value mask_grid="tx0.1v2">$DIN_LOC_ROOT/share/meshes/tx0.25v1_190204_ESMFmesh.nc</value>
     </values>
   </entry>
 

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -273,7 +273,8 @@ contains
     ! (1) if asked to create the mesh
     !     - create mesh from input file given by model_createmesh_fromfile
     !     - if single column find the nearest neighbor in model_createmesh_fromfile
-    ! (2) if not single column - obtain the mesh directly from the mesh input
+    ! (2) if not single column - obtain the mesh directly from the mesh input 
+    !     - reset the model mesh if the model maskfile is not equal to the model mesh file 
 
     if (trim(model_meshfile) == nullstr) then
 
@@ -319,7 +320,7 @@ contains
           scol_lat  = shr_const_spval
        end if
 
-       ! Now create the model meshfile using the model_maskfile as the input file
+       ! Now create the model meshfile
        call dshr_mesh_create(trim(model_createmesh_fromfile), scol_mode, scol_lon, scol_lat, &
             trim(compname), my_task, logunit, model_mesh, model_mask, model_frac, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -330,61 +331,20 @@ contains
        model_mesh = ESMF_MeshCreate(trim(model_meshfile), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       ! TODO: need a check that the mask file has the same grid as the model mesh
        ! Reset the model mesh mask if the mask file is different from the mesh file
        if (trim(model_meshfile) /= trim(model_maskfile)) then
 
-          pio_subsystem => shr_pio_getiosys(trim(compname))
-          io_type       =  shr_pio_getiotype(trim(compname))
-          io_format     =  shr_pio_getioformat(trim(compname))
-
-          ! obtain lsize and model_gindex
-          call ESMF_MeshGet(model_mesh, elementdistGrid=distGrid, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_DistGridGet(distGrid, localDe=0, elementCount=lsize, rc=rc)
+          ! obtain the model mask by mapping the mesh created by reading in the model_maskfile to the
+          ! model mesh and then reset the model mesh mask
+          call dshr_set_modelmask(model_mesh, model_maskfile, compname, model_mask, model_frac, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          ! allocate memory for model_mask and model_frac
-          allocate(model_frac(lsize))
-          allocate(model_mask(lsize))
-
-          ! get model_gindex (allocate memory first)
-          allocate(model_gindex(lsize))
-          call ESMF_DistGridGet(distGrid, localDe=0, seqIndexList=model_gindex, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-          ! obtain model mask and model frac from separate model_maskfile
-          rcode = pio_openfile(pio_subsystem, pioid, io_type, trim(model_maskfile), pio_nowrite)
-          call pio_seterrorhandling(pioid, PIO_BCAST_ERROR)
-          rcode = pio_inq_varid(pioid, 'mask', varid)
-          if ( rcode /= PIO_NOERR ) then
-             call shr_sys_abort(' ERROR: variable mask not found in file '//trim(model_maskfile))
+          if (masterproc) then
+             write(logunit,F00) trim(subname)// " obtained "//trim(compname)//" mesh from "// &
+                  trim(model_meshfile)
+             write(logunit,F00) trim(subname)// " obtained "//trim(compname)//" mask from "// &
+                  trim(model_maskfile)
           end if
-          call pio_seterrorhandling(pioid, PIO_INTERNAL_ERROR)
-          call pio_initdecomp(pio_subsystem, pio_int, (/model_nxg, model_nyg/), model_gindex, pio_iodesc)
-          call pio_read_darray(pioid, varid, pio_iodesc, model_mask, rcode)
-          call pio_freedecomp(pio_subsystem, pio_iodesc)
-
-          ! obtain model model frac from separate model_maskfile
-          call pio_seterrorhandling(pioid, PIO_BCAST_ERROR)
-          rcode = pio_inq_varid(pioid, 'frac', varid)
-          if ( rcode /= PIO_NOERR ) then
-             call shr_sys_abort(' ERROR: variable frac not found in file '//trim(model_maskfile))
-          end if
-          call pio_seterrorhandling(pioid, PIO_INTERNAL_ERROR)
-          call pio_initdecomp(pio_subsystem, pio_double, (/model_nxg, model_nyg/), model_gindex, pio_iodesc)
-          call pio_read_darray(pioid, varid, pio_iodesc, model_frac, rcode)
-          call pio_freedecomp(pio_subsystem, pio_iodesc)
-
-          ! close file
-          call pio_closefile(pioid)
-
-          ! deallocate pointers
-          deallocate(model_gindex)
-
-          ! reset the model mesh mask
-          call ESMF_MeshSet(model_mesh, elementMask=model_mask, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        else ! model_meshfile and model_maskfile are the same
 
@@ -407,13 +367,13 @@ contains
           call ESMF_ArrayDestroy(elemMaskArray, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+          if (masterproc) then
+             write(logunit,F00) trim(subname)// " obtained "//trim(compname)//" mesh and mask from "// &
+                  trim(model_meshfile)
+          end if
        end if
-
     end if
 
-    if (masterproc) then
-       write(logunit,F00) trim(subname)// " obtaining "//trim(compname)//" mesh from "// trim(model_meshfile)
-    end if
 
   end subroutine dshr_mesh_init
 
@@ -1607,5 +1567,122 @@ contains
     getNextRadCDay_i8 = nextsw_cday
 
   end function getNextRadCDay_i8
+
+  !===============================================================================
+  subroutine dshr_set_modelmask(mesh_dst, meshfile_mask, compname, mask_dst, frac_dst, rc)
+
+    use ESMF, only : ESMF_FieldRegridStore, ESMF_FieldRegrid, ESMF_FIELDCREATE
+    use ESMF, only : ESMF_REGRIDMETHOD_CONSERVE, ESMF_NORMTYPE_DSTAREA, ESMF_UNMAPPEDACTION_IGNORE
+    use ESMF, only : ESMF_TYPEKIND_R8, ESMF_MESHLOC_ELEMENT
+    use ESMF, only : ESMF_RouteHandleDestroy, ESMF_FieldDestroy
+
+    ! input/out variables
+    type(ESMF_Mesh)     , intent(in)  :: mesh_dst
+    character(len=*)    , intent(in)  :: meshfile_mask
+    character(len=*)    , intent(in)  :: compname
+    integer , pointer   , intent(out) :: mask_dst(:)
+    real(r8), pointer   , intent(out) :: frac_dst(:)
+    integer             , intent(out) :: rc
+
+    ! local variables:
+    type(ESMF_Mesh)        :: mesh_mask
+    type(ESMF_Field)       :: field_mask
+    type(ESMF_Field)       :: field_dst
+    type(ESMF_RouteHandle) :: rhandle
+    integer                :: srcMaskValue = 0
+    integer                :: dstMaskValue = -987987 ! spval for RH mask values
+    integer                :: srcTermProcessing_Value = 0
+    logical                :: checkflag = .false.
+    real(r8) , pointer     :: mask_src(:) ! on mesh created from meshfile_mask
+    real(r8) , pointer     :: dataptr1d(:)
+    type(ESMF_DistGrid)    :: distgrid_mask
+    type(ESMF_Array)       :: elemMaskArray
+    integer                :: lsize_mask, lsize_dst
+    integer                :: n, spatialDim
+    real(r8)               :: fminval = 0.001_r8
+    real(r8)               :: fmaxval = 1._r8
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    mesh_mask = ESMF_MeshCreate(trim(meshfile_mask), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_MeshGet(mesh_dst, spatialDim=spatialDim, numOwnedElements=lsize_dst, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    allocate(mask_dst(lsize_dst))
+    allocate(frac_dst(lsize_dst))
+
+    ! create fields on source and destination meshes
+    field_mask = ESMF_FieldCreate(mesh_mask, ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    field_dst = ESMF_FieldCreate(mesh_dst, ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! create route handle to map source mask (assume ocean) to destination mesh (assume atm/lnd)
+    call ESMF_FieldRegridStore(field_mask, field_dst, routehandle=rhandle, &
+         srcMaskValues=(/srcMaskValue/), dstMaskValues=(/dstMaskValue/), &
+         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, normType=ESMF_NORMTYPE_DSTAREA, &
+         srcTermProcessing=srcTermProcessing_Value, &
+         ignoreDegenerate=.true., unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! fill in values for field_mask with mask on source mesh
+    call ESMF_MeshGet(mesh_mask, elementdistGrid=distgrid_mask, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_DistGridGet(distgrid_mask, localDe=0, elementCount=lsize_mask, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    allocate(mask_src(lsize_mask))
+    elemMaskArray = ESMF_ArrayCreate(distgrid_mask, mask_src, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! The following call fills in the values of mask_src
+    call ESMF_MeshGet(mesh_mask, elemMaskArray=elemMaskArray, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! The following call fills in the values of field_mask
+    call ESMF_FieldGet(field_mask, farrayptr=dataptr1d, rc=rc)
+    dataptr1d(:) = mask_src(:)
+
+    ! map source mask to destination mesh - to obtain destination mask and frac
+    call ESMF_FieldRegrid(field_mask, field_dst, routehandle=rhandle, &
+         termorderflag=ESMF_TERMORDER_SRCSEQ, checkflag=checkflag, zeroregion=ESMF_REGION_TOTAL, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    ! now determine mask_dst and frac_dst 
+    call ESMF_MeshGet(mesh_dst, spatialDim=spatialDim, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_FieldGet(field_dst, farrayptr=dataptr1d, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    frac_dst(:) = dataptr1d(:)
+    do n = 1,lsize_dst
+       if (compname == 'LND') then
+          frac_dst(n) = 1._r8 - frac_dst(n)
+       end if
+       if (frac_dst(n) > fmaxval) then
+          frac_dst(n) = 1._r8
+       end if
+       if (frac_dst(n) < fminval) then
+          frac_dst(n) = 0._r8
+       end if
+       if (frac_dst(n) /= 0._r8) then
+          mask_dst(n) = 1
+       else
+          mask_dst(n) = 0
+       end if
+    enddo
+
+    ! reset the model mesh mask
+    call ESMF_MeshSet(mesh_dst, elementMask=mask_dst, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! deallocate memory
+    call ESMF_RouteHandleDestroy(rhandle, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_FieldDestroy(field_mask, rc=rc) 
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_FieldDestroy(field_dst, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    deallocate(mask_src)
+
+  end subroutine dshr_set_modelmask
 
 end module dshr_mod


### PR DESCRIPTION
### Description of changes
Ability to create masks/fractions for dlnd/docn
fix for performance slowdown and new dynamic fraction/mask capability

### Specific notes
This PR does several things:
1) It fixes a huge slowdown where multiple stream files are present (added two new file closes that fixed things)
2) Ability to create masks/fractions for dlnd/docn
3) Changes names of master_task to iamroot

Contributors other than yourself, if any: None

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [x] CIME (list) hash 91c9f65b3 from branch mvertens/dynfrac - currently has PR to master
 - [x] CMEPS (list) hash 15f40db from branch mvertens/dynfrac - currently has PR to master

Are changes expected to change answers?
 - [x] bit for bit (except for F compsets that have slightly different fractions)
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - for CESM have a new XML variable MASK_GRID that determines how the land/ocean mask is determined
 - [ ] No

Testing performed:
Used nuopc_dev hash 91c9f65b3 and all tests were bfb except for the F2000 test which was different due to small changes in the fractions sent to the atm - see CMEPS PR #151 (https://github.com/ESCOMP/CMEPS/pull/151) for more details

Hashes used for testing:
- [x] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: hash 91c9f65b3 from branch mvertens/dynfrac - currently has PR to master
- [x] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: hash 15f40db from branch mvertens/dynfrac - currently has PR to master
- [x] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: ef7260e
