### PR TITLE
fix for zero pressure in nldas2 configuration

### DIFF
--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -384,7 +384,13 @@ contains
        Sa_ptem(n) = Sa_tbot(n)
 
        !--- pressure ---
-       if (.not. associated(strm_pbot)) Sa_pbot(n) = pstd
+       if (.not. associated(strm_pbot)) then
+          Sa_pbot(n) = pstd
+       else if (Sa_pbot(n) == 0._r8) then
+          ! This happens if you are using points over ocean where the mask is 0
+          Sa_pbot(n) = pstd
+       end if
+
        Sa_pslv(n) = Sa_pbot(n)
 
        !--- u, v wind velocity ---


### PR DESCRIPTION
### Description of changes
fix for zero pressure in nldas2 configuration

### Specific notes
The problem encountered in nldas2 is that both the mesh had a mask of zero over ocean points and the route handle for the mapping of streams to the model resolution uses  zeroregion=ESMF_REGION_TOTAL. As a result, all mapped values over ocean were set to zero. This is a real problem if the variable is surface pressure. Since the values over ocean are never used, the solution is to simply set a valid value of surface pressure over ocean. 

Contributors other than yourself, if any: @jedwards4b @uturuncoglu 

CDEPS Issues Fixed: None

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): 
The following test now passes and gives results that are comparable to mct
SMS_D_Ld1.nldas2_rnldas2_mnldas2.I2000Ctsm50NwpSpNldas.cheyenne_intel.clm-default

Hashes used for testing: ctsm5.1.dev091

