### PR TITLE
fix restarts using coszen angle time interpolation 

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -403,7 +403,7 @@ contains
     ! Initialize and update orbital values
     call dshr_orbital_init(gcomp, logunit, my_task == main_task, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_orbital_update(clock, logunit, my_task == main_task, &
+    call dshr_orbital_update(currTime, logunit, my_task == main_task, &
          orbEccen, orbObliqr, orbLambm0, orbMvelpp, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -481,7 +481,7 @@ contains
     call shr_cal_ymd2date(yr, mon, day, next_ymd)
 
     ! Update the orbital values
-    call dshr_orbital_update(clock, logunit, my_task == main_task, &
+    call dshr_orbital_update(nextTime, logunit, my_task == main_task, &
          orbEccen, orbObliqr, orbLambm0, orbMvelpp, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1298,14 +1298,14 @@ contains
   end subroutine dshr_orbital_init
 
   !===============================================================================
-  subroutine dshr_orbital_update(clock, logunit,  maintask, eccen, obliqr, lambm0, mvelpp, rc)
+  subroutine dshr_orbital_update(Time, logunit,  maintask, eccen, obliqr, lambm0, mvelpp, rc)
 
     !----------------------------------------------------------
     ! Update orbital settings
     !----------------------------------------------------------
 
     ! input/output variables
-    type(ESMF_Clock) , intent(in)    :: clock
+    type(ESMF_Time)  , intent(in)    :: Time
     integer          , intent(in)    :: logunit
     logical          , intent(in)    :: maintask
     real(R8)         , intent(inout) :: eccen  ! orbital eccentricity
@@ -1315,7 +1315,6 @@ contains
     integer          , intent(out)   :: rc     ! output error
 
     ! local variables
-    type(ESMF_Time)   :: CurrTime ! current time
     integer           :: year     ! model year at current time
     integer           :: orb_year ! orbital year for current orbital computation
     character(len=CL) :: msgstr   ! temporary
@@ -1325,9 +1324,7 @@ contains
     !-------------------------------------------
 
     if (trim(orb_mode) == trim(orb_variable_year)) then
-       call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_TimeGet(CurrTime, yy=year, rc=rc)
+       call ESMF_TimeGet(Time, yy=year, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        orb_year = orb_iyear + (year - orb_iyear_align)
        lprint = maintask

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1329,7 +1329,7 @@ contains
     endif
 
     if (newdata) then
-       ! read uppber bound of data
+       ! read upper bound of data
        call shr_strdata_readstrm(sdat, sdat%pstrm(ns), stream, &
             sdat%pstrm(ns)%fldbun_data(sdat%pstrm(ns)%stream_ub), &
             filename_ub, n_ub, istr=trim(istr)//'_UB', boundstr='ub', rc=rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -138,7 +138,6 @@ module dshr_strdata_mod
      real(r8)                       :: lambm0 = SHR_ORB_UNDEF_REAL     ! cosz t-interp info
      real(r8)                       :: obliqr = SHR_ORB_UNDEF_REAL     ! cosz t-interp info
      real(r8), allocatable          :: tavCoszen(:)                    ! cosz t-interp data
-     logical                        :: is_restart = .false.
   end type shr_strdata_type
 
   real(r8)         ,parameter :: deg2rad = SHR_CONST_PI/180.0_r8
@@ -1277,11 +1276,7 @@ contains
     call ESMF_TraceRegionExit(trim(istr)//'_setup')
 
     ! if model current date is outside of model lower or upper bound - find the stream bounds
-    if (sdat%is_restart) then
-       find_bounds = .true.
-    else
-       find_bounds = (rDateM < rDateLB .or. rDateM >= rDateUB)
-    end if
+    find_bounds = (rDateM < rDateLB .or. rDateM >= rDateUB)
     if (debug > 0 .and. sdat%mainproc) then
        write(sdat%logunit,'(a,i4,2x,6(i18,2x),l7)')' stream,lbymd,lbsec,mdate,msec,ubymd,ubsec,newdata= ',ns,&
             sdat%pstrm(ns)%ymdLB,sdat%pstrm(ns)%todLB, &
@@ -1307,12 +1302,7 @@ contains
     endif
 
     ! determine if need to read in new stream data
-    if (sdat%is_restart) then
-       newdata = .true.
-    else
-       newdata = (sdat%pstrm(ns)%ymdLB /= oDateLB .or. sdat%pstrm(ns)%todLB /= oSecLB)
-    end if
-
+    newdata = (sdat%pstrm(ns)%ymdLB /= oDateLB .or. sdat%pstrm(ns)%todLB /= oSecLB)
     if (newdata) then
        if (sdat%pstrm(ns)%ymdLB == oDateUB .and. sdat%pstrm(ns)%todLB == oSecUB) then
           ! copy fldbun_stream_ub to fldbun_stream_lb
@@ -1347,11 +1337,6 @@ contains
        end if
     endif
     call ESMF_TraceRegionExit(trim(istr)//'_filemgt')
-
-    ! reset is_restart flag
-    if (sdat%is_restart) then
-       sdat%is_restart = .false.
-    end if
 
   end subroutine shr_strdata_readLBUB
 

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -783,7 +783,9 @@ contains
     character(*),parameter :: F04   = "('(shr_stream_findBounds) ',2a,i4)"
     !-------------------------------------------------------------------------------
 
-    if (debug>0) write(strm%logunit,F02) "DEBUG: ---------- enter ------------------"
+    if (debug>0 .and. isroot_task) then
+       write(strm%logunit,F02) "DEBUG: ---------- enter ------------------"
+    end if
 
     if ( .not. strm%init ) then
        call shr_sys_abort(trim(subName)//" ERROR: trying to find bounds of uninitialized stream")
@@ -828,9 +830,9 @@ contains
 
     dDateIn = dYear*10000 + modulo(mDateIn,10000) ! mDateIn mapped to range of data years
     rDateIn = dDateIn + secIn/spd                 ! dDateIn + fraction of a day
-    if(debug>0) then
-       write(strm%logunit,*) 'fbd1 ',mYear,dYear,dDateIn,rDateIn
-       write(strm%logunit,*) 'fbd2 ',yrFirst,yrLast,yrAlign,nYears
+    if (debug>0 .and. isroot_task) then
+       write(strm%logunit,'(a,2(i8,2x),2(f20.4,2x))') 'mYear,dYear,dDateIn,rDateIn  = ',mYear,dYear,dDateIn,rDateIn
+       write(strm%logunit,'(a,2(i8,2x),2(f20.4,2x))') 'yrFirst,yrLast,yrAlign,nYears= ',yrFirst,yrLast,yrAlign,nYears
     endif
 
     !----------------------------------------------------------------------------
@@ -865,8 +867,8 @@ contains
              call shr_sys_abort(trim(subName)//" ERROR: LVD not found, all data is after yearLast")
           end if
        end if
-       if (debug>1 ) then
-          if (strm%found_lvd) write(strm%logunit,F01) "DEBUG: found LVD = ",strm%file(k)%date(n)
+       if (debug>1 .and. isroot_task ) then
+          if (strm%found_lvd) write(strm%logunit,F01) " found LVD = ",strm%file(k)%date(n)
        end if
     end if
 
@@ -886,8 +888,8 @@ contains
     else
        rDategvd = 99991231.0
     endif
-    if(debug>0) then
-       write(strm%logunit,*) 'fbd3 ',rDateIn,rDatelvd,rDategvd
+    if (debug>0 .and. isroot_task) then
+       write(strm%logunit,'(a,3(f20.4,2x))') 'rDateIn,rDatelvd,rDategvd = ',rDateIn,rDatelvd,rDategvd
     endif
 
     !-----------------------------------------------------------
@@ -941,8 +943,8 @@ contains
                       strm%n_gvd = n
                       strm%found_gvd = .true.
                       rDategvd = strm%file(k)%date(n) + strm%file(k)%secs(n)/spd ! GVD date + frac day
-                      if (debug>1) then
-                         write(strm%logunit,F01) "DEBUG: found GVD ",strm%file(k)%date(n)
+                      if (debug>1 .and. isroot_task) then
+                         write(strm%logunit,F01) " found GVD ",strm%file(k)%date(n)
                       end if
                       exit B
                    end if
@@ -1210,7 +1212,7 @@ contains
 
     ! open file if needed
     if (.not. pio_file_is_open(strm%file(k)%fileid)) then
-       if (debug > 0 .and. isroot_task) then
+       if (debug>1 .and. isroot_task) then
           write(strm%logunit, '(a)') trim(subname)//' opening stream filename = '//trim(filename)
        end if
        rcode = pio_openfile(strm%pio_subsystem, strm%file(k)%fileid, strm%pio_iotype, filename, pio_nowrite)
@@ -1271,7 +1273,7 @@ contains
     deallocate(tvar)
 
     ! close file
-    if (debug > 0 .and. isroot_task) then
+    if (debug>1 .and. isroot_task) then
        write(strm%logunit, '(a)') trim(subname)//' closing stream filename = '//trim(filename)
     end if
     call pio_closefile(strm%file(k)%fileid)
@@ -1334,7 +1336,9 @@ contains
       !-------------------------------------------------------------------------------
 
       rc = 0
-      if (debug>1 ) write(strm%logunit,F01) "checking t-coordinate data   for file k =",k
+      if (debug>1 .and. isroot_task) then
+         write(strm%logunit,F01) "checking t-coordinate data   for file k =",k
+      end if
 
       if ( .not. strm%file(k)%haveData) then
          rc = 1
@@ -1356,7 +1360,7 @@ contains
                   date2 = strm%file(k  )%date(n)
                   secs2 = strm%file(k  )%secs(n)
                   checkIt = .true.
-                  if (debug>1 ) write(strm%logunit,F01) "comparing with previous file for file k =",k
+                  if (debug>1 .and. isroot_task) write(strm%logunit,F01) "comparing with previous file for file k =",k
                end if
             end if
          else if (n==strm%file(k)%nt+1) then
@@ -1369,7 +1373,7 @@ contains
                   date2 = strm%file(k+1)%date(1)
                   secs2 = strm%file(k+1)%secs(1)
                   checkIt = .true.
-                  if (debug>1 ) write(strm%logunit,F01) "comparing with next     file for file k =",k
+                  if (debug>1 .and. isroot_task) write(strm%logunit,F01) "comparing with next     file for file k =",k
                end if
             end if
          else
@@ -1405,7 +1409,8 @@ contains
          end if
       end do
 
-      if (debug>0) write(strm%logunit,F01) "data is OK (non-decreasing)  for file k =",k
+      if (debug>0 .and. isroot_task) write(strm%logunit,F01) "data is OK (non-decreasing)  for file k =",k
+
     end subroutine verifyTCoord
 
   end subroutine shr_stream_readTCoord

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -222,8 +222,8 @@ contains
           p => item(getElementsByTagname(streamnode, "taxmode"), 0)
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%taxmode)
-             if (streamdat(i)%taxmode /= shr_stream_taxis_cycle   .and. &  
-                 streamdat(i)%taxmode /= shr_stream_taxis_extend  .and. & 
+             if (streamdat(i)%taxmode /= shr_stream_taxis_cycle   .and. &
+                 streamdat(i)%taxmode /= shr_stream_taxis_extend  .and. &
                  streamdat(i)%taxmode /= shr_stream_taxis_limit) then
                 call shr_sys_abort("tintalgo must have a value of either cycle, extend or limit")
              end if
@@ -232,8 +232,8 @@ contains
           p => item(getElementsByTagname(streamnode, "mapalgo"), 0)
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%mapalgo)
-             if (streamdat(i)%mapalgo /= shr_stream_mapalgo_bilinear .and. &  
-                 streamdat(i)%mapalgo /= shr_stream_mapalgo_redist   .and. & 
+             if (streamdat(i)%mapalgo /= shr_stream_mapalgo_bilinear .and. &
+                 streamdat(i)%mapalgo /= shr_stream_mapalgo_redist   .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_nn       .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_consf    .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_consd    .and. &
@@ -245,8 +245,8 @@ contains
           p => item(getElementsByTagname(streamnode, "tintalgo"), 0)
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%tInterpAlgo)
-             if (streamdat(i)%tInterpAlgo /= shr_stream_tinterp_lower   .and. &  
-                 streamdat(i)%tInterpAlgo /= shr_stream_tinterp_upper   .and. & 
+             if (streamdat(i)%tInterpAlgo /= shr_stream_tinterp_lower   .and. &
+                 streamdat(i)%tInterpAlgo /= shr_stream_tinterp_upper   .and. &
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_nearest .and. &
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_linear  .and. &
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_coszen) then
@@ -1681,10 +1681,13 @@ contains
     type(var_desc_t)     :: varid, tvarid, dvarid, ntvarid, hdvarid
     integer              :: rcode
     integer              :: dimid_stream, dimid_files,dimid_nt, dimid_str
-    integer              :: n, k, maxnfiles=0
+    integer              :: n,i, k, maxnfiles=0
     integer              :: maxnt = 0
     integer, allocatable :: tmp(:)
     character(len=CL)    :: fname
+    integer, allocatable :: itemp2d(:,:)
+    integer, allocatable :: itemp3d(:,:,:)
+    character(len=CL), allocatable :: ctemp2d(:,:)
     !-------------------------------------------------------------------------------
 
     if (mode .eq. 'define') then
@@ -1699,21 +1702,29 @@ contains
              endif
           enddo
        enddo
-       rcode = pio_def_dim(pioid, 'nt',   maxnt, dimid_nt)
-       rcode = pio_def_dim(pioid, 'nfiles',   maxnfiles, dimid_files)
+       rcode = pio_def_dim(pioid, 'nt'      , maxnt, dimid_nt)
+       rcode = pio_def_dim(pioid, 'nfiles'  , maxnfiles, dimid_files)
        rcode = pio_def_dim(pioid, 'nstreams', size(streams), dimid_stream)
-       rcode = pio_def_var(pioid, 'nt'    , PIO_INT, (/dimid_files, dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'nfiles',   PIO_INT, (/dimid_stream/), varid)
+
+       rcode = pio_def_var(pioid, 'ymdLB' ,   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'ymdUB' ,   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'todLB' ,   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'todUB' ,   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'nfiles',   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'offset',   PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'k_lvd',    PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'n_lvd',    PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'k_gvd',    PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'n_gvd',    PIO_INT , (/dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'nt'    ,   PIO_INT , (/dimid_files, dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'haveData', PIO_INT , (/dimid_files, dimid_stream/), varid)
        rcode = pio_def_var(pioid, 'filename', PIO_CHAR, (/dimid_str, dimid_files, dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'date',     PIO_INT, (/dimid_nt, dimid_files, dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'timeofday',PIO_INT, (/dimid_nt, dimid_files, dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'offset',   PIO_INT, (/dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'k_lvd',    PIO_INT, (/dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'n_lvd',    PIO_INT, (/dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'k_gvd',    PIO_INT, (/dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'n_gvd',    PIO_INT, (/dimid_stream/), varid)
-       rcode = pio_def_var(pioid, 'haveData', PIO_INT, (/dimid_files, dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'date',     PIO_INT , (/dimid_nt , dimid_files, dimid_stream/), varid)
+       rcode = pio_def_var(pioid, 'timeofday',PIO_INT , (/dimid_nt , dimid_files, dimid_stream/), varid)
+
     else if (mode .eq. 'write') then
+
+       ! write out nfiles
        rcode = pio_inq_varid(pioid, 'nfiles', varid)
        allocate(tmp(size(streams)))
        do k=1,size(streams)
@@ -1721,30 +1732,35 @@ contains
        enddo
        rcode = pio_put_var(pioid, varid, tmp)
 
+       ! write out offset
        rcode = pio_inq_varid(pioid, 'offset', varid)
        do k=1,size(streams)
           tmp(k) = streams(k)%offset
        enddo
        rcode = pio_put_var(pioid, varid, tmp)
 
+       ! write out k_lvd
        rcode = pio_inq_varid(pioid, 'k_lvd', varid)
        do k=1,size(streams)
           tmp(k) = streams(k)%k_lvd
        enddo
        rcode = pio_put_var(pioid, varid, tmp)
 
+       ! write out n_lvd
        rcode = pio_inq_varid(pioid, 'n_lvd', varid)
        do k=1,size(streams)
           tmp(k) = streams(k)%n_lvd
        enddo
        rcode = pio_put_var(pioid, varid, tmp)
 
+       ! write out k_gvd
        rcode = pio_inq_varid(pioid, 'k_gvd', varid)
        do k=1,size(streams)
           tmp(k) = streams(k)%k_gvd
        enddo
        rcode = pio_put_var(pioid, varid, tmp)
 
+       ! write out n_gvd
        rcode = pio_inq_varid(pioid, 'n_gvd', varid)
        do k=1,size(streams)
           tmp(k) = streams(k)%n_gvd
@@ -1752,43 +1768,100 @@ contains
        rcode = pio_put_var(pioid, varid, tmp)
        deallocate(tmp)
 
-       rcode = pio_inq_varid(pioid, 'filename', varid)
-       rcode = pio_inq_varid(pioid, 'date', dvarid)
-       rcode = pio_inq_varid(pioid, 'timeofday', tvarid)
-       rcode = pio_inq_varid(pioid, 'nt', ntvarid)
-       rcode = pio_inq_varid(pioid, 'haveData', hdvarid)
+       ! write out nt
+       allocate(itemp2d(maxnfiles, size(streams)))
+       itemp2d(:,:) = -999
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
-             rcode = pio_put_var(pioid, varid, (/1,n,k/), streams(k)%file(n)%name)
-             rcode = pio_put_var(pioid, ntvarid, (/n,k/), streams(k)%file(n)%nt)
-             if (allocated(streams(k)%file(n)%date)) then
-                rcode = pio_put_var(pioid, dvarid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/),streams(k)%file(n)%date)
-             endif
-             if (allocated(streams(k)%file(n)%secs)) then
-                rcode = pio_put_var(pioid, tvarid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/),streams(k)%file(n)%secs)
-             endif
+             itemp2d(n,k) = streams(k)%file(n)%nt
+          end do
+       end do
+       rcode = pio_inq_varid(pioid, 'nt', varid)
+       rcode = pio_put_var(pioid, varid, itemp2d)
+       deallocate(itemp2d)
+
+       ! write out haveData
+       allocate(itemp2d(maxnfiles, size(streams)))
+       itemp2d(:,:) = -999
+       do k=1,size(streams)
+          do n=1,streams(k)%nfiles
              if(streams(k)%file(n)%haveData) then
-                rcode = pio_put_var(pioid, hdvarid, (/n,k/), 1)
+                itemp2d(n,k) = 1
              else
-                rcode = pio_put_var(pioid, hdvarid, (/n,k/), 0)
+                itemp2d(n,k) = 0
              endif
-          enddo
-       enddo
+          end do
+       end do
+       rcode = pio_inq_varid(pioid, 'haveData', varid)
+       rcode = pio_put_var(pioid, varid, itemp2d)
+       deallocate(itemp2d)
+
+       ! write out date
+       allocate(itemp3d(maxnt, maxnfiles, size(streams)))
+       itemp3d(:,:,:) = -999
+       do k=1,size(streams)
+          do n=1,streams(k)%nfiles
+             if (allocated(streams(k)%file(n)%date)) then
+                do i = 1,size(streams(k)%file(n)%date)
+                   itemp3d(i,n,k) = streams(k)%file(n)%date(i)
+                end do
+             end if
+          end do
+       end do
+       rcode = pio_inq_varid(pioid, 'date', varid)
+       rcode = pio_put_var(pioid, varid, itemp3d)
+       deallocate(itemp3d)
+
+       ! write out timeofday
+       allocate(itemp3d(maxnt, maxnfiles, size(streams)))
+       itemp3d(:,:,:) = -999
+       do k=1,size(streams)
+          do n=1,streams(k)%nfiles
+             if (allocated(streams(k)%file(n)%secs)) then
+                do i = 1,size(streams(k)%file(n)%secs)
+                   itemp3d(i,n,k) = streams(k)%file(n)%secs(i)
+                end do
+             end if
+          end do
+       end do
+       rcode = pio_inq_varid(pioid, 'timeofday', dvarid)
+       rcode = pio_put_var(pioid, dvarid, itemp3d)
+       deallocate(itemp3d)
+
+       ! write out filename
+       allocate(ctemp2d(maxnfiles, size(streams)))
+       ctemp2d(:,:) = 'unset'
+       do k = 1,size(streams)
+          do n = 1,streams(k)%nfiles
+             ctemp2d(n,k) = streams(k)%file(n)%name
+          end do
+       end do
+       rcode = pio_inq_varid(pioid, 'filename', varid)
+       do k = 1,size(streams)
+          do n = 1,maxnfiles 
+             rcode = pio_put_var(pioid, varid, (/1,n,k/), ctemp2d(n,k))
+          end do
+       end do
+       deallocate(ctemp2d)
+
     else if (mode .eq. 'read') then
+
+       ! Read in nfiles
        rcode = pio_inq_varid(pioid, 'nfiles', varid)
        allocate(tmp(size(streams)))
        rcode = pio_get_var(pioid, varid, tmp)
        do k=1,size(streams)
           if (streams(k)%nFiles /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in nfiles')
           endif
        enddo
 
+       ! read in offset
        rcode = pio_inq_varid(pioid, 'offset', varid)
        rcode = pio_get_var(pioid, varid, tmp)
        do k=1,size(streams)
           if (streams(k)%offset /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in offset')
           endif
        enddo
 
@@ -1797,7 +1870,7 @@ contains
        do k=1,size(streams)
           streams(k)%k_lvd = tmp(k)
           if (streams(k)%k_lvd /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in k_lvd')
           endif
        enddo
 
@@ -1806,7 +1879,7 @@ contains
        do k=1,size(streams)
           streams(k)%n_lvd = tmp(k)
           if (streams(k)%n_lvd /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in n_lvd')
           endif
        enddo
 
@@ -1815,7 +1888,7 @@ contains
        do k=1,size(streams)
           streams(k)%k_gvd = tmp(k)
           if (streams(k)%k_gvd /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in k_gvd')
           endif
        enddo
 
@@ -1824,50 +1897,66 @@ contains
        do k=1,size(streams)
           streams(k)%n_gvd = tmp(k)
           if (streams(k)%n_gvd /= tmp(k)) then
-             call shr_sys_abort('something is wrong')
+             call shr_sys_abort('ERROR reading in n_gvd')
           endif
        enddo
        deallocate(tmp)
 
-       rcode = pio_inq_varid(pioid, 'filename', varid)
-       rcode = pio_inq_varid(pioid, 'date', dvarid)
+       rcode = pio_inq_varid(pioid, 'filename' , varid)
+       rcode = pio_inq_varid(pioid, 'nt'       , ntvarid)
+       rcode = pio_inq_varid(pioid, 'date'     , dvarid)
        rcode = pio_inq_varid(pioid, 'timeofday', tvarid)
-       rcode = pio_inq_varid(pioid, 'nt', ntvarid)
-       rcode = pio_inq_varid(pioid, 'haveData', hdvarid)
+       rcode = pio_inq_varid(pioid, 'haveData' , hdvarid)
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
+
+             ! read in filename
              rcode = pio_get_var(pioid, varid, (/1,n,k/), fname)
-             if(fname .ne. streams(k)%file(n)%name) Then
-                call shr_sys_abort('something is wrong')
+             if (trim(fname) /= trim(streams(k)%file(n)%name)) then
+                write(6,'(a)')' fname = '//trim(fname)
+                write(6,'(a,i8,2x,i8,2x,a)')' k,n,streams(k)%file(n)%name = ',k,n,trim(streams(k)%file(n)%name)
+                call shr_sys_abort('ERROR reading in filename')
              endif
+
+             ! read in nt
              allocate(tmp(1))
              rcode = pio_get_var(pioid, ntvarid, (/n,k/), tmp(1))
              streams(k)%file(n)%nt = tmp(1)
              if(tmp(1) /= streams(k)%file(n)%nt) then
-                call shr_sys_abort('something is wrong')
+                call shr_sys_abort('ERROR read in nt')
              endif
              deallocate(tmp)
+
              if (streams(k)%file(n)%nt > 0) then
+
+                ! Allocate memory
                 allocate(tmp(streams(k)%file(n)%nt))
+
+                ! Read in date
                 rcode = pio_get_var(pioid, dvarid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/),tmp)
                 streams(k)%file(n)%date = tmp
-                if (.not. allocated(streams(k)%file(n)%date) .or. &
-                     any(tmp .ne. streams(k)%file(n)%date) ) then
-                   call shr_sys_abort('something is wrong')
+                if (.not. allocated(streams(k)%file(n)%date) .or. any(tmp .ne. streams(k)%file(n)%date) ) then
+                   call shr_sys_abort('ERROR reading in date')
                 endif
+
+                ! Read in timeofday
                 rcode = pio_get_var(pioid, tvarid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/),tmp)
                 streams(k)%file(n)%secs = tmp
-                if (.not. allocated(streams(k)%file(n)%secs) .or. &
-                     any(tmp .ne. streams(k)%file(n)%secs) ) then
-                   call shr_sys_abort('something is wrong')
+                if (.not. allocated(streams(k)%file(n)%secs) .or. any(tmp .ne. streams(k)%file(n)%secs) ) then
+                   call shr_sys_abort('ERROR reaing in timeofday')
                 endif
+
+                ! Read in havedata
                 rcode = pio_get_var(pioid, hdvarid, (/n,k/), tmp(1))
                 if(tmp(1)==1) then
                    streams(k)%file(n)%havedata = .true.
                 else
                    streams(k)%file(n)%havedata = .false.
                 endif
+
+                ! Free memory
                 deallocate(tmp)
+
              endif
           enddo
        enddo

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -238,26 +238,17 @@ contains
 
     do while( reday < reday2) ! mid-interval t-steps thru interval [LB,UB]
 
+       !--- get next cosz value for t-avg ---
+       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
+       n = n + ldt
+       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
+
        !--- advance to next time in [LB,UB] ---
        ymd0 = ymd
        tod0 = tod
        reday0 = reday
        call shr_cal_advDateInt(ldt,'seconds',ymd0,tod0,ymd,tod,calendar)
        call shr_cal_timeSet(reday,ymd,tod,calendar)
-
-       if (reday > reday2) then
-          ymd = ymd2
-          tod = tod2
-          timeint = reday2-reday0
-          call ESMF_TimeIntervalGet(timeint, s_i8=dtsec, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          ldt = int(dtsec, shr_kind_in)
-       endif
-
-       !--- get next cosz value for t-avg ---
-       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
-       n = n + ldt
-       tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
 
     end do
     tavCosz = tavCosz/real(n,r8) ! form t-avg

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -20,14 +20,14 @@ module dshr_tInterp_mod
   public :: shr_tInterp_getAvgCosz  ! get cosz, time avg of
   public :: shr_tInterp_getCosz     ! get cosz
 
+  integer :: debug = 0
+
   real(R8)     ,parameter :: deg2rad = SHR_CONST_PI/180.0_R8
   real(r8)     ,parameter :: c0 = 0.0_r8
   real(r8)     ,parameter :: c1 = 1.0_r8
   real(r8)     ,parameter :: eps = 1.0E-12_r8
   character(*) ,parameter :: u_FILE_u = &
        __FILE__
-
-  integer :: debug = 0
 
 !===============================================================================
 contains
@@ -158,7 +158,8 @@ contains
 
   !===============================================================================
   subroutine shr_tInterp_getAvgCosz(tavCosz, lon, lat, &
-       ymd1, tod1, ymd2, tod2, eccen, mvelpp, lambm0, obliqr, modeldt, calendar, rc)
+       ymd1, tod1, ymd2, tod2, eccen, mvelpp, lambm0, obliqr, modeldt, calendar, &
+       isroot, logunit, rc)
 
     !---------------------------------------------------------------
     ! Returns a time-average of cos(z) over the time interval [LB,UB].
@@ -180,6 +181,8 @@ contains
     real(r8)     ,intent(in)    :: obliqr     ! orb param
     integer      ,intent(in)    :: modeldt    ! model time step in secs
     character(*) ,intent(in)    :: calendar   ! calendar type
+    logical      , intent(in)   :: isroot
+    integer      , intent(in)   :: logunit
     integer      ,intent(out)   :: rc         ! error status
 
     ! local variables
@@ -236,10 +239,15 @@ contains
     lsize = size(tavCosz)
     allocate(cosz(lsize))
 
+    if (debug>0 .and. isroot) then
+       write(logunit,'(a,4(i8,2x))') trim(subname)//' calculating time average over interval ymd1,tod1,ymd2,tod2 = ', &
+            ymd1,tod1,ymd2,tod2
+    end if
+
     do while( reday < reday2) ! mid-interval t-steps thru interval [LB,UB]
 
        !--- get next cosz value for t-avg ---
-       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
+       call shr_tInterp_getCosz(cosz,lon,lat,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar,isroot,logunit)
        n = n + ldt
        tavCosz = tavCosz + cosz*real(ldt,r8)  ! add to partial sum
 
@@ -258,7 +266,8 @@ contains
   end subroutine shr_tInterp_getAvgCosz
 
   !===============================================================================
-  subroutine shr_tInterp_getCosz(cosz, lon, lat, ymd, tod, eccen, mvelpp, lambm0, obliqr, calendar)
+  subroutine shr_tInterp_getCosz(cosz, lon, lat, ymd, tod, &
+       eccen, mvelpp, lambm0, obliqr, calendar, isroot, logunit)
 
     !---------------------------------------------------------------
     ! Calculate and return the cos(solar-zenith angle).
@@ -274,6 +283,8 @@ contains
     real(r8)     , intent(in)    :: lambm0     ! orb param
     real(r8)     , intent(in)    :: obliqr     ! orb param
     character(*) , intent(in)    :: calendar   ! calendar type
+    logical      , intent(in)    :: isroot
+    integer      , intent(in)    :: logunit
 
     ! local variables
     integer                 :: n
@@ -293,6 +304,11 @@ contains
 
     call shr_cal_date2julian(ymd, tod, calday, calendar)
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr, declin, eccf )
+    if (debug > 0 .and. isroot) then
+       write(logunit,'(a,2(i8,2x),d20.10,2x,a)') trim(subname)//' ymd, tod, calday, calendar = ',ymd,tod,calday,calendar  
+       write(logunit,'(a,4(d20.10,2x))') trim(subname)//' eccen, mvelpp, lambm0, obliqr = ',eccen, mvelpp, lambm0, obliqr
+       write(logunit,'(a,2(d20.10,2x))') trim(subname)//' declin,eccf= ',declin,eccf
+    end if
     do n = 1,lsize
        lonr = lon(n) * deg2rad
        latr = lat(n) * deg2rad


### PR DESCRIPTION
### Description of changes
fix restarts using coszen angle time interpolation 

### Specific notes
Fixes for restart problems for streams that are using coszen angle time interpolation in historical simulations 
(e.g. ERS_Ly3_P72x2.f10_f10_mg37.IHistClm50Sp)
The main problem is that the update to the orbital parameter setting was using the current time rather than the next time 
when called from atm_comp_nuopc.
Also cleaned up data model restart files so reasonable values were obtained.

Contributors other than yourself, if any: 

CDEPS Issues:
Fixed #120 
Fixed #35 
Fixed #144 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): The changes will only effect streams that use coszen angle time interpolation and only effect historical simulations using datm.

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Verified that restarts passed for ERS_Ly3_P72x2.f10_f10_mg37.IHistClm50Sp

Hashes used for testing: ctsm5.1.dev086 with modifications for cdeps

