### PR TITLE
more robust implementation of sstice xml settings

### DIFF
--- a/docn/cime_config/config_component.xml
+++ b/docn/cime_config/config_component.xml
@@ -175,39 +175,21 @@
     This is only used when DOCN_MODE=prescribed.</desc>
   </entry>
 
-  <entry id="SSTICE_GRID_FILENAME">
+  <entry id="SSTICE_MESH_FILENAME">
     <type>char</type>
     <valid_values></valid_values>
-    <default_value>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</default_value>
-    <values match="last">
-      <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"							>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"			>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="1850" grid="a%T31.*_oi%T31"							>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc </value>
-      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"				>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"				>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"		>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"	>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"		>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"		>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="1850" grid=".+"									>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
-      <value compset="1850" grid="a%1.9x2.5.*_oi%1.9x2.5"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>
-      <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"					>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="1850" grid="a%0.47x0.63.*_oi%0.47x0.63"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="1850" grid="a%0.23x0.31.*_oi%0.23x0.31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"							>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"							>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"				>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"				>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
+    <default_value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029_ESMFmesh_120520.nc</default_value>
+    <values>
+      <value grid="_oi%T31">$DIN_LOC_ROOT/share/meshes/T31_040122_ESMFmesh.nc</value>
+      <value grid="_oi%1.9x2.5">$DIN_LOC_ROOT/share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</value>
+      <value grid="_oi%0.9x1.25">$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</value>
+      <value grid="_oi%0.47x0.63">$DIN_LOC_ROOT/share/meshes/fv0.47x0.63_141008_ESMFmesh.nc</value>
+      <value grid="_oi%0.23x0.31">UNSET</value><!-- fill this in -->
+      <value grid="_oi%4x5">$DIN_LOC_ROOT/share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
-    <desc>Prescribed SST and ice coverage grid file name.
+    <desc>Prescribed SST and ice coverage mesh file name.
     Sets SST and ice coverage grid file name for prescribed runs.
     This is only used when DOCN_MODE=prescribed.</desc>
   </entry>

--- a/docn/cime_config/stream_definition_docn.xml
+++ b/docn/cime_config/stream_definition_docn.xml
@@ -6,13 +6,7 @@
 
   <stream_entry name="prescribed">  
     <stream_meshfile >
-      <meshfile model_grid="_oi%T31">$DIN_LOC_ROOT/share/meshes/T31_040122_ESMFmesh.nc</meshfile>
-      <meshfile model_grid="_oi%1.9x2.5">$DIN_LOC_ROOT/share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</meshfile>
-      <meshfile model_grid="_oi%0.9x1.25">$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
-      <meshfile model_grid="_oi%0.47x0.63">$DIN_LOC_ROOT/share/meshes/fv0.47x0.63_141008_ESMFmesh.nc</meshfile>
-      <meshfile model_grid="_oi%0.23x0.31"><!-- fill this in --></meshfile>
-      <meshfile model_grid="_oi%4x5">$DIN_LOC_ROOT/share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029_ESMFmesh_120520.nc</meshfile>
+      <meshfile>$SSTICE_MESH_FILENAME</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$SSTICE_DATA_FILENAME</file>


### PR DESCRIPTION
### Description of changes
more robust implementation of sstice xml settings

### Specific notes
The current implementation of xml settings for F compsets in nuopc makes it very error prone to customize the docn/prescribed-ice forcing. This PR introduces a new xml variable that addresses this.

Contributors other than yourself, if any: None

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list): Yes -  This PR must also be accompanied by CICE6 and CICE5 PRs to work.

Are changes expected to change answers (bfb, different to roundoff, more substantial): BFB

Any User Interface Changes (namelist or namelist defaults changes): Yes - new xml variable for SSTICE_MESH_FILE and removal of SSTICE_GRID_FILE

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Verified that ERP_Ln9_Vnuopc.f09_f09_mg17.F2000climo.cheyenne_intel.cam-outfrq9s was bfb with cesm2_3_alpha09c baseline 

Hashes used for testing: cesm2_3_alpha09c

