### PR TITLE
environ seems to hang at times

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -82,7 +82,7 @@ def buildlib(bldroot, libroot, case):
     cmake_flags += " -DLIBROOT={} ".format(libroot)
     cmake_flags += " -DMPILIB={} ".format(mpilib)
     cmake_flags += " -DSRCROOT={} ".format(case.get_value("SRCROOT"))
-    if os.environ["PIO_LIBDIR"]:
+    if os.getenv("PIO_LIBDIR"):
         cmake_flags += " -DPIO_C_LIBRARY={libdir} -DPIO_C_INCLUDE_DIR={incdir} ".format(libdir=os.environ["PIO_LIBDIR"], incdir=os.environ["PIO_INCDIR"])
         cmake_flags += " -DPIO_Fortran_LIBRARY={libdir} -DPIO_Fortran_INCLUDE_DIR={incdir} ".format(libdir=os.environ["PIO_LIBDIR"], incdir=os.environ["PIO_INCDIR"])
     else:


### PR DESCRIPTION
### Description of changes
Need to use os.getenv("PIO_LIBDIR") instead of os.environ["PIO_LIBDIR"] to avoid a hang on some systems.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

