### PR TITLE
correct mismatch of leap year

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -445,7 +445,7 @@ contains
 
   !===============================================================================
   subroutine ModelAdvance(gcomp, rc)
-
+    use shr_file_mod, only : shr_file_setlogunit
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
     integer, intent(out) :: rc
@@ -472,6 +472,7 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    call shr_file_setlogunit(logunit)
 
     call ESMF_TraceRegionEnter(subname)
     call memcheck(subname, 5, my_task==main_task)

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -122,7 +122,9 @@ module cdeps_datm_comp
   integer                      :: iradsw = 0                          ! radiation interval (input namelist)
   character(CL)                :: factorFn_mesh = 'null'              ! file containing correction factors mesh
   character(CL)                :: factorFn_data = 'null'              ! file containing correction factors data
-  logical                      :: flds_presaero = .false.             ! true => send valid prescribe aero fields to mediator
+  logical                      :: flds_presaero = .false.             ! true => send valid prescribed aero fields to mediator
+  logical                      :: flds_presndep = .false.             ! true => send valid prescribed ndep fields to mediator
+  logical                      :: flds_preso3 = .false.               ! true => send valid prescribed ozone fields to mediator
   logical                      :: flds_co2 = .false.                  ! true => send prescribed co2 to mediator
   logical                      :: flds_wiso = .false.                 ! true => send water isotopes to mediator
   character(CL)                :: bias_correct = nullstr              ! send bias correction fields to coupler
@@ -131,6 +133,7 @@ module cdeps_datm_comp
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global                           ! global nx
   integer                      :: ny_global                           ! global ny
+  logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
 
   ! linked lists
   type(fldList_type) , pointer :: fldsImport => null()
@@ -227,7 +230,8 @@ contains
     namelist / datm_nml / datamode, &
          model_meshfile, model_maskfile, &
          nx_global, ny_global, restfilm, iradsw, factorFn_data, factorFn_mesh, &
-         flds_presaero, flds_co2, flds_wiso, bias_correct, anomaly_forcing
+         flds_presaero, flds_co2, flds_wiso, bias_correct, anomaly_forcing, &
+         skip_restart_read, flds_presndep, flds_preso3
 
     rc = ESMF_SUCCESS
 
@@ -266,8 +270,11 @@ contains
     call shr_mpi_bcast(factorFn_mesh             , mpicom, 'factorFn_mesh')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
     call shr_mpi_bcast(flds_presaero             , mpicom, 'flds_presaero')
+    call shr_mpi_bcast(flds_presndep             , mpicom, 'flds_presndep')
+    call shr_mpi_bcast(flds_preso3               , mpicom, 'flds_preso3')
     call shr_mpi_bcast(flds_co2                  , mpicom, 'flds_co2')
     call shr_mpi_bcast(flds_wiso                 , mpicom, 'flds_wiso')
+    call shr_mpi_bcast(skip_restart_read         , mpicom, 'skip_restart_read')
 
     ! write namelist input to standard out
     if (my_task == main_task) then
@@ -282,8 +289,11 @@ contains
        write(logunit,F00)' factorFn_data  = ',trim(factorFn_data)
        write(logunit,F00)' factorFn_mesh  = ',trim(factorFn_mesh)
        write(logunit,F02)' flds_presaero  = ',flds_presaero
+       write(logunit,F02)' flds_presndep  = ',flds_presndep
+       write(logunit,F02)' flds_preso3    = ',flds_preso3
        write(logunit,F02)' flds_co2       = ',flds_co2
        write(logunit,F02)' flds_wiso      = ',flds_wiso
+       write(logunit,F02)' skip_restart_read = ',skip_restart_read
     end if
 
     ! Validate sdat datamode
@@ -304,19 +314,19 @@ contains
     select case (trim(datamode))
     case ('CORE2_NYF', 'CORE2_IAF')
        call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, rc)
+            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CORE_IAF_JRA')
        call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, rc)
+            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CLMNCEP')
        call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, rc)
+            flds_co2, flds_wiso, flds_presaero, flds_presndep, flds_preso3, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CPLHIST')
        call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, rc)
+            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('ERA5')
        call datm_datamode_era5_advertise(exportState, fldsExport, flds_scalar_name, rc)
@@ -403,7 +413,7 @@ contains
     ! Initialize and update orbital values
     call dshr_orbital_init(gcomp, logunit, my_task == main_task, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_orbital_update(clock, logunit, my_task == main_task, &
+    call dshr_orbital_update(currTime, logunit, my_task == main_task, &
          orbEccen, orbObliqr, orbLambm0, orbMvelpp, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -481,13 +491,13 @@ contains
     call shr_cal_ymd2date(yr, mon, day, next_ymd)
 
     ! Update the orbital values
-    call dshr_orbital_update(clock, logunit, my_task == main_task, &
+    call dshr_orbital_update(nextTime, logunit, my_task == main_task, &
          orbEccen, orbObliqr, orbLambm0, orbMvelpp, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     restart_write = dshr_check_restart_alarm(clock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    
+
     ! Run datm
     call ESMF_TraceRegionEnter('datm_run')
     call datm_comp_run(importstate, exportstate, next_ymd, next_tod, mon, &
@@ -573,7 +583,7 @@ contains
        end select
 
        ! Read restart if needed
-       if (restart_read) then
+       if (restart_read .and. .not. skip_restart_read) then
           select case (trim(datamode))
           case('CORE2_NYF','CORE2_IAF')
              call datm_datamode_core2_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
@@ -701,6 +711,7 @@ contains
 
       ! local variables
       integer                         :: n
+      character(CS)                   :: strm_flds2(2)
       character(CS)                   :: strm_flds3(3)
       character(CS)                   :: strm_flds4(4)
       integer                         :: rank
@@ -727,6 +738,10 @@ contains
                  exportState, logunit, mainproc, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
          else if (rank == 2) then
+            ! The following maps stream input fields to export fields that have an ungridded dimension
+            ! TODO: in the future it might be better to change the format of the streams file to have two more entries
+            ! that could denote how the stream variables are mapped to export fields that have an ungridded dimension
+
             select case (trim(lfieldnames(n)))
             case('Faxa_bcph')
                strm_flds3 = (/'Faxa_bcphidry', 'Faxa_bcphodry', 'Faxa_bcphiwet'/)
@@ -760,6 +775,11 @@ contains
                strm_flds3 = (/'Faxa_snowl_16O', 'Faxa_snowl_18O', 'Faxa_snowl_HDO'/)
                call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            case('Faxa_ndep')
+               strm_flds2 = (/'Faxa_ndep_nhx', 'Faxa_ndep_noy'/)
+               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds2, exportState, logunit, mainproc, rc)
+               if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
             end select
          end if
       end do

--- a/share/shr_cal_mod.F90
+++ b/share/shr_cal_mod.F90
@@ -1411,18 +1411,21 @@ contains
     if(rc /= ESMF_SUCCESS) call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
   end subroutine shr_cal_ymds2rday_offset
 
+  !===============================================================================
   logical function shr_cal_leapyear(yr)
     integer, intent(in) :: yr
     shr_cal_leapyear = .false.
-    if (real(yr)/4.0 == yr/4) then
-       if (real(yr)/100.0 == yr/100) then
-          if(real(yr)/400.0 == yr/400) then
+    if (modulo(yr, 4) == 0) then
+       if (modulo(yr, 100) == 0) then
+          if(modulo(yr, 400) == 0) then
              shr_cal_leapyear =  .true.
           endif
        else
           shr_cal_leapyear =  .true.
        endif
     endif
+
   end function shr_cal_leapyear
+
   !===============================================================================
 end module shr_cal_mod

--- a/share/shr_cal_mod.F90
+++ b/share/shr_cal_mod.F90
@@ -89,6 +89,7 @@ module shr_cal_mod
   public :: shr_cal_ymdtod2string ! translate ymdtod to string for filenames
   public :: shr_cal_datetod2string ! translate date to string for filenames
   public :: shr_cal_ymds2rday_offset ! translate yr,month,day,sec offset to a fractional day offset
+  public :: shr_cal_leapyear ! logical function: is this a leap year?
 
   ! !PUBLIC DATA MEMBERS:
 
@@ -1410,5 +1411,18 @@ contains
     if(rc /= ESMF_SUCCESS) call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
   end subroutine shr_cal_ymds2rday_offset
 
+  logical function shr_cal_leapyear(yr)
+    integer, intent(in) :: yr
+    shr_cal_leapyear = .false.
+    if (real(yr)/4.0 == yr/4) then
+       if (real(yr)/100.0 == yr/100) then
+          if(real(yr)/400.0 == yr/400) then
+             shr_cal_leapyear =  .true.
+          endif
+       else
+          shr_cal_leapyear =  .true.
+       endif
+    endif
+  end function shr_cal_leapyear
   !===============================================================================
 end module shr_cal_mod

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -908,8 +908,8 @@ contains
           ! case(0)
           ymdmod(ns) = ymd
           todmod    = tod
+          calendar = trim(sdat%stream(ns)%calendar)
           if (trim(sdat%model_calendar) /= trim(sdat%stream(ns)%calendar)) then
-             calendar = shr_cal_noleap
              if (( trim(sdat%model_calendar) == trim(shr_cal_gregorian)) .and. &
                   (trim(sdat%stream(ns)%calendar) == trim(shr_cal_noleap))) then
                 ! case (1), set feb 29 = feb 28
@@ -917,6 +917,7 @@ contains
                 if (month == 2 .and. day == 29) then
                    call shr_cal_ymd2date(year,2,28,ymdmod(ns))
                 endif
+                calendar = shr_cal_noleap
              else if ((trim(sdat%model_calendar) == trim(shr_cal_noleap)) .and. &
                       (trim(sdat%stream(ns)%calendar) == trim(shr_cal_gregorian))) then
                 ! case (2), feb 29 input data will be skipped automatically
@@ -985,7 +986,6 @@ contains
              ! Reset time bounds if newdata read in
              call shr_cal_timeSet(timeLB,sdat%pstrm(ns)%ymdLB,0,calendar,rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
              call shr_cal_timeSet(timeUB,sdat%pstrm(ns)%ymdUB,0,calendar,rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -933,7 +933,7 @@ contains
                    endif
                 else if(datamonth == 2) then
                    if(.not. shr_cal_leapyear(year)) then
-                      if(debug .and. sdat%mainproc) then
+                      if(debug>0 .and. sdat%mainproc) then
                          write(logunit, *) subname,' dataday = ', dataday
                       endif
                       calendar = shr_cal_noleap

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -948,23 +948,10 @@ contains
 
           if (newData(ns)) then
              ! Reset time bounds if newdata read in
-             call shr_cal_date2ymd(sdat%pstrm(ns)%ymdUB,year,month,day)
-             print *,__FILE__,__LINE__,'Upper bound:',sdat%pstrm(ns)%ymdUB,year,month,day
-
              call shr_cal_timeSet(timeLB,sdat%pstrm(ns)%ymdLB,0,sdat%stream(ns)%calendar,rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-
              call shr_cal_timeSet(timeUB,sdat%pstrm(ns)%ymdUB,0,sdat%stream(ns)%calendar,rc=rc)
-             if(rc .ne. ESMF_SUCCESS) then
-                if(month .eq. 2 .and. day .eq. 29) then
-                   ! Change the date to 0301 (0229 + 72)
-                   write(sdat%stream(1)%logunit, *) trim(subname),': Leap year date conflict, adjusting time upper bound'
-                   sdat%pstrm(ns)%ymdUB = sdat%pstrm(ns)%ymdUB + 72
-                   call shr_cal_timeSet(timeUB,sdat%pstrm(ns)%ymdUB,0,sdat%stream(ns)%calendar,rc=rc)
-                endif
-             endif
-             print *,__FILE__,__LINE__,rc
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
              timeint = timeUB-timeLB

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -19,7 +19,7 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_FieldReGridStore, ESMF_FieldRedistStore, ESMF_UNMAPPEDACTION_IGNORE
   use ESMF             , only : ESMF_TERMORDER_SRCSEQ, ESMF_FieldRegrid, ESMF_FieldFill, ESMF_FieldIsCreated
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
-  use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_RC_ARG_OUTOFRANGE
+  use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
   use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
   use shr_sys_mod      , only : shr_sys_abort

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -786,7 +786,14 @@ contains
     ! on the time series input data.
     !
     ! (0) The stream calendar and model calendar are identical:
-    ! Proceed in the standard way.
+    !     In this case it is still possible to have a mismatch if both are gregorian.
+    !     These cases are:
+    !     -   Model is no_leap, data is Gregorian and leapyear date 2/29 is encountered in data - skip date
+    !     -   Model is Gregorian, data is no_leap and leapyear date 2/29 is encountered in model - repeat 2/28 data
+    !     -   Model is Gregorian, data is gregorian but leapyears do not align.
+    !     -       if in model leap year repeat data from 2/28 
+    !     -       if in data leap year skip date 2/29
+    !     
     !
     ! (1) The stream is a no leap calendar and the model is gregorian:
     ! Time interpolate on the noleap calendar.  If the model date is Feb 29,

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -819,6 +819,9 @@ contains
 
     if (cycle) then
        dYear  = yrFirst + modulo(mYear-yrAlign+(2*nYears),nYears)   ! current data year
+       if(debug .and. isroot_task) then
+          write(strm%logunit, *) trim(subname), ' dyear, yrfirst, myear, yralign, nyears =', dyear, yrfirst, myear, yralign, nyears
+       endif
     else
        dYear  = yrFirst + mYear - yrAlign
     endif
@@ -1161,7 +1164,7 @@ contains
                    call shr_cal_date2ymd(dDateUB,yy,mm,dd)
                    yy = yy + (mYear-dYear)
                    if(mm == 2 .and. dd==29 .and. .not. shr_cal_leapyear(yy)) then
-                      if(isroot_task) write(strm%logunit, *) 'Found leapyear mismatch', myear, dyear  
+                      if(isroot_task) write(strm%logunit, *) 'Found leapyear mismatch', myear, dyear, yy
                       mm = 3
                       dd = 1
                    endif

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -25,6 +25,7 @@ module dshr_stream_mod
   use shr_cal_mod      , only : shr_cal_calendarName
   use shr_cal_mod      , only : shr_cal_advDate
   use shr_cal_mod      , only : shr_cal_advdateint
+  use shr_cal_mod      , only : shr_cal_leapyear
   use dshr_methods_mod , only : chkerr
   use pio              , only : pio_noerr, pio_seterrorhandling, pio_inq_att, pio_openfile, pio_closefile
   use pio              , only : file_desc_t, pio_inq_varid, iosystem_desc_t, pio_file_is_open
@@ -1159,6 +1160,11 @@ contains
                    dDateUB = strm%file(k_ub)%date(n_ub)
                    call shr_cal_date2ymd(dDateUB,yy,mm,dd)
                    yy = yy + (mYear-dYear)
+                   if(mm == 2 .and. dd==29 .and. .not. shr_cal_leapyear(yy)) then
+                      if(isroot_task) write(strm%logunit, *) 'Found leapyear mismatch', myear, dyear  
+                      mm = 3
+                      dd = 1
+                   endif
                    call shr_cal_ymd2date(yy,mm,dd,mDateUB)
                    secUB = strm%file(k_ub)%secs(n_ub)
                    fileUB = strm%file(k_ub)%name

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -819,7 +819,7 @@ contains
 
     if (cycle) then
        dYear  = yrFirst + modulo(mYear-yrAlign+(2*nYears),nYears)   ! current data year
-       if(debug .and. isroot_task) then
+       if(debug>0 .and. isroot_task) then
           write(strm%logunit, *) trim(subname), ' dyear, yrfirst, myear, yralign, nyears =', dyear, yrfirst, myear, yralign, nyears
        endif
     else


### PR DESCRIPTION
### Description of changes
Handle a number of special cases in matching inputdata dates to model dates.
These cases are:

-   Model is no_leap, data is Gregorian and leapyear date 2/29 is encountered in data - skip date
-   Model is Gregorian, data is no_leap and leapyear date 2/29 is encountered in model - repeat 2/28 data
-   Model is Gregorian, data is gregorian but leapyears do not align.
-       if in model leap year repeat data from 2/28 
-       if in data leap year skip date 2/29


### Specific notes

Contributors other than yourself, if any:  @mvertens 

CDEPS Issues Fixed (include github issue #): #190 

Are there dependencies on other component PRs (if so list): https://github.com/ESCOMP/CESM_share/pull/35

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):  Neon spinup of over 100 years

Hashes used for testing:

sM  ./ccs_config
        modified sandbox, ccs_config_cesm0.0.44 (branch main) --> ccs_config_cesm0.0.38
    ./cime
        clean sandbox, on cime6.0.45
s   ./components/cdeps
        clean sandbox, 0f3f7070c208a5de221577566b50e6dcfa6e7766 (branch leap_year_corrections) --> cdeps0.12.63
    ./components/cdeps/fox
        clean sandbox, on 4.1.2.1
    ./components/cdeps/share/genf90
        clean sandbox, on genf90_200608
    ./components/cism
        clean sandbox, on cismwrap_2_1_95
    ./components/cism/source_cism
        clean sandbox, on cism_main_2.01.011
 M  ./components/cmeps
        modified sandbox, on cmeps0.13.71
    ./components/cpl7
        clean sandbox, on cpl7.0.14
    ./components/mizuRoute
        clean sandbox, on 34723c2e4df7caa16812770f8d53ebc83fa22360
    ./components/mosart
        clean sandbox, on mosart1_0_45
    ./components/rtm
        clean sandbox, on rtm1_0_78
e-o ./doc/doc-builder
        -, not checked out --> v1.0.8
    ./libraries/mct
        clean sandbox, on MCT_2.11.0
    ./libraries/parallelio
        clean sandbox, on pio2_5_7
s   ./share
        clean sandbox, bfa2b5d0a9de06153f2ac94a95818568a1f5cf11 (branch shr_cal_leapyear) --> share1.0.12
    ./src/fates
        clean sandbox, on sci.1.58.1_api.24.1.0
