### PR TITLE
Set default years for 1PT to 2018 to 2019, and use DATM_YR variables for NEON

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -206,7 +206,7 @@
     <valid_values></valid_values>
     <default_value>2004</default_value>
     <values match="last">
-      <value compset="2000.*_DATM%1PT">1972</value>
+      <value compset="2000.*_DATM%1PT">2018</value>
       <value compset="1850.*_DATM%QIA">1948</value>
       <value compset="1850.*_DATM%CRU">1901</value>
       <value compset="1850.*_DATM%GSW">1901</value>
@@ -248,7 +248,7 @@
     <valid_values></valid_values>
     <default_value>2004</default_value>
     <values match="last">
-      <value   compset="2000.*_DATM%1PT">2004</value>
+      <value   compset="2000.*_DATM%1PT">2019</value>
       <value   compset="1850.*_DATM%QIA">1972</value>
       <value   compset="1850.*_DATM%CRU">1920</value>
       <value   compset="1850.*_DATM%GSW">1920</value>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -203,7 +203,7 @@
       <meshfile>none</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="2018" last_year="2019">$DIN_LOC_ROOT/atm/cdeps/v1/$NEONSITE/%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/cdeps/v1/$NEONSITE/%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>PRECTmms Faxa_precn</var>
@@ -220,9 +220,9 @@
       <mapalgo>none</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>2018</stream_year_align>
-    <stream_year_first>2018</stream_year_first>
-    <stream_year_last>2019</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>


### PR DESCRIPTION
Set the default DATM_YR_* variables for 1PT streams to 2018 to 2019. For the NEON streams use the $DATM_YR_* settings rather than hardcoded values. This allows the case settings of the DATM_YR_* variables change the datm.streams.xml file.

### Description of changes

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): 
  Fixes #78

Are there dependencies on other component PRs: Yes CTSM
 https://github.com/ESCOMP/CTSM/pull/1278

Are changes expected to change answers? No
 - [x] bit for bit

Any User Interface Changes (namelist or namelist defaults changes)? No
 - [x ] No

Testing performed: 
  Ran SMS_D_Vnuopc.CLM_USRDAT.I1PtClm51Bgc.cheyenne_intel.clm-NEON_NIWO
  which worked and PASSes.

Hashes used for testing:
- [ ] CIME.   cime5.6.43
- [ ] CMEPS v0.10.0
 - [ ] CTSM: ctsm5.1.dev036-31-geb5f2e309 (NEON-compset PR https://github.com/ESCOMP/CTSM/pull/1278)
