### PR TITLE
added skip_restart_read logic needed for CTSM spin-up runs

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -131,6 +131,7 @@ module cdeps_datm_comp
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global                           ! global nx
   integer                      :: ny_global                           ! global ny
+  logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
 
   ! linked lists
   type(fldList_type) , pointer :: fldsImport => null()
@@ -227,7 +228,8 @@ contains
     namelist / datm_nml / datamode, &
          model_meshfile, model_maskfile, &
          nx_global, ny_global, restfilm, iradsw, factorFn_data, factorFn_mesh, &
-         flds_presaero, flds_co2, flds_wiso, bias_correct, anomaly_forcing
+         flds_presaero, flds_co2, flds_wiso, bias_correct, anomaly_forcing, &
+         skip_restart_read
 
     rc = ESMF_SUCCESS
 
@@ -268,6 +270,7 @@ contains
     call shr_mpi_bcast(flds_presaero             , mpicom, 'flds_presaero')
     call shr_mpi_bcast(flds_co2                  , mpicom, 'flds_co2')
     call shr_mpi_bcast(flds_wiso                 , mpicom, 'flds_wiso')
+    call shr_mpi_bcast(skip_restart_read         , mpicom, 'skip_restart_read')
 
     ! write namelist input to standard out
     if (my_task == main_task) then
@@ -284,6 +287,7 @@ contains
        write(logunit,F02)' flds_presaero  = ',flds_presaero
        write(logunit,F02)' flds_co2       = ',flds_co2
        write(logunit,F02)' flds_wiso      = ',flds_wiso
+       write(logunit,F02)' skip_restart_read = ',skip_restart_read
     end if
 
     ! Validate sdat datamode
@@ -573,7 +577,7 @@ contains
        end select
 
        ! Read restart if needed
-       if (restart_read) then
+       if (restart_read .and. .not. skip_restart_read) then
           select case (trim(datamode))
           case('CORE2_NYF','CORE2_IAF')
              call datm_datamode_core2_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -292,6 +292,17 @@
     <desc>ending year to loop data over</desc>
   </entry>
 
+  <entry id="DATM_SKIP_RESTART_READ">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_component_datm</group>
+    <file>env_run.xml</file>
+    <desc> If set to true, than datm restarts will not be read on a continuation run.
+      This capability is used, for example, in CTSM spinup runs.
+    </desc>
+  </entry>
+
   <help>
     =========================================
     DATM naming conventions in compset name

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -316,4 +316,17 @@
     </values>
   </entry>
 
+  <entry id="skip_restart_read" modify_via_xml="DATM_SKIP_RESTART_READ">
+    <type>logical</type>
+    <category>datm</category>
+    <group>datm_nml</group>
+    <desc>
+      If set to true, than datm restarts will not be read on a continuation run.
+      This capability is used, for example, in CTSM spinup runs.
+    </desc>
+    <values>
+      <value>$DATM_SKIP_RESTART_READ</value>
+    </values>
+  </entry>
+
 </entry_id>


### PR DESCRIPTION
### Description of changes
added skip_restart_read logic needed for CTSM spin-up runs

### Specific notes
This PR is CESM specific and only effects datm. The addition of a new XML variable DATM_SKIP_RESTART_READ will skip reading the datm restart file on a continuation run.

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #97 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): Yes - a new datm namelist is added - `skip_restart_read` - whose default value is .false. - so this will not effect any UFS applications.

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Verified that ERS.f19_f19_mg17.IHistClm51Sp.cheyenne_intel restarts worked when the skip_restart_read was aded set to true.

Hashes used for testing: cesm2_3_alpha09a plus these changes

