### PR TITLE
fix typo in cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,4 +99,4 @@ foreach(DEPS streams dshr cdeps_share FoX_dom FoX_wxml FoX_sax FoX_common FoX_ut
           COMPONENT Library)
   install(EXPORT      ${DEPS} 
           DESTINATION lib/cmake)
-endforeach(COMP)
+endforeach(DEPS)


### PR DESCRIPTION
### Description of changes
This PR aims to fix minor type issue in main cmake file. It also Closes #45.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers: Cheyenne, Intel compiler, MPT
   - details (e.g. failed tests): `qcmd -l walltime=4:00:00 -- ./create_test --xml-testlist ../../components/cdeps/cime_config/testdefs/testlist_cdeps.xml --xml-machine cheyenne --xml-category aux_cdeps`
    Only test that uses f10_f10_musgs grid fails.
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: 91c9f65
- [x] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: b829de9
- [x] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: c019fc2

Standalone build testing:
Passed with following instructions,
```
module purge
module load ncarenv/1.3 cmake intel/19.0.5 esmf_libs mkl
module use /glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/
module load esmf-8.1.0b41-ncdfio-mpt-O mpt/2.21 netcdf/4.7.3 pnetcdf/1.12.1 ncarcompilers/0.5.0

CC=mpicc FC=mpif90 cmake -DBLD_STANDALONE=ON -DCMAKE_INSTALL_PREFIX=$PWD/../install -DPIO_Fortran_LIBRARY=/glade/work/turuncu/PROGS/pio-2.5.2/install/lib -DPIO_Fortran_INCLUDE_DIR=/glade/work/turuncu/PROGS/pio-2.5.2/install/include -DPIO_C_LIBRARY=/glade/work/turuncu/PROGS/pio-2.5.2/install/lib -DPIO_C_INCLUDE_DIR=/glade/work/turuncu/PROGS/pio-2.5.2/install/include ../
```