### PR TITLE
Point to new dlnd scpl forcing data

### DIFF
--- a/dlnd/cime_config/config_component.xml
+++ b/dlnd/cime_config/config_component.xml
@@ -49,7 +49,7 @@
     <type>char</type>
     <default_value>UNSET</default_value>
     <values match="last">
-      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/i.e20.I1850Clm50Sp.f09_g17.001_c180502</value>
+      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/b.e21.B1850.f09_g17.CMIP6-piControl.001_c210324</value>
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
@@ -60,7 +60,7 @@
     <type>char</type>
     <default_value>UNSET</default_value>
     <values match="last">
-      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">i.e20.I1850Clm50Sp.f09_g17.001</value>
+      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">b.e21.B1850.f09_g17.CMIP6-piControl.001</value>
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
@@ -94,7 +94,7 @@
     <type>integer</type>
     <default_value>-999</default_value>
     <values match="last">
-      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">1</value>
+      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">1971</value>
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
@@ -105,7 +105,7 @@
     <type>integer</type>
     <default_value>-999</default_value>
     <values match="last">
-      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">30</value>
+      <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">2000</value>
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>

--- a/dlnd/cime_config/stream_definition_dlnd.xml
+++ b/dlnd/cime_config/stream_definition_dlnd.xml
@@ -19,7 +19,7 @@
       <meshfile>$LND_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="0001" last_year="0030">$DLND_CPLHIST_DIR/$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</file>
+      <file first_year="1971" last_year="2000">$DLND_CPLHIST_DIR/$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>l2x1yr_glc_Sl_tsrf%glc     Sl_tsrf_elev%glc  </var>

--- a/dlnd/cime_config/stream_definition_dlnd.xml
+++ b/dlnd/cime_config/stream_definition_dlnd.xml
@@ -19,7 +19,9 @@
       <meshfile>$LND_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="1971" last_year="2000">$DLND_CPLHIST_DIR/$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</file>
+      <!-- Specify first year = 0, last year = 99999 in order to apply
+           this pattern to all possible years that might be included. -->
+      <file first_year="0" last_year="99999">$DLND_CPLHIST_DIR/$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>l2x1yr_glc_Sl_tsrf%glc     Sl_tsrf_elev%glc  </var>


### PR DESCRIPTION
### Description of changes

Point to new dlnd scpl forcing data. These data are used to force cases with GLC - i.e., T compsets.

### Specific notes

Contributors other than yourself, if any: Choice of data approved by @whlipscomb, @katetc and @gunterl

CMEPS Issues Fixed (include github issue #): none

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [x] more substantial - substantial changes for T compsets (bit-for-bit for other compsets)

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- Just ran `SMS_Vnuopc_Ly35.f09_g17_gl4.T1850G.cheyenne_intel` (using CDEPS version from the CESM nuopc_dev branch (b91e418) with the first two commits on this branch cherry-picked in. I then checked the last commit on this branch (48a26e6) by confirming that the dlnd.streams.xml file was identical before and after that change.

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [x] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: `913272a`
