### PR TITLE
Revert PR #123

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1261,7 +1261,7 @@ contains
     call ESMF_TraceRegionExit(trim(istr)//'_setup')
 
     ! if model current date is outside of model lower or upper bound - find the stream bounds
-    if (rDateM < rDateLB .or. rDateM >= rDateUB) then
+    if (rDateM < rDateLB .or. rDateM > rDateUB) then
        call ESMF_TraceRegionEnter(trim(istr)//'_fbound')
        call shr_stream_findBounds(stream, mDate, mSec,  sdat%mainproc, &
             sdat%pstrm(ns)%ymdLB, dDateLB, sdat%pstrm(ns)%todLB, n_lb, filename_lb, &

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -238,17 +238,26 @@ contains
 
     do while( reday < reday2) ! mid-interval t-steps thru interval [LB,UB]
 
-       !--- get next cosz value for t-avg ---
-       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
-       n = n + ldt
-       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
-
        !--- advance to next time in [LB,UB] ---
        ymd0 = ymd
        tod0 = tod
        reday0 = reday
        call shr_cal_advDateInt(ldt,'seconds',ymd0,tod0,ymd,tod,calendar)
        call shr_cal_timeSet(reday,ymd,tod,calendar)
+
+       if (reday > reday2) then
+          ymd = ymd2
+          tod = tod2
+          timeint = reday2-reday0
+          call ESMF_TimeIntervalGet(timeint, s_i8=dtsec, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          ldt = int(dtsec, shr_kind_in)
+       endif
+
+       !--- get next cosz value for t-avg ---
+       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
+       n = n + ldt
+       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
 
     end do
     tavCosz = tavCosz/real(n,r8) ! form t-avg


### PR DESCRIPTION
### Description of changes

PR #123 (solar zenith angle correction) led to exact restart failures in some situations: see #144. This PR backs out the changes from #123 .

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): Temporarily deals with #144.

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): more substantial. I have verified that this brings answers back to being bfb with those in cdeps0.12.35 (i.e., prior to #123) via a run of the aux_clm test suite.

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): aux_clm

Hashes used for testing: billsacks/CTSM@3fd7f6fbf

