### PR TITLE
Fix buildlib arg order when called as a subprocess

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 Contributors other than yourself, if any:
 
-CMEPS Issues Fixed (include github issue #):
+CDEPS Issues Fixed (include github issue #):
 
 Are there dependencies on other component PRs
  - [ ] CIME (list)

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -18,8 +18,6 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.utils import run_cmd, symlink_force, expect
 from CIME.build import get_standard_cmake_args
-from CIME.XML.machines import Machines
-from CIME.XML.compilers import Compilers
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +56,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     return args.buildroot, args.installpath, args.caseroot
 
 
-def buildlib(bldroot, libroot, case, compname=None):
-    if bldroot.endswith("obj") and not compname:
-        compname = os.path.basename(os.path.abspath(os.path.join(bldroot,os.pardir)))
+def buildlib(bldroot, libroot, case):
+    expect(not bldroot.endswith("obj"),
+           "It appears that the main CDEPS buildlib is being called for a specific component\n"
+           "(specific data model components should use buildlib_comps)")
 
     if case.get_value("DEBUG"):
         strdebug = "debug"
@@ -75,88 +74,76 @@ def buildlib(bldroot, libroot, case, compname=None):
     sharedpath = os.path.join(case.get_value("COMPILER"),mpilib,
                               strdebug, strthread, "nuopc")
 
-    exe_root = case.get_value("EXEROOT")
+    logger.info("Running cmake for CDEPS")
+    srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__),os.pardir))
+    cmake_flags = get_standard_cmake_args(case, os.path.join(sharedpath,"cdeps"), shared_lib=True)
+    # base path of install to be completed by setting DESTDIR in make install
+    cmake_flags += " -DCMAKE_INSTALL_PREFIX:PATH=/"
+    cmake_flags += " -DLIBROOT={} ".format(libroot)
+    cmake_flags += " -DMPILIB={} ".format(mpilib)
+    cmake_flags += " -DPIO_C_LIBRARY={path}/lib -DPIO_C_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
+    cmake_flags += " -DPIO_Fortran_LIBRARY={path}/lib -DPIO_Fortran_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
+    cmake_flags += srcpath
+    all_src_files = list(all_files_under(srcpath, ignoredirs=[".git","cmake","test",".github","cime_config","fox"]))
+    # Search SourceMods path for CDEPS files. We only look in the data component directories for these, files in cdeps share
+    # directories should be added to one of the data component directories
+    srcmodsdir = os.path.join(case.get_value("CASEROOT"),"SourceMods")
+    all_files_in_srcmods = []
+    for comp_class in case.get_values("COMP_CLASSES"):
+        if comp_class == "CPL":
+            continue
+        comp = case.get_value("COMP_{}".format(comp_class))
+        cdeps_comp_name = "d"+comp_class.lower()
+        if comp == cdeps_comp_name:
+            all_files_in_srcmods.extend(list(all_files_under(os.path.join(srcmodsdir,"src."+cdeps_comp_name))))
 
-    if compname:
-        s, o, e = run_cmd("make d{}".format(compname), from_dir=bldroot, verbose=True)
-        libname = "lib{}.a".format(compname)
-        dlibname = "libd{}.a".format(compname)
-        dlibpath = os.path.join(bldroot, dlibname)
-        if os.path.exists(dlibpath):
-            symlink_force(os.path.join(bldroot,dlibname), os.path.join(libroot,libname))
-        else:
-            expect(False, "ERROR in {} build {} {}".format(compname,o,e))
+    basenames1 = [os.path.basename(f) for f in all_src_files]
+    basenames2 = [os.path.basename(f) for f in all_files_in_srcmods]
+    srcmods = list(set(basenames1).intersection(set(basenames2)))
+    if srcmods:
+        logger.info("Found SourceMods {}".format(srcmods))
+        for i, v in enumerate(all_src_files):
+            for sfile in all_files_in_srcmods:
+                if os.path.basename(sfile) == os.path.basename(v):
+                    all_src_files[i] = v.replace(os.path.dirname(v), os.path.dirname(sfile))
+    logger.debug("all_src_files: {}".format(all_src_files))
+    latest_src_file = max(all_src_files, key=os.path.getmtime)
+
+    src_time = os.path.getmtime(latest_src_file)
+    if os.path.exists(os.path.join(bldroot,"CMakeFiles")):
+        bld_time = os.path.getmtime(os.path.join(bldroot,"CMakeFiles"))
     else:
-        logger.info("Running cmake for CDEPS")
-        srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__),os.pardir))
-        cmake_flags = get_standard_cmake_args(case, os.path.join(sharedpath,"cdeps"), shared_lib=True)
-        # base path of install to be completed by setting DESTDIR in make install
-        cmake_flags += " -DCMAKE_INSTALL_PREFIX:PATH=/"
-        cmake_flags += " -DLIBROOT={} ".format(libroot)
-        cmake_flags += " -DMPILIB={} ".format(mpilib)
-        cmake_flags += " -DPIO_C_LIBRARY={path}/lib -DPIO_C_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
-        cmake_flags += " -DPIO_Fortran_LIBRARY={path}/lib -DPIO_Fortran_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
-        cmake_flags += srcpath
-        all_src_files = list(all_files_under(srcpath, ignoredirs=[".git","cmake","test",".github","cime_config","fox"]))
-        # Search SourceMods path for CDEPS files. We only look in the data component directories for these, files in cdeps share
-        # directories should be added to one of the data component directories
-        srcmodsdir = os.path.join(case.get_value("CASEROOT"),"SourceMods")
-        all_files_in_srcmods = []
-        for comp_class in case.get_values("COMP_CLASSES"):
-            if comp_class == "CPL":
-                continue
-            comp = case.get_value("COMP_{}".format(comp_class))
-            cdeps_comp_name = "d"+comp_class.lower()
-            if comp == cdeps_comp_name:
-                all_files_in_srcmods.extend(list(all_files_under(os.path.join(srcmodsdir,"src."+cdeps_comp_name))))
+        bld_time = src_time - 1
 
-        basenames1 = [os.path.basename(f) for f in all_src_files]
-        basenames2 = [os.path.basename(f) for f in all_files_in_srcmods]
-        srcmods = list(set(basenames1).intersection(set(basenames2)))
-        if srcmods:
-            logger.info("Found SourceMods {}".format(srcmods))
-            for i, v in enumerate(all_src_files):
-                for sfile in all_files_in_srcmods:
-                    if os.path.basename(sfile) == os.path.basename(v):
-                        all_src_files[i] = v.replace(os.path.dirname(v), os.path.dirname(sfile))
-        logger.debug("all_src_files: {}".format(all_src_files))
-        latest_src_file = max(all_src_files, key=os.path.getmtime)
+    # if any file in src is newer than CmakeFiles in the build directory, rerun cmake
 
-        src_time = os.path.getmtime(latest_src_file)
-        if os.path.exists(os.path.join(bldroot,"CMakeFiles")):
-            bld_time = os.path.getmtime(os.path.join(bldroot,"CMakeFiles"))
-        else:
-            bld_time = src_time - 1
+    if src_time > bld_time:
+        logger.info("cmake_flags {}".format(cmake_flags))
+        s,o,e = run_cmd("cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True)
+        expect(not s,"ERROR from cmake output={}, error={}".format(o,e))
+    else:
+        # The dwav_lib is the last file built in cdeps, wait for it to be built
+        dwav_lib = os.path.join(bldroot,"dwav","libdwav.a")
+        time_to_wait = 300
+        time_counter = 0
+        while not os.path.exists(dwav_lib):
+            time.sleep(1)
+            time_counter += 1
+            if time_counter > time_to_wait:
+                break
+        expect(time_counter <= time_to_wait," Timeout waiting for {}".format(dwav_lib))
 
-        # if any file in src is newer than CmakeFiles in the build directory, rerun cmake
+    s,o,e = run_cmd("make install VERBOSE=1 DESTDIR={}".format(libroot), from_dir=bldroot, verbose=True)
+    expect(not s,"ERROR from make output={}, error={}".format(o,e))
 
-        if src_time > bld_time:
-            logger.info("cmake_flags {}".format(cmake_flags))
-            s,o,e = run_cmd("cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True)
-            expect(not s,"ERROR from cmake output={}, error={}".format(o,e))
-        else:
-            # The dwav_lib is the last file built in cdeps, wait for it to be built
-            dwav_lib = os.path.join(bldroot,"dwav","libdwav.a")
-            time_to_wait = 300
-            time_counter = 0
-            while not os.path.exists(dwav_lib):
-                time.sleep(1)
-                time_counter += 1
-                if time_counter > time_to_wait:
-                    break
-            expect(time_counter <= time_to_wait," Timeout waiting for {}".format(dwav_lib))
-
-        s,o,e = run_cmd("make install VERBOSE=1 DESTDIR={}".format(libroot), from_dir=bldroot, verbose=True)
-        expect(not s,"ERROR from make output={}, error={}".format(o,e))
-
-        # Link the CDEPS component directories to the location expected by cime
-        for comp in ("atm", "lnd", "ice", "ocn", "rof", "wav"):
-            compname = case.get_value("COMP_{}".format(comp.upper()))
-            comppath = os.path.join(case.get_value("EXEROOT"),comp,"obj")
-            if compname == "d"+comp:
-                if not os.path.islink(comppath):
-                    os.rmdir(comppath)
-                symlink_force(os.path.join(bldroot,compname), comppath)
+    # Link the CDEPS component directories to the location expected by cime
+    for comp in ("atm", "lnd", "ice", "ocn", "rof", "wav"):
+        compname = case.get_value("COMP_{}".format(comp.upper()))
+        comppath = os.path.join(case.get_value("EXEROOT"),comp,"obj")
+        if compname == "d"+comp:
+            if not os.path.islink(comppath):
+                os.rmdir(comppath)
+            symlink_force(os.path.join(bldroot,compname), comppath)
 
 def all_files_under(path, ignoredirs=[]):
     """Iterates through all files that are under the given path."""
@@ -164,23 +151,6 @@ def all_files_under(path, ignoredirs=[]):
         [dirnames.remove(d) for d in list(dirnames) if d in ignoredirs]
         for filename in filenames:
             yield os.path.join(cur_path, filename)
-
-def get_compiler_names(case):
-    machine=case.get_value("MACH")
-    machobj = Machines(machine=machine)
-    compobj = Compilers(machobj)
-    compiler = case.get_value("COMPILER")
-    if case.get_value("MPILIB") == 'mpi-serial':
-        ccomp = compobj.get_value("SCC",{"COMPILER":compiler,"MACH":machine}).strip()
-        cxxcomp = compobj.get_value("SCXX",{"COMPILER":compiler}).strip()
-        fcomp = compobj.get_value("SFC",{"COMPILER":compiler}).strip()
-    else:
-        ccomp = compobj.get_value("MPICC",{"COMPILER":compiler}).strip()
-        cxxcomp = compobj.get_value("MPICXX",{"COMPILER":compiler}).strip()
-        fcomp = compobj.get_value("MPIFC",{"COMPILER":compiler}).strip()
-
-    return ccomp, cxxcomp, fcomp
-
 
 def _main_func(args):
     bldroot, installpath, caseroot = parse_command_line(args, __doc__)

--- a/cime_config/buildlib_comps
+++ b/cime_config/buildlib_comps
@@ -4,7 +4,7 @@
 build cime component model library.   This buildlib script is used by all CDEPS components.
 """
 
-import sys, os, time
+import sys, os
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -18,135 +18,24 @@ from standard_script_setup import *
 from CIME.buildlib import parse_input
 from CIME.case import Case
 from CIME.utils import run_cmd, symlink_force, expect
-from CIME.build import get_standard_cmake_args
-from CIME.XML.machines import Machines
-from CIME.XML.compilers import Compilers
 
 logger = logging.getLogger(__name__)
 
 def buildlib(bldroot, libroot, case, compname=None):
-    if bldroot.endswith("obj") and not compname:
+    if not compname:
+        expect(bldroot.endswith("obj"),
+               "It appears that buildlib_comps is being called for the main CDEPS build\n"
+               "(the main CDEPS build should use buildlib, not buildlib_comps)")
         compname = os.path.basename(os.path.abspath(os.path.join(bldroot,os.pardir)))
 
-    if case.get_value("DEBUG"):
-        strdebug = "debug"
+    _, o, e = run_cmd("make d{}".format(compname), from_dir=bldroot, verbose=True)
+    libname = "lib{}.a".format(compname)
+    dlibname = "libd{}.a".format(compname)
+    dlibpath = os.path.join(bldroot, dlibname)
+    if os.path.exists(dlibpath):
+        symlink_force(os.path.join(bldroot,dlibname), os.path.join(libroot,libname))
     else:
-        strdebug = "nodebug"
-    if case.get_value("BUILD_THREADED"):
-        strthread = "threads"
-    else:
-        strthread = "nothreads"
-    mpilib = case.get_value("MPILIB")
-
-    sharedpath = os.path.join(case.get_value("COMPILER"),mpilib,
-                              strdebug, strthread, "nuopc")
-
-    exe_root = case.get_value("EXEROOT")
-
-    if compname:
-        s, o, e = run_cmd("make d{}".format(compname), from_dir=bldroot, verbose=True)
-        libname = "lib{}.a".format(compname)
-        dlibname = "libd{}.a".format(compname)
-        dlibpath = os.path.join(bldroot, dlibname)
-        if os.path.exists(dlibpath):
-            symlink_force(os.path.join(bldroot,dlibname), os.path.join(libroot,libname))
-        else:
-            expect(False, "ERROR in {} build {} {}".format(compname,o,e))
-    else:
-        logger.info("Running cmake for CDEPS")
-        srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__),os.pardir))
-        cmake_flags = get_standard_cmake_args(case, os.path.join(sharedpath,"cdeps"), shared_lib=True)
-        # base path of install to be completed by setting DESTDIR in make install
-        cmake_flags += " -DCMAKE_INSTALL_PREFIX:PATH=/"
-        cmake_flags += " -DLIBROOT={} ".format(libroot)
-        cmake_flags += " -DMPILIB={} ".format(mpilib)
-        cmake_flags += " -DPIO_C_LIBRARY={path}/lib -DPIO_C_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
-        cmake_flags += " -DPIO_Fortran_LIBRARY={path}/lib -DPIO_Fortran_INCLUDE_DIR={path}/include ".format(path=os.path.join(case.get_value("EXEROOT"),sharedpath))
-        cmake_flags += srcpath
-        all_src_files = list(all_files_under(srcpath, ignoredirs=[".git","cmake","test",".github","cime_config","fox"]))
-        # Search SourceMods path for CDEPS files. We only look in the data component directories for these, files in cdeps share
-        # directories should be added to one of the data component directories
-        srcmodsdir = os.path.join(case.get_value("CASEROOT"),"SourceMods")
-        all_files_in_srcmods = []
-        for comp_class in case.get_values("COMP_CLASSES"):
-            if comp_class == "CPL":
-                continue
-            comp = case.get_value("COMP_{}".format(comp_class))
-            cdeps_comp_name = "d"+comp_class.lower()
-            if comp == cdeps_comp_name:
-                all_files_in_srcmods.extend(list(all_files_under(os.path.join(srcmodsdir,"src."+cdeps_comp_name))))
-
-        basenames1 = [os.path.basename(f) for f in all_src_files]
-        basenames2 = [os.path.basename(f) for f in all_files_in_srcmods]
-        srcmods = list(set(basenames1).intersection(set(basenames2)))
-        if srcmods:
-            logger.info("Found SourceMods {}".format(srcmods))
-            for i, v in enumerate(all_src_files):
-                for sfile in all_files_in_srcmods:
-                    if os.path.basename(sfile) == os.path.basename(v):
-                        all_src_files[i] = v.replace(os.path.dirname(v), os.path.dirname(sfile))
-        logger.debug("all_src_files: {}".format(all_src_files))
-        latest_src_file = max(all_src_files, key=os.path.getmtime)
-
-        src_time = os.path.getmtime(latest_src_file)
-        if os.path.exists(os.path.join(bldroot,"CMakeFiles")):
-            bld_time = os.path.getmtime(os.path.join(bldroot,"CMakeFiles"))
-        else:
-            bld_time = src_time - 1
-
-        # if any file in src is newer than CmakeFiles in the build directory, rerun cmake
-
-        if src_time > bld_time:
-            logger.info("cmake_flags {}".format(cmake_flags))
-            s,o,e = run_cmd("cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True)
-            expect(not s,"ERROR from cmake output={}, error={}".format(o,e))
-        else:
-            # The dwav_lib is the last file built in cdeps, wait for it to be built
-            dwav_lib = os.path.join(bldroot,"dwav","libdwav.a")
-            time_to_wait = 300
-            time_counter = 0
-            while not os.path.exists(dwav_lib):
-                time.sleep(1)
-                time_counter += 1
-                if time_counter > time_to_wait:
-                    break
-            expect(time_counter <= time_to_wait," Timeout waiting for {}".format(dwav_lib))
-
-        s,o,e = run_cmd("make install VERBOSE=1 DESTDIR={}".format(libroot), from_dir=bldroot, verbose=True)
-        expect(not s,"ERROR from make output={}, error={}".format(o,e))
-
-        # Link the CDEPS component directories to the location expected by cime
-        for comp in ("atm", "lnd", "ice", "ocn", "rof", "wav"):
-            compname = case.get_value("COMP_{}".format(comp.upper()))
-            comppath = os.path.join(case.get_value("EXEROOT"),comp,"obj")
-            if compname == "d"+comp:
-                if not os.path.islink(comppath):
-                    os.rmdir(comppath)
-                symlink_force(os.path.join(bldroot,compname), comppath)
-
-def all_files_under(path, ignoredirs=[]):
-    """Iterates through all files that are under the given path."""
-    for cur_path, dirnames, filenames in os.walk(path, topdown=True):
-        [dirnames.remove(d) for d in list(dirnames) if d in ignoredirs]
-        for filename in filenames:
-            yield os.path.join(cur_path, filename)
-
-def get_compiler_names(case):
-    machine=case.get_value("MACH")
-    machobj = Machines(machine=machine)
-    compobj = Compilers(machobj)
-    compiler = case.get_value("COMPILER")
-    if case.get_value("MPILIB") == 'mpi-serial':
-        ccomp = compobj.get_value("SCC",{"COMPILER":compiler,"MACH":machine}).strip()
-        cxxcomp = compobj.get_value("SCXX",{"COMPILER":compiler}).strip()
-        fcomp = compobj.get_value("SFC",{"COMPILER":compiler}).strip()
-    else:
-        ccomp = compobj.get_value("MPICC",{"COMPILER":compiler}).strip()
-        cxxcomp = compobj.get_value("MPICXX",{"COMPILER":compiler}).strip()
-        fcomp = compobj.get_value("MPIFC",{"COMPILER":compiler}).strip()
-
-    return ccomp, cxxcomp, fcomp
-
+        expect(False, "ERROR in {} build {} {}".format(compname,o,e))
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)

--- a/cime_config/buildlib_comps
+++ b/cime_config/buildlib_comps
@@ -15,6 +15,7 @@ _LIBDIR = os.path.join(_CIMEROOT, "scripts", "lib")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup import *
+from CIME.buildlib import parse_input
 from CIME.case import Case
 from CIME.utils import run_cmd, symlink_force, expect
 from CIME.build import get_standard_cmake_args
@@ -22,41 +23,6 @@ from CIME.XML.machines import Machines
 from CIME.XML.compilers import Compilers
 
 logger = logging.getLogger(__name__)
-
-def parse_command_line(args, description):
-###############################################################################
-    parser = argparse.ArgumentParser(
-        usage="""\n{0} [--debug]
-OR
-{0} --verbose
-OR
-{0} --help
-
-\033[1mEXAMPLES:\033[0m
-    \033[1;32m# Run \033[0m
-    > {0}
-""" .format (os.path.basename(args[0])),
-
-description=description,
-
-formatter_class=argparse.ArgumentDefaultsHelpFormatter
-)
-
-    CIME.utils.setup_standard_logging_options(parser)
-
-    parser.add_argument("buildroot",
-                        help="build path root")
-
-    parser.add_argument("installpath",
-                        help="install path ")
-
-    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
-                        help="Case directory to build")
-
-    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
-
-    return args.buildroot, args.installpath, args.caseroot
-
 
 def buildlib(bldroot, libroot, case, compname=None):
     if bldroot.endswith("obj") and not compname:
@@ -183,9 +149,9 @@ def get_compiler_names(case):
 
 
 def _main_func(args):
-    bldroot, installpath, caseroot = parse_command_line(args, __doc__)
+    caseroot, libroot, bldroot = parse_input(args)
     with Case(caseroot) as case:
-        buildlib(bldroot, installpath, case)
+        buildlib(bldroot, libroot, case)
 
 if __name__ == "__main__":
     _main_func(sys.argv)

--- a/datm/cime_config/buildlib
+++ b/datm/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps

--- a/dice/cime_config/buildlib
+++ b/dice/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps

--- a/dlnd/cime_config/buildlib
+++ b/dlnd/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps

--- a/docn/cime_config/buildlib
+++ b/docn/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps

--- a/drof/cime_config/buildlib
+++ b/drof/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps

--- a/dwav/cime_config/buildlib
+++ b/dwav/cime_config/buildlib
@@ -1,1 +1,1 @@
-../../cime_config/buildlib
+../../cime_config/buildlib_comps


### PR DESCRIPTION
### Description of changes

The argument order in the buildlib function was wrong when it was called as a subprocess in the course of building the CDEPS shared library.

As noted in ESMCI/cime#4034, this was using argument parsing that is appropriate for components, which (confusingly!) differs from the order of arguments in calls to libraries' buildlibs. The CDEPS shared library is built using the library code, not the component code.

However, this was made trickier by the fact that the same buildlib was being used for both the CDEPS shared library build and the individual data model builds. The latter need the original argument order. It seemed like there was little value gained by using the same buildlib for both, so I have split this into two different files in this PR.

I have confirmed that this works by introducing the following temporary diffs to force the CDEPS buildlibs to be called as subprocesses:

``` diff
diff --git a/cime_config/buildlib b/cime_config/buildlib
index 27e3776..f92591d 100755
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -56,7 +56,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     return args.buildroot, args.installpath, args.caseroot
 
 
-def buildlib(bldroot, libroot, case):
+def buildlib2(bldroot, libroot, case):
     expect(not bldroot.endswith("obj"),
            "It appears that the main CDEPS buildlib is being called for a specific component\n"
            "(specific data model components should use buildlib_comps)")
@@ -155,7 +155,7 @@ def all_files_under(path, ignoredirs=[]):
 def _main_func(args):
     bldroot, installpath, caseroot = parse_command_line(args, __doc__)
     with Case(caseroot) as case:
-        buildlib(bldroot, installpath, case)
+        buildlib2(bldroot, installpath, case)
 
 if __name__ == "__main__":
     _main_func(sys.argv)
diff --git a/cime_config/buildlib_comps b/cime_config/buildlib_comps
index 7e640eb..34ecad0 100755
--- a/cime_config/buildlib_comps
+++ b/cime_config/buildlib_comps
@@ -21,7 +21,7 @@ from CIME.utils import run_cmd, symlink_force, expect
 
 logger = logging.getLogger(__name__)
 
-def buildlib(bldroot, libroot, case, compname=None):
+def buildlib2(bldroot, libroot, case, compname=None):
     if not compname:
         expect(bldroot.endswith("obj"),
                "It appears that buildlib_comps is being called for the main CDEPS build\n"
@@ -40,7 +40,7 @@ def buildlib(bldroot, libroot, case, compname=None):
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)
     with Case(caseroot) as case:
-        buildlib(bldroot, libroot, case)
+        buildlib2(bldroot, libroot, case)
 
 if __name__ == "__main__":
     _main_func(sys.argv)
```

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
Resolves ESCOMP/CDEPS#104

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed:
- [x] (required) aux_cdeps
   - machines and compilers: cheyenne_intel
   - details (e.g. failed tests): All tests passed and were bit-for-bit except for these two that also failed from the baseline (the PEND test is still running after about 4 hours in both; I'm killing it):
   ```
   PEND SMS_Ln9_P1.T42_T42.2000_DATM%QIA_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV.cheyenne_intel.datm-scam RUN
   FAIL SMS_Vnuopc_Ld5.TL319_t061.2000_DATM%ERA5_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP.cheyenne_intel RUN time=9
   ```

- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [x] CTSM
  - repository to check out: https://github.com/ESCOMP/CTSM.git
  - tag: ctsm5.1.dev065