### PR TITLE
Fixes #63, two files were in NetCDF4 format and need a NetCDF5 version

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -301,7 +301,7 @@
 
   <stream_entry name="CLMCRUNCEPv7.Solar">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.c2016.0.5d.ESMFmesh_260520.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.cdf5.c2016.0.5d.ESMFmesh_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1901" last_year="2016">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/Solar6Hrly/clmforc.cruncep.V7.c2016.0.5d.Solr.%ym.nc</file>
@@ -332,7 +332,7 @@
 
   <stream_entry name="CLMCRUNCEPv7.Precip">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.c2016.0.5d.ESMFmesh_260520.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.cdf5.c2016.0.5d.ESMFmesh_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1901" last_year="2016">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/Precip6Hrly/clmforc.cruncep.V7.c2016.0.5d.Prec.%ym.nc</file>
@@ -363,7 +363,7 @@
 
   <stream_entry name="CLMCRUNCEPv7.TPQW">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.c2016.0.5d.ESMFmesh_260520.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/clmforc.cruncep.V7.cdf5.c2016.0.5d.ESMFmesh_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1901" last_year="2016">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.%ym.nc</file>
@@ -601,7 +601,7 @@
 
   <stream_entry name="CLMNLDAS2.Solar">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.0.125d.v1.ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.cdf5.0.125d.v1.ESMFmesh_120620_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1980" last_year="2018">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Solar/ctsmforc.NLDAS2.0.125d.v1.Solr.%ym.nc</file>
@@ -632,7 +632,7 @@
 
   <stream_entry name="CLMNLDAS2.Precip">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.0.125d.v1.ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.cdf5.0.125d.v1.ESMFmesh_120620_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1980" last_year="2018">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Precip/ctsmforc.NLDAS2.0.125d.v1.Prec.%ym.nc</file>
@@ -663,7 +663,7 @@
 
   <stream_entry name="CLMNLDAS2.TPQW">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.0.125d.v1.ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/ctsmforc.NLDAS2.cdf5.0.125d.v1.ESMFmesh_120620_c210330.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1980" last_year="2018">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/TPQWL/ctsmforc.NLDAS2.0.125d.v1.TPQWL.%ym.nc</file>
@@ -938,7 +938,7 @@
 
   <stream_entry name="Anomaly.Forcing.Precip">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.pr.ccsm4.rcp45.2006-2300.nc</file>
@@ -969,7 +969,7 @@
 
   <stream_entry name="Anomaly.Forcing.Temperature">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.tas.ccsm4.rcp45.2006-2300.nc</file>
@@ -1000,7 +1000,7 @@
 
   <stream_entry name="Anomaly.Forcing.Pressure">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.ps.ccsm4.rcp45.2006-2300.nc</file>
@@ -1031,7 +1031,7 @@
 
   <stream_entry name="Anomaly.Forcing.Humidity">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.huss.ccsm4.rcp45.2006-2300.nc</file>
@@ -1062,7 +1062,7 @@
 
   <stream_entry name="Anomaly.Forcing.Uwind">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.uas.ccsm4.rcp45.2006-2300.nc</file>
@@ -1093,7 +1093,7 @@
 
   <stream_entry name="Anomaly.Forcing.Vwind">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.vas.ccsm4.rcp45.2006-2300.nc</file>
@@ -1124,7 +1124,7 @@
 
   <stream_entry name="Anomaly.Forcing.Shortwave">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.rsds.ccsm4.rcp45.2006-2300.nc</file>
@@ -1155,7 +1155,7 @@
 
   <stream_entry name="Anomaly.Forcing.Longwave">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc/domain.permafrostRCN_P2_ESMFmesh_120620.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/af.rlds.ccsm4.rcp45.2006-2300.nc</file>


### PR DESCRIPTION
### Description of changes

There were three ESMF mesh files that needed to be corrected. Two were in NetCDF4 format and needed to be NetCDF5 and one was entered incorrectly.

### Specific notes

Contributors other than yourself, if any: None

CMEPS Issues Fixed (include github issue #): #63

Are there dependencies on other component PRs: No

Are changes expected to change answers? No
 - [x] bit for bit

Any User Interface Changes (namelist or namelist defaults changes)?
 - [X] Yes

Testing performed: Ran a short list of tests on izumi:

ERP_D_Ld5_P48x1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-flexCN_FUN
ERP_D_Ld5_P48x1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-luna
ERP_D_Ld5_P48x1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-noFUN_flexCN
ERP_D_Ld5_P48x1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-reduceOutput
SMS_D_Ld1_P48x1_Vnuopc.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-af_bias_v7

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
 - tag: cime5.8.39
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: v0.5.0
- [ ] CTSM
  - repository to check out: https://github.com/mvertens/CTSM.git
  - branch: mvertens/scolpr
