### PR TITLE
Fix generic CLM_USRDAT 1PT streams

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -68,6 +68,10 @@ class StreamCDEPS(GenericXML):
                 self.stream_nodes = super(StreamCDEPS,self).get_child("stream_entry", {"name" : "NEON.$NEONSITE"},
                                                                      err_msg="No stream_entry {} found".format(stream_name))
 
+            elif stream_name.startswith("CLM_USRDAT."):
+                self.stream_nodes = super(StreamCDEPS,self).get_child("stream_entry", {"name" : "CLM_USRDAT.$CLM_USRDAT_NAME"},
+                                                                     err_msg="No stream_entry {} found".format(stream_name))
+
             elif stream_name:
                 self.stream_nodes = super(StreamCDEPS,self).get_child("stream_entry", {"name" : stream_name},
                                                                      err_msg="No stream_entry {} found".format(stream_name))

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -40,6 +40,9 @@
       <value datm_mode="1PT" model_grid="CLM_USRDAT" neon="True">
         NEON.$NEONSITE
       </value>
+      <value datm_mode="1PT" model_grid="CLM_USRDAT">
+        CLM_USRDAT.$CLM_USRDAT_NAME
+      </value>
       <value datm_mode="CORE2_NYF" >
         CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP
       </value>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -228,10 +228,10 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>extend</taxmode>
+      <taxmode>limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1e30</dtlimit>
+      <dtlimit>1.5</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -742,6 +742,46 @@
   <!-- datm_mode 1PT      -->
   <!-- ===================-->
 
+  <!-- Generic single point site  -->
+
+  <stream_entry name="CLM_USRDAT.$CLM_USRDAT_NAME">
+    <stream_meshfile>
+      <meshfile>none</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT_CLMFORC/$CLM_USRDAT_NAME/CLM1PT_data/%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>PRECTmms Faxa_precn</var>
+      <var>FSDS     Faxa_swdn </var>
+      <var>ZBOT     Sa_z    </var>
+      <var>TBOT     Sa_tbot </var>
+      <var>WIND     Sa_wind </var>
+      <var>RH       Sa_rh   </var>
+      <var>PSRF     Sa_pbot </var>
+      <var>FLDS     Faxa_lwdn </var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>none</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>limit</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
   <stream_entry name="1PT.mexicocityMEX">
     <stream_meshfile>
       <meshfile>none</meshfile>
@@ -774,10 +814,10 @@
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>extend</taxmode>
+      <taxmode>limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.e30</dtlimit>
+      <dtlimit>1.5</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -814,10 +854,10 @@
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>extend</taxmode>
+      <taxmode>limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.e30</dtlimit>
+      <dtlimit>1.5</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -869,10 +909,10 @@
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>extend</taxmode>
+      <taxmode>limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.e30</dtlimit>
+      <dtlimit>1.5</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3271,11 +3311,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3317,11 +3355,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3363,11 +3399,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3409,11 +3443,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3455,7 +3487,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -3501,11 +3532,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3547,11 +3576,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3593,7 +3620,6 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode model_grid="1x1">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -228,7 +228,8 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>limit</taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -664,7 +665,8 @@
       <tintalgo>coszen</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>cycle</taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -695,7 +697,8 @@
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>cycle</taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -730,7 +733,8 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>cycle</taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -774,7 +778,8 @@
       <tintalgo>linear</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>limit</taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
@@ -3265,11 +3270,9 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>
-      <taxmode compset="DATM%1PT">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -3490,7 +3493,6 @@
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.5</dtlimit>
-      <dtlimit compset="DATM%1PT">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>


### PR DESCRIPTION
### Description of changes

Add in ability to handle 1PT forcing streams for a generic CLM_USRDAT site. This was in MCT, but left off of the NUOPC implementation. NEON sites were added, but not the generic case.

Also change some of the settings of extend from 1PT streams to cycle. And for 1PT cases and NLDAS2 forcing use limit in place of cycle, so you'll see if you are out of the data range.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

  Fixes #86

Are there dependencies on other component PRs
 - [ x] CIME cime5.8.47 #3954

Are changes expected to change answers?
 - [ x] bit for bit


Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ x] No

Testing performed: Ran following single point tests...

SMS_D_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PtClm50SpRs.cheyenne_intel.clm-default			
SMS_D_Lm1_Mmpi-serial.CLM_USRDAT.I1PtClm50SpRs.cheyenne_intel.clm-USUMB_mct			
SMS_D_Lm1_Mmpi-serial_Vnuopc.CLM_USRDAT.I1PtClm50SpRs.cheyenne_intel.clm-USUMB_nuopc			
SMS_Lm1_Mmpi-serial.1x1_brazil.IHistClm50BgcQianRs.cheyenne_gnu.clm-output_bgc_highfreq			
SMS_Lm1_Mmpi-serial_Vnuopc.1x1_brazil.IHistClm50BgcQianRs.cheyenne_gnu.clm-output_bgc_highfreq

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: cime5.8.47
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - tag: v0.10.0
- [ ] CTSM
  - repository to check out: https://github.com/jedwards4b/CTSM.git
  - branch: neon_compsets
  - describe: ctsm5.1.dev038-37-g8a65d2f19
  - This will be ctsm5.1.dev039
