### PR TITLE
Fix for ESMF config file for multiple stream 

### DIFF
--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -698,6 +698,7 @@ contains
           streamdat(i)%varlist(n)%nameinfile = strm_tmpstrings(n)(1:index(trim(strm_tmpstrings(n)), " "))
           streamdat(i)%varlist(n)%nameinmodel = strm_tmpstrings(n)(index(trim(strm_tmpstrings(n)), " ", .true.)+1:)
         enddo
+        deallocate(strm_tmpstrings)
       else
         call shr_sys_abort("stream data variables must be provided")
       endif


### PR DESCRIPTION
### Description of changes
This PR fixes ESMF config format to provide multiple stream to CDEPS. It just affects UFS application at this point since this format only used under UFS.

### Specific notes
Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): https://github.com/ESCOMP/CDEPS/issues/139

Are there dependencies on other component PRs
 - [ ] CIME (list)
 - [ ] CMEPS (list)

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed: Testing is done under UFS since this option is only used there.
- [ ] (required) aux_cdeps
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CIME
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CMEPS
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
- [ ] CESM
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch:
  - hash:
