### PR TITLE
this compset should not produce an ocn stream file

### DIFF
--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -71,7 +71,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
 
     if case.get_value('PTS_LON'):
         scol_lon = float(case.get_value('PTS_LON'))
-    else: 
+    else:
         scol_lon = -999.
     if case.get_value('PTS_LAT'):
         scol_lat = float(case.get_value('PTS_LAT'))
@@ -90,7 +90,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['docn_nml'])
 
     # Generate docn.streams.xml if needed
-    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant'):
+    print("docn_mode is {}".format(docn_mode))
+    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant') or (docn_mode == 'som_aquap'):
         generate_stream_file = False
     else:
         generate_stream_file = True


### PR DESCRIPTION
### Description of changes
add docn_mode som_aquap to those that do not produce a stream file.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): #70

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash: 8b48a2e2d4b
- [X] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash: c0c2001b8bf
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
