### PR TITLE
Actually add a read for ZBOT in the streams for CLMNCEP fixing #168

### DIFF
--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -208,6 +208,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Sa_rh'          , strm_rh    , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer( sdat, 'Sa_z'           , strm_z  , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_swdndf'    , strm_swdndf, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_swdndr'    , strm_swdndr, rc)


### PR DESCRIPTION
### Description of changes

Actually do the read for ZBOT

### Specific notes

Contributors other than yourself, if any: None

CDEPS Issues Fixed (include github issue #):
  Fixes #168

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): Yes (if ZBOT is on the stream file)

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Ran NEON-NIWO case

Ran a simple NEON case...

SMS_D.CLM_USRDAT.I1PtClm51Bgc.cheyenne_intel.clm-NEON-NIWO

which worked both before and after. But atmImp_Sa_z,lndExp_Sa_z change from the default 30. beforehand to 8. as expected.

Hashes used for testing:

a27404c30e6065000c3c2c4af9dcf2a51f10360c

ctsm5.1.dev098
cmeps0.13.63
cime6.0.27
