### PR TITLE
fix to put in coszen interpolation to work for CIAF and GIAF compsets

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -1777,7 +1777,7 @@
     <stream_year_last>2009</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
-      <tintalgo>linear</tintalgo>
+      <tintalgo>coszen</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode>cycle</taxmode>


### PR DESCRIPTION
### Description of changes
fix to put in coszen interpolation to work for CIAF and GIAF compsets

### Specific notes
The CORE_IAF SWDN forcing is not being time interpolated with coszen interpolation - but rather is using linear interpolation. This is not a problem in the mct CDEPS. This will be a problem for CORE2_IAF.GISS.SWDN but not for JRA forcings.

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #176 

Are there dependencies on other component PRs (if so list): None

Are changes expected to change answers (bfb, different to roundoff, more substantial): Answers will change significantly for CIAF and GIAF compsets

Any User Interface Changes (namelist or namelist defaults changes): NOne

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Verified that SMS_Vnuopc_Ld1.T62_g17.CIAF.cheyenne_intel.pop-default now has the same swdn profile as mct

Hashes used for testing:

