### PR TITLE
add call to pio_init

### DIFF
--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -144,9 +144,6 @@ contains
     call ESMF_VMGet(vm, mpiCommunicator=mpicom, localPet=my_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Initialize IO system
-    call shr_pio_init_component(gcomp)
-
     ! get scalar attributes
     call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -107,7 +107,9 @@ contains
   !===============================================================================
   subroutine dshr_init(gcomp, compname, sdat, mpicom, my_task, inst_index, inst_suffix, &
        flds_scalar_name, flds_scalar_num, flds_scalar_index_nx, flds_scalar_index_ny, logunit, rc)
-
+#ifdef CESMCOUPLED
+    use nuopc_shr_methods, only : set_component_logging
+#endif
     ! input/output variables
     type(ESMF_GridComp)                   :: gcomp
     character(len=*)      , intent(in)    :: compname  !e.g. ATM, OCN, ...
@@ -126,6 +128,7 @@ contains
     ! local variables
     type(ESMF_VM)     :: vm
     logical           :: isPresent, isSet
+    integer           :: slogunit
     character(len=CX) :: cvalue
     character(len=CX) :: logmsg
     character(len=CX) :: diro
@@ -140,6 +143,9 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMGet(vm, mpiCommunicator=mpicom, localPet=my_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Initialize IO system
+    call shr_pio_init_component(gcomp)
 
     ! get scalar attributes
     call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
@@ -191,15 +197,18 @@ contains
     else
        logfile = "d"//shr_string_toLower(compname)//".log"
     endif
-
+#ifdef CESMCOUPLED
+    call set_component_logging(gcomp, my_task == main_task, logunit, slogunit, rc=rc)
+#else
     if (my_task == main_task) then 
        call ESMF_LogWrite(trim(subname)//' : output logging is written to '//trim(diro)//"/"//trim(logfile), ESMF_LOGMSG_INFO)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        open(newunit=logunit, file=trim(diro)//"/"//trim(logfile))
+       
     else
        logUnit = 6
     endif
-
+#endif
     ! set component instance and suffix
     call NUOPC_CompAttributeGet(gcomp, name="inst_suffix", isPresent=isPresent, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
### Description of changes
Redo pio initialization for nuopc, removes mct specific data structures and subroutine calls. 

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):
CIME:  https://github.com/ESMCI/CIME/pull/4199
CMEPS: https://github.com/ESCOMP/CMEPS/pull/275

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): None

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): scripts_regression_tests.py, cesm prealpha - see https://github.com/ESCOMP/CMEPS/pull/275

Hashes used for testing:

