### PR TITLE
zenith angle time correction

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1255,7 +1255,7 @@ contains
     call ESMF_TraceRegionExit(trim(istr)//'_setup')
 
     ! if model current date is outside of model lower or upper bound - find the stream bounds
-    if (rDateM < rDateLB .or. rDateM > rDateUB) then
+    if (rDateM < rDateLB .or. rDateM >= rDateUB) then
        call ESMF_TraceRegionEnter(trim(istr)//'_fbound')
        call shr_stream_findBounds(stream, mDate, mSec,  sdat%masterproc, &
             sdat%pstrm(ns)%ymdLB, dDateLB, sdat%pstrm(ns)%todLB, n_lb, filename_lb, &

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -238,26 +238,17 @@ contains
 
     do while( reday < reday2) ! mid-interval t-steps thru interval [LB,UB]
 
+       !--- get next cosz value for t-avg ---
+       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
+       n = n + ldt
+       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
+
        !--- advance to next time in [LB,UB] ---
        ymd0 = ymd
        tod0 = tod
        reday0 = reday
        call shr_cal_advDateInt(ldt,'seconds',ymd0,tod0,ymd,tod,calendar)
        call shr_cal_timeSet(reday,ymd,tod,calendar)
-
-       if (reday > reday2) then
-          ymd = ymd2
-          tod = tod2
-          timeint = reday2-reday0
-          call ESMF_TimeIntervalGet(timeint, s_i8=dtsec, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          ldt = int(dtsec, shr_kind_in)
-       endif
-
-       !--- get next cosz value for t-avg ---
-       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
-       n = n + ldt
-       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
 
     end do
     tavCosz = tavCosz/real(n,r8) ! form t-avg


### PR DESCRIPTION
### Description of changes
  Corrects the calculation of solar zenith angle, which was off by one timestep.

### Specific notes
Sean ran two five day simulations, with and without your cdeps changes.  The changes correct the bug.  

Contributors other than yourself, if any: Sean Swenson

CDEPS Issues Fixes #120 #35 

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [X] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
