### PR TITLE
replace musgs with mg37 in cdeps tests

### DIFF
--- a/cime_config/testdefs/testlist_cdeps.xml
+++ b/cime_config/testdefs/testlist_cdeps.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -9,7 +9,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -17,7 +17,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -25,7 +25,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -33,7 +33,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -41,7 +41,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -49,7 +49,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>


### PR DESCRIPTION
### Description of changes
Replace musgs mask with mg37 masks in test compsets and generate new baselines. 
Baselines generated in  /glade/p/cesmdata/cseg/cdeps_baselines/feb0121

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master 
  - hash:ef6b28c80d2
- [X] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash:ff6ec1977
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
