### PR TITLE
undo pr 71, that fix was incorrect

### DIFF
--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -91,7 +91,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
 
     # Generate docn.streams.xml if needed
     print("docn_mode is {}".format(docn_mode))
-    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant') or (docn_mode == 'som_aquap'):
+#    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant') or (docn_mode == 'som_aquap'):
+    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant'):
         generate_stream_file = False
     else:
         generate_stream_file = True

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -91,7 +91,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
 
     # Generate docn.streams.xml if needed
     print("docn_mode is {}".format(docn_mode))
-#    if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant') or (docn_mode == 'som_aquap'):
     if (re.search(r'sst_aquap[0-9]+',docn_mode) is not None) or (docn_mode == 'sst_aquap_constant'):
         generate_stream_file = False
     else:


### PR DESCRIPTION
### Description of changes
Add back stream files for docn_mode=='som_aquap'  PR #71 broke several compsets.  

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list) 

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed:
- [X] (required) aux_cdeps
   - machines and compilers: cheyenne, intel 
   - details (e.g. failed tests): ALL pass also tested with PR#73 merged.
   
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [X] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master
  - hash: 296aeaf4a
- [X] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: master 
  - hash:c0c2001
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: 
  - hash:
