### PR TITLE
fix som aquaplanet to run at resolutions other than f09 and f19

### DIFF
--- a/docn/cime_config/config_component.xml
+++ b/docn/cime_config/config_component.xml
@@ -125,6 +125,7 @@
     <values match="last">
       <value compset="_DOCN%SOMAQP" grid="_oi%1.9x2.5">$DIN_LOC_ROOT/ocn/docn7/SOM/default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.2degFV_c20170421.nc</value>
       <value compset="_DOCN%SOMAQP" grid="_oi%0.9x1.25">$DIN_LOC_ROOT/ocn/docn7/SOM/default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.1degFV_c20170421.nc</value>
+      <value compset="_DOCN%SOMAQP">$DIN_LOC_ROOT/ocn/docn7/SOM/default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.1degFV_c20170421.nc</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>

--- a/docn/cime_config/stream_definition_docn.xml
+++ b/docn/cime_config/stream_definition_docn.xml
@@ -108,6 +108,7 @@
     <stream_meshfile>
       <meshfile model_grid="_oi%1.9x2.5">$DIN_LOC_ROOT/share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</meshfile>
       <meshfile model_grid="_oi%0.9x1.25">$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
       <file>$DOCN_SOMAQP_DATAFILE</file>


### PR DESCRIPTION
### Description of changes
fix som aquaplanet to run at resolutions other than f09 and f19

### Specific notes
This PR enables the test ERS_Ln9.ne30pg3_ne30pg3_mg17.QSC6.cheyenne_intel.cam-outfrq9s to run successfully

Contributors other than yourself, if any: @jedwards4b 

CDEPS Issues Fixed: None

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): som aquaplanet cases now have reasonable values for the docn.streams.xml file

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
   - ERS_D_Ln9_Vnuopc.f09_f09_mg17.QSC6.cheyenne_intel.cam-outfrq9s
   - ERS_Ln9.ne30pg3_ne30pg3_mg17.QSC6.cheyenne_intel.cam-outfrq9s

Hashes used for testing: cesm2_3_alpha10a

