### PR TITLE
initialize fields to 1 in map creation

### DIFF
--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -1,4 +1,8 @@
+#ifdef CESMCOUPLED
 module ocn_comp_nuopc
+#else
+module cdeps_docn_comp
+#endif
 
   !----------------------------------------------------------------------------
   ! This is the NUOPC cap for DOCN
@@ -107,7 +111,11 @@ module ocn_comp_nuopc
   logical                      :: aquaplanet = .false.
   logical                      :: diagnose_data = .true.
   integer      , parameter     :: master_task = 0                 ! task number of master task
+#ifdef CESMCOUPLED
   character(*) , parameter     :: module_name = "(ocn_comp_nuopc)"
+#else
+  character(*) , parameter     :: module_name = "(cdeps_docn_comp)"
+#endif
   character(*) , parameter     :: modelname = 'docn'
   character(*) , parameter     :: u_FILE_u = &
        __FILE__
@@ -175,10 +183,10 @@ contains
     integer           :: ierr               ! error code
     logical           :: exists             ! check for file existence
     character(len=*),parameter :: subname=trim(module_name)//':(InitializeAdvertise) '
-    character(*)    ,parameter :: F00 = "('(ocn_comp_nuopc) ',8a)"
-    character(*)    ,parameter :: F01 = "('(ocn_comp_nuopc) ',a,2x,i8)"
-    character(*)    ,parameter :: F02 = "('(ocn_comp_nuopc) ',a,l6)"
-    character(*)    ,parameter :: F03 = "('(ocn_comp_nuopc) ',a,f8.5,2x,f8.5)"
+    character(*)    ,parameter :: F00 = "('(" // trim(module_name) // ") ',8a)"
+    character(*)    ,parameter :: F01 = "('(" // trim(module_name) // ") ',a,2x,i8)"
+    character(*)    ,parameter :: F02 = "('(" // trim(module_name) // ") ',a,l6)"
+    character(*)    ,parameter :: F03 = "('(" // trim(module_name) // ") ',a,f8.5,2x,f8.5)"
     !-------------------------------------------------------------------------------
 
     namelist / docn_nml / datamode, &
@@ -254,8 +262,6 @@ contains
     else
        call shr_sys_abort(' ERROR illegal docn datamode = '//trim(datamode))
     endif
-
-    write(6,*)'DEBUG: datamode = ',trim(datamode)
 
     ! Advertise docn fields
     if (trim(datamode)=='sst_aquap_analytic' .or. trim(datamode)=='sst_aquap_constant') then
@@ -607,4 +613,8 @@ contains
     end if
   end subroutine ModelFinalize
 
+#ifdef CESMCOUPLED
 end module ocn_comp_nuopc
+#else
+end module cdeps_docn_comp
+#endif

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -1,8 +1,4 @@
-#ifdef CESMCOUPLED
 module ocn_comp_nuopc
-#else
-module cdeps_docn_comp
-#endif
 
   !----------------------------------------------------------------------------
   ! This is the NUOPC cap for DOCN
@@ -111,11 +107,7 @@ module cdeps_docn_comp
   logical                      :: aquaplanet = .false.
   logical                      :: diagnose_data = .true.
   integer      , parameter     :: master_task = 0                 ! task number of master task
-#ifdef CESMCOUPLED
   character(*) , parameter     :: module_name = "(ocn_comp_nuopc)"
-#else
-  character(*) , parameter     :: module_name = "(cdeps_docn_comp)"
-#endif
   character(*) , parameter     :: modelname = 'docn'
   character(*) , parameter     :: u_FILE_u = &
        __FILE__
@@ -183,10 +175,10 @@ contains
     integer           :: ierr               ! error code
     logical           :: exists             ! check for file existence
     character(len=*),parameter :: subname=trim(module_name)//':(InitializeAdvertise) '
-    character(*)    ,parameter :: F00 = "('(" // trim(module_name) // ") ',8a)"
-    character(*)    ,parameter :: F01 = "('(" // trim(module_name) // ") ',a,2x,i8)"
-    character(*)    ,parameter :: F02 = "('(" // trim(module_name) // ") ',a,l6)"
-    character(*)    ,parameter :: F03 = "('(" // trim(module_name) // ") ',a,f8.5,2x,f8.5)"
+    character(*)    ,parameter :: F00 = "('(ocn_comp_nuopc) ',8a)"
+    character(*)    ,parameter :: F01 = "('(ocn_comp_nuopc) ',a,2x,i8)"
+    character(*)    ,parameter :: F02 = "('(ocn_comp_nuopc) ',a,l6)"
+    character(*)    ,parameter :: F03 = "('(ocn_comp_nuopc) ',a,f8.5,2x,f8.5)"
     !-------------------------------------------------------------------------------
 
     namelist / docn_nml / datamode, &
@@ -239,7 +231,7 @@ contains
     call shr_mpi_bcast(sst_constant_value        , mpicom, 'sst_constant_value')
 
     ! Special logic for prescribed aquaplanet
-    if (datamode(1:9) == 'sst_aquap') then
+    if (datamode(1:9) == 'sst_aquap' .and. trim(datamode) /= 'sst_aquap_constant') then
        ! First determine the prescribed aquaplanet option
        if (len_trim(datamode) == 10) then
           read(datamode(10:10),'(i1)') aquap_option
@@ -262,6 +254,8 @@ contains
     else
        call shr_sys_abort(' ERROR illegal docn datamode = '//trim(datamode))
     endif
+
+    write(6,*)'DEBUG: datamode = ',trim(datamode)
 
     ! Advertise docn fields
     if (trim(datamode)=='sst_aquap_analytic' .or. trim(datamode)=='sst_aquap_constant') then
@@ -622,8 +616,4 @@ contains
     end if
   end subroutine ModelFinalize
 
-#ifdef CESMCOUPLED
 end module ocn_comp_nuopc
-#else
-end module cdeps_docn_comp
-#endif

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -10,12 +10,12 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
   use ESMF             , only : ESMF_CalKind_Flag, ESMF_Time, ESMF_TimeInterval
   use ESMF             , only : ESMF_TimeIntervalGet, ESMF_TYPEKIND_R8, ESMF_FieldCreate
-  use ESMF             , only : ESMF_FILEFORMAT_ESMFMESH, ESMF_FieldCreate
+  use ESMF             , only : ESMF_FILEFORMAT_ESMFMESH, ESMF_FieldCreate, ESMF_FieldFill
   use ESMF             , only : ESMF_FieldBundleCreate, ESMF_MESHLOC_ELEMENT, ESMF_FieldBundleAdd
   use ESMF             , only : ESMF_POLEMETHOD_ALLAVG, ESMF_EXTRAPMETHOD_NEAREST_STOD, ESMF_REGRIDMETHOD_BILINEAR, ESMF_REGRIDMETHOD_NEAREST_STOD
   use ESMF             , only : ESMF_ClockGet, operator(-), operator(==), ESMF_CALKIND_NOLEAP
   use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
-  use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill
+  use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
   use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
@@ -522,6 +522,8 @@ contains
              sdat%pstrm(ns)%field_stream = ESMF_FieldCreate(stream_mesh, &
                   ESMF_TYPEKIND_r8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call ESMF_FieldFill(sdat%pstrm(ns)%field_stream, dataFillScheme="const", const1=1.0_r8, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
           end if
        endif
 
@@ -534,6 +536,7 @@ contains
           sdat%stream(ns)%mapalgo = 'none'
        else
           if (trim(sdat%stream(ns)%mapalgo) == "bilinear") then
+
              call ESMF_FieldRegridStore(sdat%pstrm(ns)%field_stream, lfield_dst, &
                   routehandle=sdat%pstrm(ns)%routehandle, &
                   regridmethod=ESMF_REGRIDMETHOD_BILINEAR,  &

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -10,12 +10,12 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
   use ESMF             , only : ESMF_CalKind_Flag, ESMF_Time, ESMF_TimeInterval
   use ESMF             , only : ESMF_TimeIntervalGet, ESMF_TYPEKIND_R8, ESMF_FieldCreate
-  use ESMF             , only : ESMF_FILEFORMAT_ESMFMESH, ESMF_FieldCreate, ESMF_FieldFill
+  use ESMF             , only : ESMF_FILEFORMAT_ESMFMESH, ESMF_FieldCreate
   use ESMF             , only : ESMF_FieldBundleCreate, ESMF_MESHLOC_ELEMENT, ESMF_FieldBundleAdd
   use ESMF             , only : ESMF_POLEMETHOD_ALLAVG, ESMF_EXTRAPMETHOD_NEAREST_STOD, ESMF_REGRIDMETHOD_BILINEAR, ESMF_REGRIDMETHOD_NEAREST_STOD
   use ESMF             , only : ESMF_ClockGet, operator(-), operator(==), ESMF_CALKIND_NOLEAP
   use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
-  use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid
+  use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
   use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
@@ -536,7 +536,6 @@ contains
           sdat%stream(ns)%mapalgo = 'none'
        else
           if (trim(sdat%stream(ns)%mapalgo) == "bilinear") then
-
              call ESMF_FieldRegridStore(sdat%pstrm(ns)%field_stream, lfield_dst, &
                   routehandle=sdat%pstrm(ns)%routehandle, &
                   regridmethod=ESMF_REGRIDMETHOD_BILINEAR,  &


### PR DESCRIPTION
### Description of changes
fix for failed cesm tests

### Specific notes

1. This PR initializes fields to 1 that are used in the stream->model map creation. This resolves failures for the following two tests:
```
SMS_D_Ld3_Vnuopc.f10_f10_mg37.I1850Clm50BgcCrop.cheyenne_intel.clm-default
ERI_D_Ld9_Vnuopc.ne30_g17.I2000Clm50BgcCru.cheyenne_intel.clm-vrtlay
```
2. This PR also fixes a problem for setting aqua-planet constant values. Currently, this is only used in CESM.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers: cheyenne/intel
   - details (e.g. failed tests): compare to aug0621 and all results were bfb
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [x] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: 949b0e798
- [x] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - hash: cesm2_3_alpha05b
