### PR TITLE
Allow none mapalgo

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -44,7 +44,7 @@ _stream_file_template = """
 """
 
 valid_values = {}
-valid_values["mapalgo"]  = ["bilinear", "nn", "redist", "mapconsd", "mapconf"]
+valid_values["mapalgo"]  = ["bilinear", "nn", "redist", "mapconsd", "mapconf", "none"]
 valid_values["tintalgo"] = ["lower", "upper", "nearest", "linear", "coszen"]
 valid_values["taxmode"]  = ["cycle", "extend", "limit"]
 
@@ -94,7 +94,7 @@ class StreamCDEPS(GenericXML):
                     break
                 # endif
             # end while
-            index += 1 
+            index += 1
             lines_input_new.append(line)
         #end while
 
@@ -104,9 +104,9 @@ class StreamCDEPS(GenericXML):
             expect(len(stream_mods) == 2,
                    "input stream mod can only be of the form streamname:var=value(s)")
             stream,varmod = stream_mods
-            expect (stream in stream_names, 
+            expect (stream in stream_names,
                     "{} contains a streamname \'{}\' that is not part of valid streamnames {}".
-                    format(user_mods_file,stream,stream_names)) 
+                    format(user_mods_file,stream,stream_names))
             if stream  not in stream_mod_dict:
                 stream_mod_dict[stream] = {}
             # var=value and check the validity


### PR DESCRIPTION
### Description of changes

Allow `none` to be an option for `mapalgo` in the `user_nl_datm_streams namelist` file.

### Specific notes

For single-point runs of CTSM, we need to be able to set `foo:mapalgo=none` , where `foo` is the stream name. I added `none` as an option to `cime_config/stream_cdeps.py` [here](https://github.com/adrifoster/CDEPS/blob/45e24e67d0896d77c644b5e34c1e9cb1351acf98/cime_config/stream_cdeps.py#L47):

```
valid_values["mapalgo"]  = ["bilinear", "nn", "redist", "mapconsd", "mapconf", "none"]
```

Contributors other than yourself, if any:
@billsacks and @ekluzek 

CDEPS Issues Fixed (include github issue #): #134

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [x] Yes - we allow `mapalgo=none` in the `user_nl_datm_streams` namelist
 - [ ] No

Testing performed:
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
