### PR TITLE
Add only clause

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -4,7 +4,15 @@ module atm_comp_nuopc
   ! This is the NUOPC cap for DATM
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_SUCCESS, ESMF_LogWrite
+  use ESMF             , only : ESMF_GridCompSetEntryPoint, ESMF_METHOD_INITIALIZE
+  use ESMF             , only : ESMF_MethodRemove, ESMF_State, ESMF_Clock, ESMF_TimeInterval
+  use ESMF             , only : ESMF_State, ESMF_Field, ESMF_LOGMSG_INFO, ESMF_ClockGet
+  use ESMF             , only : ESMF_Time, ESMF_Alarm, ESMF_TimeGet, ESMF_TimeInterval
+  use ESMF             , only : operator(+), ESMF_TimeIntervalGet, ESMF_ClockGetAlarm
+  use ESMF             , only : ESMF_AlarmIsRinging, ESMF_AlarmRingerOff, ESMF_StateGet
+  use ESMF             , only : ESMF_FieldGet, ESMF_MAXSTR
+  use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model      , only : model_routine_SS        => SetServices

--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -1,6 +1,7 @@
 module datm_datamode_clmncep_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_State, ESMF_StateItem_Flag
+  use ESMF             , only : ESMF_STATEITEM_NOTFOUND, ESMF_LOGMSG_INFO, ESMF_StateGet, operator(/=)
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -100,7 +101,7 @@ module datm_datamode_clmncep_mod
   real(r8) , parameter :: stebol   = SHR_CONST_STEBOL   ! Stefan-Boltzmann constant ~ W/m^2/K^4
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR    ! dry air gas constant   ~ J/K/kg
 
-  
+
   character(*), parameter :: nullstr = 'null'
   character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
@@ -302,13 +303,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
        atm_prognostic = .true.
-       call dshr_state_getfldptr(importState, 'Sx_anidr', fldptr1=Sx_anidr, rc=rc) 
+       call dshr_state_getfldptr(importState, 'Sx_anidr', fldptr1=Sx_anidr, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call dshr_state_getfldptr(importState, 'Sx_anidf', fldptr1=Sx_anidf, rc=rc) 
+       call dshr_state_getfldptr(importState, 'Sx_anidf', fldptr1=Sx_anidf, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call dshr_state_getfldptr(importState, 'Sx_avsdr', fldptr1=Sx_avsdr, rc=rc) 
+       call dshr_state_getfldptr(importState, 'Sx_avsdr', fldptr1=Sx_avsdr, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call dshr_state_getfldptr(importState, 'Sx_avsdf', fldptr1=Sx_avsdf, rc=rc) 
+       call dshr_state_getfldptr(importState, 'Sx_avsdf', fldptr1=Sx_avsdf, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
@@ -490,7 +491,7 @@ contains
     ! bias correction / anomaly forcing ( start block )
     ! modify atmospheric input fields if streams exist
     !----------------------------------------------------------
-    
+
     ! bias correct precipitation relative to observed
     ! (via bias_correct nameslist option)
     if (associated(strm_precsf)) then
@@ -541,7 +542,7 @@ contains
   !===============================================================================
   subroutine datm_datamode_clmncep_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix

--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -1,6 +1,19 @@
 module datm_datamode_core2_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_State, ESMF_Field, ESMF_FieldBundle
+  use ESMF             , only : ESMF_DistGrid, ESMF_RouteHandle, ESMF_MeshCreate
+  use ESMF             , only : ESMF_Mesh, ESMF_MeshGet, ESMF_MeshCreate
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_FILEFORMAT_ESMFMESH
+  use ESMF             , only : ESMF_FieldBundleCreate, ESMF_FieldCreate, ESMF_MESHLOC_ELEMENT
+  use ESMF             , only : ESMF_FieldBundleAdd, ESMF_LOGMSG_INFO, ESMF_TYPEKIND_R8
+  use ESMF             , only : ESMF_RouteHandleDestroy, ESMF_EXTRAPMETHOD_NEAREST_STOD
+  use ESMF             , only : ESMF_POLEMETHOD_ALLAVG, ESMF_REGRIDMETHOD_BILINEAR
+  use ESMF             , only : ESMF_DistGridGet, ESMF_FieldRegridStore, ESMF_FieldRedistStore
+  use pio              , only : Var_Desc_t, file_desc_t, io_desc_t, pio_read_darray, pio_freedecomp
+  use pio              , only : pio_openfile, PIO_NOWRITE, pio_seterrorhandling, PIO_BCAST_ERROR
+  use pio              , only : pio_initdecomp, pio_inq_dimlen, pio_inq_varid
+  use pio              , only : pio_inq_varndims, pio_inq_vardimid, pio_double
+  use pio              , only : pio_closefile
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -11,7 +24,6 @@ module datm_datamode_core2_mod
   use dshr_mod         , only : dshr_restart_read, dshr_restart_write
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
-  use pio
 
   implicit none
   private ! except
@@ -369,7 +381,7 @@ contains
   !===============================================================================
   subroutine datm_datamode_core2_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix
@@ -405,7 +417,7 @@ contains
   subroutine datm_get_adjustment_factors(sdat, fileName_mesh, fileName_data, windF, winddF, qsatF, rc)
 
     ! input/output variables
-    type(shr_strdata_type) , intent(in)  :: sdat 
+    type(shr_strdata_type) , intent(in)  :: sdat
     character(*)           , intent(in)  :: fileName_mesh ! file name string
     character(*)           , intent(in)  :: fileName_data ! file name string
     real(R8)               , pointer     :: windF(:)      ! wind adjustment factor

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -1,6 +1,7 @@
 module datm_datamode_cplhist_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_State
+  use ESMF             , only : ESMF_StateItem_Flag
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -198,7 +199,7 @@ contains
   !===============================================================================
   subroutine datm_datamode_cplhist_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -1,6 +1,6 @@
 module datm_datamode_era5_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -60,7 +60,7 @@ module datm_datamode_era5_mod
   real(r8) , parameter :: tKFrz    = SHR_CONST_TKFRZ
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
-  
+
   character(*), parameter :: nullstr = 'undefined'
   character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
@@ -248,7 +248,7 @@ contains
 
        !--- calculate wind speed ---
        if (associated(Sa_wspd)) then
-         Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n)) 
+         Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n))
        end if
 
        !--- temperature ---
@@ -316,7 +316,7 @@ contains
   !===============================================================================
   subroutine datm_datamode_era5_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -1,6 +1,7 @@
 module datm_datamode_jra_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_MeshGet
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -11,7 +12,6 @@ module datm_datamode_jra_mod
   use dshr_mod         , only : dshr_restart_read, dshr_restart_write
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
-  use pio
 
   implicit none
   private ! except
@@ -223,7 +223,7 @@ contains
        Sa_pbot(n) = Sa_pslv(n)
        Sa_ptem(n) = Sa_tbot(n)
 
-       ! density computation for JRA55 forcing 
+       ! density computation for JRA55 forcing
        Sa_dens(n) = Sa_pbot(n)/(rdair*Sa_tbot(n)*(1 + 0.608*Sa_shum(n)))
 
        ! precipitation data
@@ -253,7 +253,7 @@ contains
   !===============================================================================
   subroutine datm_datamode_jra_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix

--- a/dice/dice_datamode_ssmi_mod.F90
+++ b/dice/dice_datamode_ssmi_mod.F90
@@ -1,6 +1,8 @@
 module dice_datamode_ssmi_mod
 
-  use ESMF
+  use ESMF                 , only : ESMF_State, ESMF_LogWrite, ESMF_Array, ESMF_MeshGet
+  use ESMF                 , only : ESMF_SUCCESS, ESMF_LOGMSG_INFO, ESMF_DistGrid
+  use ESMF                 , only : ESMF_ArrayCreate, ESMF_ArrayDestroy
   use NUOPC                , only : NUOPC_Advertise
   use shr_kind_mod         , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod          , only : shr_sys_abort
@@ -12,7 +14,6 @@ module dice_datamode_ssmi_mod
   use dshr_mod             , only : dshr_restart_read, dshr_restart_write
   use dice_flux_atmice_mod , only : dice_flux_atmice
   use dshr_fldlist_mod     , only : fldlist_type, dshr_fldlist_add
-  use pio
 
   implicit none
   private ! except

--- a/dice/dice_flux_atmice_mod.F90
+++ b/dice/dice_flux_atmice_mod.F90
@@ -1,19 +1,13 @@
 module dice_flux_atmice_mod
 
   use shr_kind_mod, only : r8=>shr_kind_r8, cxx=>shr_kind_cxx, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_const_mod   ! shared constants
-  use shr_sys_mod     ! shared system routines
-
+  ! shared constants
+  use shr_const_mod, only : loc_zvir => shr_const_zvir, loc_cpdair => shr_const_cpdair
+  use shr_const_mod, only : loc_cpvir => shr_const_cpvir, loc_karman => shr_const_karman
+  use shr_const_mod, only : loc_g => shr_const_g, loc_latvap => shr_const_latvap
+  use shr_const_mod, only : loc_latice => shr_const_latice, loc_stebol => shr_const_stebol
+  use shr_const_mod, only : spval => shr_const_spval
   implicit none
-
-  real(R8) :: loc_zvir   = shr_const_zvir
-  real(R8) :: loc_cpdair = shr_const_cpdair
-  real(R8) :: loc_cpvir  = shr_const_cpvir
-  real(R8) :: loc_karman = shr_const_karman
-  real(R8) :: loc_g      = shr_const_g
-  real(R8) :: loc_latvap = shr_const_latvap
-  real(R8) :: loc_latice = shr_const_latice
-  real(R8) :: loc_stebol = shr_const_stebol
 
   integer,parameter :: dbug = 0 ! internal debug level
 
@@ -68,7 +62,6 @@ contains
     real(R8),parameter :: umin   =  1.0_R8            ! minimum wind speed (m/s)
     real(R8),parameter :: zref   = 10.0_R8            ! ref height           ~ m
     real(R8),parameter :: ztref  =  2.0_R8            ! ref height for air T ~ m
-    real(R8),parameter :: spval  = shr_const_spval    ! special value
     real(R8),parameter :: zzsice = 0.0005_R8          ! ice surface roughness
 
     !--- local variables --------------------------------

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -4,7 +4,14 @@ module ice_comp_nuopc
   ! This is the NUOPC cap for DICE
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF                 , only : ESMF_Mesh, ESMF_GridComp, ESMF_State, ESMF_Clock
+  use ESMF                 , only : ESMF_SUCCESS, ESMF_Time, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                 , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
+  use ESMF                 , only : ESMF_Alarm, ESMF_TimeInterval, ESMF_TimeIntervalGet
+  use ESMF                 , only : ESMF_AlarmIsRinging, ESMF_METHOD_INITIALIZE
+  use ESMF                 , only : ESMF_ClockGet, ESMF_TimeGet, ESMF_MethodRemove, ESMF_MethodAdd
+  use ESMF                 , only : ESMF_GridCompSetEntryPoint, operator(+), ESMF_AlarmRingerOff
+  use ESMF                 , only : ESMF_ClockGetAlarm
   use NUOPC                , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC                , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model          , only : model_routine_SS        => SetServices

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -4,7 +4,13 @@ module lnd_comp_nuopc
   ! This is the NUOPC cap for DLND
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF              , only : ESMF_Mesh, ESMF_GridComp, ESMF_SUCCESS, ESMF_LOGMSG_INFO
+  use ESMF              , only : ESMF_LogWrite, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
+  use ESMF              , only : ESMF_Clock, ESMF_Alarm, ESMF_State, ESMF_ClockGet, ESMF_timeGet
+  use ESMF              , only : ESMF_Time, ESMF_TimeInterval, ESMF_METHOD_INITIALIZE
+  use ESMF              , only : ESMF_MethodAdd, ESMF_MethodRemove
+  use ESMF              , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
+  use ESMF              , only : ESMF_GridCompSetEntryPoint, operator(+)
   use NUOPC             , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC             , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model       , only : model_routine_SS        => SetServices

--- a/docn/docn_datamode_aquaplanet_mod.F90
+++ b/docn/docn_datamode_aquaplanet_mod.F90
@@ -1,6 +1,6 @@
 module docn_datamode_aquaplanet_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_Mesh, ESMF_MeshGet, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi
@@ -22,7 +22,7 @@ module docn_datamode_aquaplanet_mod
   real(r8), pointer    :: So_v(:)      => null()
 
   ! model mesh lats and lons in radians
-  real(r8), pointer    :: rlon(:), rlat(:) 
+  real(r8), pointer    :: rlon(:), rlat(:)
 
   ! parameters
   real(r8) , parameter :: tkfrz = shr_const_tkfrz ! freezing point, fresh water (kelvin)

--- a/docn/docn_datamode_copyall_mod.F90
+++ b/docn/docn_datamode_copyall_mod.F90
@@ -1,6 +1,6 @@
 module docn_datamode_copyall_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_State, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
@@ -125,7 +125,7 @@ contains
   !===============================================================================
   subroutine docn_datamode_copyall_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! input/output variables
     character(len=*)            , intent(in)    :: case_name
     character(len=*)            , intent(in)    :: inst_suffix

--- a/docn/docn_datamode_iaf_mod.F90
+++ b/docn/docn_datamode_iaf_mod.F90
@@ -1,6 +1,6 @@
 module docn_datamode_iaf_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_State
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -179,7 +179,7 @@ contains
   !===============================================================================
   subroutine docn_datamode_iaf_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! write restart file
 
     ! input/output variables

--- a/docn/docn_datamode_som_mod.F90
+++ b/docn/docn_datamode_som_mod.F90
@@ -1,6 +1,9 @@
 module docn_datamode_som_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_Clock, ESMF_StateGet, ESMF_StateItem_Flag
+  use ESMF             , only : ESMF_TimeInterval, ESMF_ClockGet, ESMF_TimeIntervalGet
+  use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_STATEITEM_NOTFOUND, operator(/=)
+  use ESMF             , only : ESMF_LogWrite
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod      , only : shr_sys_abort
@@ -14,7 +17,6 @@ module docn_datamode_som_mod
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_mod         , only : dshr_restart_read, dshr_restart_write
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
-  use pio
 
   implicit none
   private ! except
@@ -193,7 +195,7 @@ contains
     call dshr_state_getfldptr(exportState, 'Fioo_q'     , fldptr1=Fioo_q     , rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! For So_fswpen is only needed for diurnal cycle calculation of atm/ocn fluxes 
+    ! For So_fswpen is only needed for diurnal cycle calculation of atm/ocn fluxes
     ! Currently this is not implemented in cmeps
     call ESMF_StateGet(exportState, 'So_fswpen', itemFlag, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -221,7 +223,7 @@ contains
     ! input/output variables
     type(ESMF_State)       , intent(inout) :: importState
     type(ESMF_State)       , intent(inout) :: exportState
-    type(ESMF_Clock)       , intent(in)    :: clock 
+    type(ESMF_Clock)       , intent(in)    :: clock
     logical                , intent(in)    :: restart_read
     character(len=*)       , intent(in)    :: datamode
     integer                , intent(out)   :: rc
@@ -278,7 +280,7 @@ contains
 
              ! compute ice formed or melt potential
              Fioo_q(n) = (tfreeze(n) - So_t(n))*(cpsw*rhosw*strm_h(n))/dt ! ice formed q>0
-             
+
              ! reset temp
              if (reset_temp) then
                 So_t(n)  = max(tfreeze(n),So_t(n))
@@ -299,7 +301,7 @@ contains
   !===============================================================================
   subroutine docn_datamode_som_restart_write(case_name, inst_suffix, ymd, tod, &
        logunit, my_task, sdat)
-    
+
     ! write restart file
 
     ! input/output variables

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -4,7 +4,13 @@ module ocn_comp_nuopc
   ! This is the NUOPC cap for DOCN
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_State, ESMF_Clock, ESMF_Time
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_METHOD_INITIALIZE
+  use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit, ESMF_ClockGet
+  use ESMF             , only : ESMF_TimeGet, ESMF_TimeInterval, ESMF_Field, ESMF_MAXSTR
+  use ESMF             , only : ESMF_Alarm, ESMF_MethodRemove, ESMF_MethodAdd
+  use ESMF             , only : ESMF_GridCompSetEntryPoint, ESMF_ClockGetAlarm, ESMF_AlarmIsRinging
+  use ESMF             , only : ESMF_StateGet, operator(+), ESMF_AlarmRingerOff, ESMF_LogWrite
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_Advertise, NUOPC_CompAttributeGet
   use NUOPC_Model      , only : model_routine_SS        => SetServices

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -4,7 +4,13 @@ module rof_comp_nuopc
   ! This is the NUOPC cap for DROF
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time, ESMF_TimeInterval
+  use ESMF             , only : ESMF_State, ESMF_Clock, ESMF_SUCCESS, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
+  use ESMF             , only : ESMF_Alarm, ESMF_METHOD_INITIALIZE, ESMF_MethodAdd, ESMF_MethodRemove
+  use ESMF             , only : ESMF_TimeGet, ESMF_ClockGet, ESMF_GridCompSetEntryPoint
+  use ESMF             , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
+  use ESMF             , only : operator(+), ESMF_LogWrite
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model      , only : model_routine_SS        => SetServices

--- a/dshr/dshr_dfield_mod.F90
+++ b/dshr/dshr_dfield_mod.F90
@@ -1,6 +1,7 @@
 module dshr_dfield_mod
 
-  use ESMF
+  use ESMF             , only : ESMF_State, ESMF_FieldBundle, ESMF_MAXSTR, ESMF_SUCCESS
+  use ESMF             , only : ESMF_FieldBundleGet, ESMF_ITEMORDER_ADDORDER, ESMF_Field
   use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use shr_sys_mod      , only : shr_sys_abort
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_count, shr_strdata_get_stream_fieldbundle
@@ -120,7 +121,7 @@ contains
     end if
 
   end subroutine dshr_dfield_add_1d
- 
+
   !===============================================================================
   subroutine dshr_dfield_add_1d_stateptr(dfields, sdat, state_fld, strm_fld, state, state_ptr, logunit, masterproc, rc)
 

--- a/dshr/dshr_fldlist_mod.F90
+++ b/dshr/dshr_fldlist_mod.F90
@@ -1,7 +1,11 @@
 module dshr_fldlist_mod
 
-  use NUOPC
-  use ESMF
+  use NUOPC            , only : NUOPC_IsConnected, NUOPC_Realize
+  use ESMF             , only : ESMF_State, ESMF_Mesh, ESMF_Field, ESMF_Grid, ESMF_GridCreate
+  use ESMF             , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_LOGERR_PASSTHRU, ESMF_LogFoundError
+  use ESMF             , only : ESMF_MESHLOC_ELEMENT, ESMF_TYPEKIND_R8, ESMF_StateRemove
+  use ESMF             , only : ESMF_Distgrid, ESMF_DistGridCreate, ESMF_FieldCreate
   use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use dshr_methods_mod , only : chkerr
 

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -4,7 +4,13 @@ module wav_comp_nuopc
   ! This is the NUOPC cap for DWAV
   !----------------------------------------------------------------------------
 
-  use ESMF
+  use ESMF             , only : ESMF_SUCCESS, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
+  use ESMF             , only : ESMF_State, ESMF_Clock, ESMF_Alarm, ESMF_LogWrite, ESMF_Time
+  use ESMF             , only : ESMF_ClockGetAlarm, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_TimeInterval, ESMF_GridCompSetEntryPoint
+  use ESMF             , only : ESMF_METHOD_INITIALIZE, ESMF_MethodAdd, ESMF_MethodRemove
+  use ESMF             , only : ESMF_ClockGet, ESMF_TimeGet, operator(+), ESMF_AlarmRingerOff
+  use ESMF             , only : ESMF_AlarmIsRinging
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model      , only : model_routine_SS        => SetServices

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -2,7 +2,16 @@ module dshr_methods_mod
 
   ! Share methods for data model functionality
 
-  use ESMF
+  use ESMF         , only : ESMF_State, ESMF_Field, ESMF_StateGet, ESMF_FieldBundle
+  use ESMF         , only : ESMF_LogWrite, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF         , only : ESMF_StateRemove, ESMF_StateGet, ESMF_RouteHandle
+  use ESMF         , only : ESMF_Region_Flag, ESMF_FieldStatus_Flag, ESMF_LOGMSG_INFO
+  use ESMF         , only : ESMF_MAXSTR, ESMF_LOGMSG_ERROR, ESMF_LOGERR_PASSTHRU
+  use ESMF         , only : ESMF_FieldBundleGet, ESMF_FieldBundleAdd, ESMF_FieldGet
+  use ESMF         , only : ESMF_REGION_TOTAL, ESMF_END_ABORT, ESMF_ITEMORDER_ADDORDER
+  use ESMF         , only : ESMF_LogFoundError, ESMF_FieldRegrid, ESMF_Finalize, ESMF_FIELDSTATUS_COMPLETE
+  use ESMF         , only : ESMF_TERMORDER_SRCSEQ, operator(/=)
+  use ESMF         , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use shr_kind_mod , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl
 
   implicit none

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -17,7 +17,7 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
   use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
-  use ESMF             , only : ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
   use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use shr_sys_mod      , only : shr_sys_abort

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -3,8 +3,20 @@ module dshr_strdata_mod
   ! holds data and methods to advance data models
   ! Obtain the model domain and the stream domain for each stream
 
-  use ESMF
-
+  use ESMF             , only : ESMF_Mesh, ESMF_RouteHandle, ESMF_Field, ESMF_FieldBundle
+  use ESMF             , only : ESMF_Clock, ESMF_VM, ESMF_VMGet, ESMF_VMGetCurrent
+  use ESMF             , only : ESMF_DistGrid, ESMF_SUCCESS, ESMF_MeshGet, ESMF_DistGridGet
+  use ESMF             , only : ESMF_VMBroadCast, ESMF_MeshIsCreated, ESMF_MeshCreate
+  use ESMF             , only : ESMF_Calendar, ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
+  use ESMF             , only : ESMF_CalKind_Flag, ESMF_Time, ESMF_TimeInterval
+  use ESMF             , only : ESMF_TimeIntervalGet, ESMF_TYPEKIND_R8, ESMF_FieldCreate
+  use ESMF             , only : ESMF_FILEFORMAT_ESMFMESH, ESMF_FieldCreate
+  use ESMF             , only : ESMF_FieldBundleCreate, ESMF_MESHLOC_ELEMENT, ESMF_FieldBundleAdd
+  use ESMF             , only : ESMF_POLEMETHOD_ALLAVG, ESMF_EXTRAPMETHOD_NEAREST_STOD, ESMF_REGRIDMETHOD_BILINEAR, ESMF_REGRIDMETHOD_NEAREST_STOD
+  use ESMF             , only : ESMF_ClockGet, operator(-), operator(==), ESMF_CALKIND_NOLEAP
+  use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
+  use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill
+  use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
   use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use shr_sys_mod      , only : shr_sys_abort
@@ -403,7 +415,7 @@ contains
        ! Determine field names for stream fields with both stream file names and data model names
        nvars = sdat%stream(ns)%nvars
 
-       ! Allocate memory 
+       ! Allocate memory
        allocate(sdat%pstrm(ns)%fldList_model(nvars))
        call shr_stream_getModelFieldList(sdat%stream(ns), sdat%pstrm(ns)%fldlist_model)
        allocate(sdat%pstrm(ns)%fldlist_stream(nvars))
@@ -1297,7 +1309,7 @@ contains
     integer                  :: pio_iovartype
     real(r8), pointer        :: nv_coords(:), nu_coords(:)
     real(r8), pointer        :: data_u_dst(:), data_v_dst(:)
-    real(r8)                 :: lat, lon 
+    real(r8)                 :: lat, lon
     real(r8)                 :: sinlat, sinlon
     real(r8)                 :: coslat, coslon
     real(r8)                 :: scale_factor, add_offset
@@ -1679,7 +1691,7 @@ contains
           data_u_dst(i) =  coslon * dataptr2d_dst(1,i) + sinlon * dataptr2d_dst(2,i)
           data_v_dst(i) = -sinlon * dataptr2d_dst(1,i) + coslon * dataptr2d_dst(2,i)
        enddo
-       
+
        deallocate(dataptr)
     endif
 

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -17,6 +17,7 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
   use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
+  use ESMF             , only : ESMF_LOGMSG_INFO
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
   use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use shr_sys_mod      , only : shr_sys_abort

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -122,7 +122,8 @@ contains
 
   subroutine shr_stream_init_from_xml(xmlfilename, streamdat, mastertask, logunit, compname, rc)
 
-    use FoX_DOM
+    use FoX_DOM, only : extractDataContent, destroy, Node, NodeList, parseFile, getElementsByTagname
+    use FoX_DOM, only : getLength, item
     use ESMF, only : ESMF_VM, ESMF_VMGetCurrent, ESMF_VMBroadCast, ESMF_SUCCESS
 
     ! ---------------------------------------------------------------------
@@ -140,7 +141,7 @@ contains
     !    <yearAlign></yearAlign>
     !    <stream_vectors></stream_vectors>
     !    <stream_mesh_file></stream_mesh_file>
-    !    <stream_lev_dimname></stream_lev_dimname> 
+    !    <stream_lev_dimname></stream_lev_dimname>
     !    <stream_data_files>
     !      <file></file>
     !    </stream_data_files>

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -4,10 +4,11 @@ module dshr_tInterp_mod
   ! data model shared time interpolation factor routines
   !---------------------------------------------------------------
 
-  use ESMF
+  use ESMF             , only : ESMF_Time, ESMF_TimeInterval, ESMF_TimeIntervalGet
+  use ESMF             , only : ESMF_SUCCESS, operator(<), operator(-), operator(>), operator(==)
   use shr_kind_mod     , only : i8=>shr_kind_i8, r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, shr_kind_in
   use shr_sys_mod      , only : shr_sys_abort
-  use shr_cal_mod      , only : shr_cal_timeSet, shr_cal_advDateInt, shr_cal_date2julian 
+  use shr_cal_mod      , only : shr_cal_timeSet, shr_cal_advDateInt, shr_cal_date2julian
   use shr_orb_mod      , only : shr_orb_cosz, shr_orb_decl, SHR_ORB_UNDEF_REAL
   use shr_const_mod    , only : SHR_CONST_PI
   use dshr_methods_mod , only : chkerr
@@ -179,10 +180,10 @@ contains
     real(r8)     ,intent(in)    :: obliqr     ! orb param
     integer      ,intent(in)    :: modeldt    ! model time step in secs
     character(*) ,intent(in)    :: calendar   ! calendar type
-    integer      ,intent(out)   :: rc         ! error status  
+    integer      ,intent(out)   :: rc         ! error status
 
     ! local variables
-    real(R8), allocatable   :: cosz(:)           ! local cos of the zenith angle 
+    real(R8), allocatable   :: cosz(:)           ! local cos of the zenith angle
     integer                 :: lsize             ! size of local data
     type(ESMF_Time)         :: reday1, reday2    ! LB, UB time
     type(ESMF_TimeInterval) :: timeint           ! time interval
@@ -295,15 +296,15 @@ contains
 
     lsize = size(lon)
     if (lsize < 1 .or. size(lat) /= lsize .or. size(cosz) /= lsize) then
-       write(6,*)'ERROR: lsize,size(lat),size(cosz) =  ',lsize,size(lat),size(cosz) 
+       write(6,*)'ERROR: lsize,size(lat),size(cosz) =  ',lsize,size(lat),size(cosz)
        call shr_sys_abort(subname//' ERROR: lon lat cosz sizes disagree')
     endif
 
     call shr_cal_date2julian(ymd, tod, calday, calendar)
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr, declin, eccf )
     do n = 1,lsize
-       lonr = lon(n) * deg2rad 
-       latr = lat(n) * deg2rad 
+       lonr = lon(n) * deg2rad
+       latr = lat(n) * deg2rad
        cosz(n) = max(solZenMin, shr_orb_cosz( calday, latr, lonr, declin))
     end do
 


### PR DESCRIPTION
### Description of changes
Add only clause to all use statements.  

### Specific notes
Ran testing for ./create_test --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml --xml-category nuopc --xml-machine cheyenne --xml-compiler intel --baseline-root /glade/p/cesmdata/cseg/cmeps_baselines/ --compare jan17
All A cases pass.   


Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
Fixes #42 

Are there dependencies on other component PRs NO
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash: 79ad32f5
- [X] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash: 4107df9193
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
