### PR TITLE
Fix a bug in streams/dshr_stream_mod.F90

### DIFF
--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -631,7 +631,7 @@ contains
         call ESMF_ConfigGetAttribute(CF,valueList=strm_tmpstrings, label="stream_data_files"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
         do n=1,streamdat(i)%nfiles
-          streamdat(i)%file(n)%name = trim(strm_tmpstrings(i))
+          streamdat(i)%file(n)%name = trim(strm_tmpstrings(n))
         enddo
         deallocate(strm_tmpstrings)
       else


### PR DESCRIPTION
### Description of changes

Revise subroutine shr_stream_init_from_esmfconfig in dshr_stream_mod.F90 to allow multiple stream input files to be processed correctly.

The revised code has been tested successfully using the most recent develop branch of https://github.com/ufs-community/ufs-weather-model.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
