### PR TITLE
should be model mesh here not stream mesh

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -984,13 +984,10 @@ contains
        ! ---------------------------------------------------------
 
        do ns = 1,nstreams
-          call ESMF_MeshGet(sdat%pstrm(ns)%stream_mesh, elementCount=lsize)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          call ESMF_MeshGet(sdat%pstrm(ns)%stream_mesh, elementCount=lsize)
+          call ESMF_MeshGet(sdat%model_mesh, elementCount=lsize)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           allocate(mask(lsize))
-          call ESMF_MeshGet(sdat%pstrm(ns)%stream_mesh, elementMask=mask)
+          call ESMF_MeshGet(sdat%model_mesh, elementMask=mask)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           
           if (trim(sdat%stream(ns)%tinterpalgo) == 'coszen') then


### PR DESCRIPTION
### Description of changes
Code introduced in cdeps0.12.28 incorrectly used the stream mesh mask where the model mesh mask should have been used.  This was causing a runtime failure in ctsm. 

### Specific notes

Contributors other than yourself, if any:
mvertens

CMEPS Issues Fixed (include github issue #):
Fixes issue https://github.com/ESCOMP/CTSM/issues/1512

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [X] bit for bit with cdeps0.12.27
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [X] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
