### PR TITLE
abort if any single column data is _Fillvalue

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1364,6 +1364,7 @@ contains
     character(*), parameter  :: subname = '(shr_strdata_readstrm) '
     character(*), parameter  :: F00   = "('(shr_strdata_readstrm) ',8a)"
     character(*), parameter  :: F02   = "('(shr_strdata_readstrm) ',2a,i8)"
+    character(CL)            :: errmsg
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1512,6 +1513,12 @@ contains
                 call shr_sys_abort(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)))
              end if
              if (handlefill) then
+                ! Single point streams are not allowed to have missing values
+                if (stream%mapalgo == 'none' .and. any(data_real2d == fillvalue_r4)) then
+                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                   if(sdat%masterproc) write(sdat%logunit,*) trim(errmsg)
+                   call shr_sys_abort(errmsg)
+                endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
                       if (.not. shr_infnan_isnan(data_real2d(n,lev)) .and. data_real2d(n,lev) .ne. fillvalue_r4) then
@@ -1538,6 +1545,13 @@ contains
                 call shr_sys_abort(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)))
              end if
              if (handlefill) then
+                ! Single point streams are not allowed to have missing values
+                if (stream%mapalgo == 'none' .and. any(data_real1d == fillvalue_r4)) then
+                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                   if(sdat%masterproc) write(sdat%logunit,*) trim(errmsg)
+                   call shr_sys_abort(errmsg)
+                endif
+
                 do n=1,size(dataptr1d)
                    if(.not. shr_infnan_isnan(data_real1d(n)) .and. data_real1d(n) .ne. fillvalue_r4) then
                       dataptr1d(n) = real(data_real1d(n), kind=r8)
@@ -1564,6 +1578,12 @@ contains
                 call shr_sys_abort(' ERROR: reading in 2d double variable: '// trim(per_stream%fldlist_stream(nf)))
              end if
              if (handlefill) then
+                ! Single point streams are not allowed to have missing values
+                if (stream%mapalgo == 'none' .and. any(data_dbl2d == fillvalue_r8)) then
+                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                   if(sdat%masterproc) write(sdat%logunit,*) trim(errmsg)
+                   call shr_sys_abort(errmsg)
+                endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
                       if (.not. shr_infnan_isnan(data_dbl2d(n,lev)) .and. data_dbl2d(n,lev) .ne. fillvalue_r8) then
@@ -1590,6 +1610,12 @@ contains
                 call shr_sys_abort(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)))
              end if
              if (handlefill) then
+                ! Single point streams are not allowed to have missing values
+                if (stream%mapalgo == 'none' .and. any(data_dbl1d == fillvalue_r8)) then
+                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                   if(sdat%masterproc) write(sdat%logunit,*) trim(errmsg)
+                   call shr_sys_abort(errmsg)
+                endif
                 do n = 1,size(dataptr1d)
                    if (.not. shr_infnan_isnan(data_dbl1d(n)) .and. data_dbl1d(n) .ne. fillvalue_r8) then
                       dataptr1d(n) = data_dbl1d(n)


### PR DESCRIPTION
### Description of changes
For single column cases (mapalgo == none) make sure that there is no missing data in the input stream, abort and report if any data is set to _Fillvalue.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): #115

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [X] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed:
- [X] (required) aux_cdeps
   - machines and compilers: cheyenne intel 
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
