### PR TITLE
This fixes a bug in running the test SMS_Ln9_P4_Vnuopc.f19_f19.A.cheyenne_intel

### DIFF
--- a/dice/cime_config/namelist_definition_dice.xml
+++ b/dice/cime_config/namelist_definition_dice.xml
@@ -68,10 +68,7 @@
       file specifying model mask if not obtained from input model mesh
     </desc>
     <values>
-      <value>$ICE_DOMAIN_MESH</value>
-      <value scol_mode='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value create_mesh='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value set_model_maskfile='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
+      <value>$MASK_MESH</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
This fixes a bug in running the test SMS_Ln9_P4_Vnuopc.f19_f19.A.cheyenne_intel

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed: No issue was created for this

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - dice namelist change for obtain ocean mask
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
Only test that was run was SMS_Ln9_P4_Vnuopc.f19_f19.A.cheyenne_intel

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [x] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: c019fc2
