### PR TITLE
remove mask from time interp due to issues with unstructured grids

### DIFF
--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -349,7 +349,7 @@ contains
        rtmp = maxval(Sa_tbot(:))
        call shr_mpi_max(rtmp, tbotmax, mpicom, 'datm_tbot', all=.true.)
        if (masterproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
-       if(tbotmax <= 0 .or. tbotmax > 1000.0) then
+       if(tbotmax <= 0) then
           call shr_sys_abort(subname//'ERROR: bad value in tbotmax')
        endif
 

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -15,7 +15,7 @@ module cdeps_docn_comp
   use ESMF             , only : ESMF_Alarm, ESMF_MethodRemove, ESMF_MethodAdd
   use ESMF             , only : ESMF_GridCompSetEntryPoint, ESMF_ClockGetAlarm, ESMF_AlarmIsRinging
   use ESMF             , only : ESMF_StateGet, operator(+), ESMF_AlarmRingerOff, ESMF_LogWrite
-  use ESMF             , only : ESMF_Field, ESMF_FieldGet
+  use ESMF             , only : ESMF_Field, ESMF_FieldGet, ESMF_VmLogMemInfo
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_Advertise, NUOPC_CompAttributeGet
   use NUOPC_Model      , only : model_routine_SS        => SetServices
@@ -306,7 +306,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-
+    call ESMF_VMLogMemInfo("Entering "//trim(subname))
     ! Initialize model mesh, restart flag, logunit, model_mask and model_frac
     call ESMF_TraceRegionEnter('docn_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'OCN', nx_global, ny_global, &
@@ -355,6 +355,7 @@ contains
        ! *******************
        ! *** RETURN HERE ***
        ! *******************
+       call ESMF_VMLogMemInfo("Leaving "//trim(subname))
        RETURN
     end if
 
@@ -374,7 +375,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_SetScalar(dble(ny_global),flds_scalar_index_ny, exportState, flds_scalar_name, flds_scalar_num, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
+    call ESMF_VMLogMemInfo("Leaving "//trim(subname))
    end subroutine InitializeRealize
 
   !===============================================================================

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -848,7 +848,6 @@ contains
     integer                             :: nstreams
     integer                             :: stream_index
     integer                             :: lsize
-    integer          ,allocatable       :: mask(:)
     real(r8)         ,parameter         :: solZenMin = 0.001_r8 ! minimum solar zenith angle
     integer          ,parameter         :: tadj = 2
     character(len=*) ,parameter         :: timname = "_strd_adv"
@@ -984,16 +983,6 @@ contains
        ! ---------------------------------------------------------
 
        do ns = 1,nstreams
-          call ESMF_MeshGet(sdat%model_mesh, elementCount=lsize, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          allocate(mask(lsize))
-          !          call ESMF_MeshGet(sdat%model_mesh, elementMask=mask, rc=rc)
-          ! for unstructured grids mask is undetermined, setting it to 1 disables the feature.
-          !          if (rc == ESMF_RC_ARG_VALUE) then
-          mask = 1
-          !          else if (chkerr(rc,__LINE__,u_FILE_u)) then
-          !             return
-          !          endif
           if (trim(sdat%stream(ns)%tinterpalgo) == 'coszen') then
 
              ! Determine stream lower bound index
@@ -1037,7 +1026,7 @@ contains
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    do i = 1,size(dataptr2d,dim=2)
                       if (coszen(i) > solZenMin) then
-                         dataptr2d(:,i) = mask(i)*dataptr2d_lb(:,i)*coszen(i)/sdat%tavCoszen(i)
+                         dataptr2d(:,i) = dataptr2d_lb(:,i)*coszen(i)/sdat%tavCoszen(i)
                       else
                          dataptr2d(:,i) = 0._r8
                       endif
@@ -1051,7 +1040,7 @@ contains
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    do i = 1,size(dataptr1d)
                       if (coszen(i) > solZenMin) then
-                         dataptr1d(i) = mask(i)*dataptr1d_lb(i)*coszen(i)/sdat%tavCoszen(i)
+                         dataptr1d(i) = dataptr1d_lb(i)*coszen(i)/sdat%tavCoszen(i)
                       else
                          dataptr1d(i) = 0._r8
                       endif
@@ -1089,7 +1078,7 @@ contains
                         sdat%pstrm(ns)%fldlist_model(nf), fldptr2=dataptr2d_ub, rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    do lev = 1,sdat%pstrm(ns)%stream_nlev
-                      dataptr2d(lev,:) = mask(:)*(dataptr2d_lb(lev,:) * flb + dataptr2d_ub(lev,:) * fub)
+                      dataptr2d(lev,:) = dataptr2d_lb(lev,:) * flb + dataptr2d_ub(lev,:) * fub
                    end do
                 else
                    call dshr_fldbun_getfldptr(sdat%pstrm(ns)%fldbun_model, &
@@ -1101,7 +1090,7 @@ contains
                    call dshr_fldbun_getfldptr(sdat%pstrm(ns)%fldbun_data(sdat%pstrm(ns)%stream_ub), &
                         sdat%pstrm(ns)%fldlist_model(nf), fldptr1=dataptr1d_ub, rc=rc)
                    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                   dataptr1d(:) = mask(:)*(dataptr1d_lb(:) * flb + dataptr1d_ub(:) * fub)
+                   dataptr1d(:) = dataptr1d_lb(:) * flb + dataptr1d_ub(:) * fub
                 end if
              end do
              call ESMF_TraceRegionExit(trim(lstr)//trim(timname)//'_tint')
@@ -1129,7 +1118,6 @@ contains
              call ESMF_TraceRegionExit(trim(lstr)//trim(timname)//'_zero')
 
           endif
-          deallocate(mask)
        end do  ! loop over ns (number of streams)
 
        deallocate(newData)
@@ -1366,7 +1354,6 @@ contains
     real(r8), allocatable    :: data_dbl2d(:,:)              ! stream input data
     integer(i2), allocatable :: data_short1d(:)              ! stream input data
     integer(i2), allocatable :: data_short2d(:,:)            ! stream input data
-    integer,     allocatable :: mask(:)
     integer                  :: lsize, n
     integer                  :: spatialDim, numOwnedElements
     integer                  :: pio_iovartype
@@ -1517,13 +1504,6 @@ contains
 
        ! read the data
        call pio_setframe(pioid, varid, int(nt,kind=Pio_Offset_Kind))
-       
-       call ESMF_MeshGet(per_stream%stream_mesh, elementCount=lsize, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       allocate(mask(lsize))
-       call ESMF_LogWrite(trim(subname)//' calling ESMF_MeshGet mask', ESMF_LOGMSG_INFO)
-       call ESMF_MeshGet(per_stream%stream_mesh, elementMask=mask, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
        if (pio_iovartype == PIO_REAL) then
           ! -----------------------------
           ! pio_iovartype is PIO_REAL
@@ -1674,14 +1654,14 @@ contains
                       if(data_short2d(n,lev) .eq. fillvalue_i2) then
                          dataptr2d(lev,n) = r8fill
                       else
-                         dataptr2d(lev,n) = mask(n)*(real(data_short2d(lev,n),r8) * scale_factor + add_offset)
+                         dataptr2d(lev,n) = real(data_short2d(lev,n),r8) * scale_factor + add_offset
                       endif
                    enddo
                 end do
              else
                 do lev = 1,stream_nlev
                    do n = 1,lsize
-                      dataptr2d(lev,n) = mask(n)*(real(data_short2d(n,lev),r8) * scale_factor + add_offset)
+                      dataptr2d(lev,n) = real(data_short2d(n,lev),r8) * scale_factor + add_offset
                    enddo
                 end do
              end if
@@ -1699,12 +1679,12 @@ contains
                    if(data_short1d(n).eq.fillvalue_i2) then
                       dataptr1d(n) = r8fill
                    else
-                      dataptr1d(n) = mask(n)*(real(data_short1d(n),r8) * scale_factor + add_offset)
+                      dataptr1d(n) = real(data_short1d(n),r8) * scale_factor + add_offset
                    endif
                 enddo
              else
                 do n=1,lsize
-                   dataptr1d(n) = mask(n)*(real(data_short1d(n),r8) * scale_factor + add_offset)
+                   dataptr1d(n) = real(data_short1d(n),r8) * scale_factor + add_offset
                 enddo
              endif
           end if
@@ -1735,16 +1715,10 @@ contains
           call ESMF_FieldFill(field_dst, dataFillScheme="const", const1=dataptr1d(1), rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        endif
-       deallocate(mask)
     enddo
 
     ! Both components of a vector stream must be in the same input stream file
     if (associated(dataptr2d_src) .and. associated(dataptr1d)) then
-       call ESMF_MeshGet(per_stream%stream_mesh, elementCount=lsize)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       allocate(mask(lsize))
-       call ESMF_MeshGet(per_stream%stream_mesh, elementMask=mask)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        ! get lon and lat of stream u and v fields
        lsize = size(dataptr1d)
@@ -1767,8 +1741,8 @@ contains
           lat = nu_coords(2*i)
           sinlon = sin(lon*deg2rad); coslon = cos(lon*deg2rad)
           sinlat = sin(lat*deg2rad); coslat = cos(lat*deg2rad)
-          dataptr2d_src(1,i) = mask(i)*(coslon * dataptr(i) - sinlon * dataptr2d_src(2,i))
-          dataptr2d_src(2,i) = mask(i)*(sinlon * dataptr(i) + coslon * dataptr2d_src(2,i))
+          dataptr2d_src(1,i) = (coslon * dataptr(i) - sinlon * dataptr2d_src(2,i))
+          dataptr2d_src(2,i) = (sinlon * dataptr(i) + coslon * dataptr2d_src(2,i))
        enddo
        vector_dst = ESMF_FieldCreate(sdat%model_mesh, ESMF_TYPEKIND_r8, name='vector_dst', &
             ungriddedLbound=(/1/), ungriddedUbound=(/2/), gridToFieldMap=(/2/), meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
@@ -1793,7 +1767,6 @@ contains
           data_u_dst(i) =  coslon * dataptr2d_dst(1,i) + sinlon * dataptr2d_dst(2,i)
           data_v_dst(i) = -sinlon * dataptr2d_dst(1,i) + coslon * dataptr2d_dst(2,i)
        enddo
-       deallocate(mask)
        deallocate(dataptr)
     endif
 


### PR DESCRIPTION
### Description of changes

Backs out tags cdeps0.12.29 and cdeps0.12.31 because using the mask on an unstructured grid doesn't work.  Will need to consider other ways to do this.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
