### PR TITLE
fixes aquap constant case for docn

### DIFF
--- a/docn/cime_config/config_component.xml
+++ b/docn/cime_config/config_component.xml
@@ -111,7 +111,7 @@
     <valid_values></valid_values>
     <default_value>-1</default_value>
     <values match="last">
-      <value compset="_DOCN%AQPCONST">300</value>
+      <value compset="_DOCN%AQPCONST">300.</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -186,7 +186,7 @@
     </desc>
     <values>
       <value>-1.0</value>
-      <value docn_mode='docn_aquap_constant'>$DOCN_AQPCONST_VALUE</value>
+      <value docn_mode='aquap_constant'>$DOCN_AQPCONST_VALUE</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes
fixes constant aquaplanet case for docn

### Specific notes

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #182 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): No

Any User Interface Changes (namelist or namelist defaults changes): Yes
    Fixes the setting of sst_constant_value for docn for a constant aquaplanet case

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): verified that ERS_Ln9_Vnuopc_D.ne30_ne30_mg17.QPRCEMIP.cheyenne_intel.cam-outfrq9s now passes

Hashes used for testing: cdeps0.12.58 and cesm2_3_beta09

