### PR TITLE
fix of restart problems on izumi

### DIFF
--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1044,6 +1044,7 @@ contains
     integer           :: dimid(1)
     type(var_desc_t)  :: varid
     type(io_desc_t)   :: pio_iodesc
+    integer           :: oldmode 
     integer           :: rcode
     character(*), parameter :: F00   = "('(dshr_restart_write) ',2a,2(i0,2x))"
     !-------------------------------------------------------------------------------
@@ -1064,6 +1065,7 @@ contains
 
     ! write data model restart data
     rcode = pio_createfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(rest_file_model), pio_clobber)
+    rcode = pio_set_fill(pioid, PIO_FILL, oldmode)
     rcode = pio_put_att(pioid, pio_global, "version", "nuopc_data_models_v0")
     if (present(fld) .and. present(fldname)) then
        rcode = pio_def_dim(pioid, 'gsize', sdat%model_gsize, dimid(1))

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -1690,12 +1690,10 @@ contains
     integer              :: maxnt = 0
     integer, allocatable :: tmp(:)
     character(len=CL)    :: fname
-    integer, allocatable :: itemp2d(:,:)
-    integer, allocatable :: itemp3d(:,:,:)
-    character(len=CL), allocatable :: ctemp2d(:,:)
     !-------------------------------------------------------------------------------
 
     if (mode .eq. 'define') then
+
        rcode = pio_def_dim(pioid, 'strlen',   CL, dimid_str)
        do k=1,size(streams)
           if (streams(k)%nfiles > maxnfiles) then
@@ -1774,80 +1772,52 @@ contains
        deallocate(tmp)
 
        ! write out nt
-       allocate(itemp2d(maxnfiles, size(streams)))
-       itemp2d(:,:) = -999
+       rcode = pio_inq_varid(pioid, 'nt', varid)
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
-             itemp2d(n,k) = streams(k)%file(n)%nt
-          end do
-       end do
-       rcode = pio_inq_varid(pioid, 'nt', varid)
-       rcode = pio_put_var(pioid, varid, itemp2d)
-       deallocate(itemp2d)
+             rcode = pio_put_var(pioid, varid, (/n,k/), streams(k)%file(n)%nt)
+          enddo
+       enddo
 
        ! write out haveData
-       allocate(itemp2d(maxnfiles, size(streams)))
-       itemp2d(:,:) = -999
+       rcode = pio_inq_varid(pioid, 'haveData', dvarid)
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
              if(streams(k)%file(n)%haveData) then
-                itemp2d(n,k) = 1
+                rcode = pio_put_var(pioid, dvarid, (/n,k/), 1)
              else
-                itemp2d(n,k) = 0
+                rcode = pio_put_var(pioid, dvarid, (/n,k/), 0)
              endif
-          end do
-       end do
-       rcode = pio_inq_varid(pioid, 'haveData', varid)
-       rcode = pio_put_var(pioid, varid, itemp2d)
-       deallocate(itemp2d)
+          enddo
+       enddo
 
        ! write out date
-       allocate(itemp3d(maxnt, maxnfiles, size(streams)))
-       itemp3d(:,:,:) = -999
+       rcode = pio_inq_varid(pioid, 'date', varid)
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
              if (allocated(streams(k)%file(n)%date)) then
-                do i = 1,size(streams(k)%file(n)%date)
-                   itemp3d(i,n,k) = streams(k)%file(n)%date(i)
-                end do
-             end if
-          end do
-       end do
-       rcode = pio_inq_varid(pioid, 'date', varid)
-       rcode = pio_put_var(pioid, varid, itemp3d)
-       deallocate(itemp3d)
+                rcode = pio_put_var(pioid, varid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/), streams(k)%file(n)%date)
+             endif
+          enddo
+       enddo
 
        ! write out timeofday
-       allocate(itemp3d(maxnt, maxnfiles, size(streams)))
-       itemp3d(:,:,:) = -999
+       rcode = pio_inq_varid(pioid, 'timeofday', varid)
        do k=1,size(streams)
           do n=1,streams(k)%nfiles
              if (allocated(streams(k)%file(n)%secs)) then
-                do i = 1,size(streams(k)%file(n)%secs)
-                   itemp3d(i,n,k) = streams(k)%file(n)%secs(i)
-                end do
-             end if
-          end do
-       end do
-       rcode = pio_inq_varid(pioid, 'timeofday', dvarid)
-       rcode = pio_put_var(pioid, dvarid, itemp3d)
-       deallocate(itemp3d)
+                rcode = pio_put_var(pioid, varid, (/1,n,k/), (/streams(k)%file(n)%nt,1,1/), streams(k)%file(n)%secs)
+             endif
+          enddo
+       enddo
 
        ! write out filename
-       allocate(ctemp2d(maxnfiles, size(streams)))
-       ctemp2d(:,:) = 'unset'
-       do k = 1,size(streams)
-          do n = 1,streams(k)%nfiles
-             ctemp2d(n,k) = streams(k)%file(n)%name
-          end do
-       end do
        rcode = pio_inq_varid(pioid, 'filename', varid)
-       do k = 1,size(streams)
-          do n = 1,maxnfiles 
-             rcode = pio_put_var(pioid, varid, (/1,n,k/), ctemp2d(n,k))
-          end do
-       end do
-       deallocate(ctemp2d)
+       do k=1,size(streams)
+          do n=1,streams(k)%nfiles
+             rcode = pio_put_var(pioid, varid, (/1,n,k/), streams(k)%file(n)%name)
+          enddo
+       enddo
 
     else if (mode .eq. 'read') then
 


### PR DESCRIPTION
### Description of changes
changes to fix restart problems for datm on izumi

### Specific notes


Contributors other than yourself, if any: @jedwards4b 

CDEPS Issues Fixed: None

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers bfb

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

- Verified that --compset I2000Clm51Sp --driver nuopc --compiler intel --res f09_g16 now can write restart files for datm successfully on izumi
- Validated that ERP_P180x2_D_Ld5.f19_g17.I2000Clm50Sp.cheyenne_intel.clm-default pases

Hashes used for testing: ctsm5.1.dev093 with cdeps updated to cdeps0.12.47

