### PR TITLE
fixes an issue in aux data streams

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -779,7 +779,10 @@ contains
                strm_flds2 = (/'Faxa_ndep_nhx', 'Faxa_ndep_noy'/)
                call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds2, exportState, logunit, mainproc, rc)
                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
+            case('cpl_scalars')
+               continue
+            case default
+               call shr_sys_abort(subName//'field '//trim(lfieldnames(n))//' not recognized')
             end select
          end if
       end do

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -106,6 +106,7 @@ module dshr_strdata_mod
      integer                             :: todUB = -1                      ! stream tod upper bound
      real(r8)                            :: dtmin = 1.0e30_r8
      real(r8)                            :: dtmax = 0.0_r8
+     logical                             :: override_annual_cycle = .false.
      type(ESMF_Field)                    :: field_coszen                    ! needed for coszen time interp
   end type shr_strdata_perstream
 
@@ -992,26 +993,36 @@ contains
              timeint = timeUB-timeLB
              call ESMF_TimeIntervalGet(timeint, StartTimeIn=timeLB, d=dday)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             dtime = abs(real(dday,r8) + real(sdat%pstrm(ns)%todUB-sdat%pstrm(ns)%todLB,r8)/shr_const_cDay)
-
-             sdat%pstrm(ns)%dtmin = min(sdat%pstrm(ns)%dtmin,dtime)
-             sdat%pstrm(ns)%dtmax = max(sdat%pstrm(ns)%dtmax,dtime)
-
-             if ((sdat%pstrm(ns)%dtmax/sdat%pstrm(ns)%dtmin) > sdat%stream(ns)%dtlimit) then
-                if (sdat%mainproc) then
-                   write(sdat%stream(1)%logunit,*) trim(subname),' ERROR: for stream ',ns
-                   write(sdat%stream(1)%logunit,*) trim(subname),' ERROR: dday = ',dday
-                   write(sdat%stream(1)%logunit,*) trim(subName),' ERROR: dtime, dtmax, dtmin, dtlimit = ',&
-                        dtime, sdat%pstrm(ns)%dtmax, sdat%pstrm(ns)%dtmin, sdat%stream(ns)%dtlimit
-                   write(sdat%stream(1)%logunit,*) trim(subName),' ERROR: ymdLB, todLB, ymdUB, todUB = ', &
-                        sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
-                end if
-                write(6,*) trim(subname),' ERROR: for stream ',ns, ' and calendar ',trim(calendar)
-                write(6,*) trim(subName),' ERROR: dtime, dtmax, dtmin, dtlimit = ',&
-                     dtime, sdat%pstrm(ns)%dtmax, sdat%pstrm(ns)%dtmin, sdat%stream(ns)%dtlimit
-                write(6,*) trim(subName),' ERROR: ymdLB, todLB, ymdUB, todUB = ', &
-                     sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
-                call shr_sys_abort(trim(subName)//' ERROR dt limit for stream, see atm.log output')
+             
+             if (.not. sdat%pstrm(ns)%override_annual_cycle) then
+                if(sdat%stream(ns)%dtlimit == -1) then
+                   sdat%pstrm(ns)%override_annual_cycle = .true.
+                   if(main_task) then
+                      write(logunit,*) trim(subname),' WARNING: Stream ',ns,' is not cycling on annual boundaries, and dtlimit check has been overridden'
+                   endif
+                else
+                   dtime = abs(real(dday,r8) + real(sdat%pstrm(ns)%todUB-sdat%pstrm(ns)%todLB,r8)/shr_const_cDay)
+                   
+                   sdat%pstrm(ns)%dtmin = min(sdat%pstrm(ns)%dtmin,dtime)
+                   sdat%pstrm(ns)%dtmax = max(sdat%pstrm(ns)%dtmax,dtime)
+                   
+                   if ((sdat%pstrm(ns)%dtmax/sdat%pstrm(ns)%dtmin) > sdat%stream(ns)%dtlimit) then
+                      if (sdat%mainproc) then
+                         write(sdat%stream(1)%logunit,*) trim(subname),' ERROR: for stream ',ns
+                         write(sdat%stream(1)%logunit,*) trim(subname),' ERROR: dday = ',dday
+                         write(sdat%stream(1)%logunit,*) trim(subName),' ERROR: dtime, dtmax, dtmin, dtlimit = ',&
+                              dtime, sdat%pstrm(ns)%dtmax, sdat%pstrm(ns)%dtmin, sdat%stream(ns)%dtlimit
+                         write(sdat%stream(1)%logunit,*) trim(subName),' ERROR: ymdLB, todLB, ymdUB, todUB = ', &
+                              sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
+                      end if
+                      write(6,*) trim(subname),' ERROR: for stream ',ns, ' and calendar ',trim(calendar)
+                      write(6,*) trim(subName),' ERROR: dtime, dtmax, dtmin, dtlimit = ',&
+                           dtime, sdat%pstrm(ns)%dtmax, sdat%pstrm(ns)%dtmin, sdat%stream(ns)%dtlimit
+                      write(6,*) trim(subName),' ERROR: ymdLB, todLB, ymdUB, todUB = ', &
+                           sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
+                      call shr_sys_abort(trim(subName)//' ERROR dt limit for stream, see atm.log output')
+                   endif
+                endif
              endif
           endif
 

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -997,7 +997,7 @@ contains
              if (.not. sdat%pstrm(ns)%override_annual_cycle) then
                 if(sdat%stream(ns)%dtlimit == -1) then
                    sdat%pstrm(ns)%override_annual_cycle = .true.
-                   if(main_task) then
+                   if(sdat%mainproc) then
                       write(logunit,*) trim(subname),' WARNING: Stream ',ns,' is not cycling on annual boundaries, and dtlimit check has been overridden'
                    endif
                 else

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -782,6 +782,7 @@ contains
     character(*),parameter :: F03   = "('(shr_stream_findBounds) ',a,i4)"
     character(*),parameter :: F04   = "('(shr_stream_findBounds) ',2a,i4)"
     !-------------------------------------------------------------------------------
+
     if (debug>0 .and. isroot_task) then
        write(strm%logunit,F02) "DEBUG: ---------- enter ------------------"
     end if
@@ -900,6 +901,7 @@ contains
     !   extend -> use lvd value, set LB to 00000101
     !   cycle -> lvd is UB, gvd is LB, shift mDateLB by -nYears
     !-----------------------------------------------------------
+
     if (rDateIn < rDatelvd) then
        if (limit) then
           write(strm%logunit,*)  trim(subName)," ERROR: limit on and rDateIn lt rDatelvd",rDateIn,rDatelvd
@@ -1153,7 +1155,7 @@ contains
 
                    dDateLB = strm%file(k_lb)%date(n_lb)
                    call shr_cal_date2ymd(dDateLB,yy,mm,dd)
-                   yy = yy + (mYear-dYear-nyears)
+                   yy = yy + (mYear-dYear)
                    call shr_cal_ymd2date(yy,mm,dd,mDateLB)
                    secLB = strm%file(k_lb)%secs(n_lb)
                    fileLB = strm%file(k_lb)%name

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -782,7 +782,6 @@ contains
     character(*),parameter :: F03   = "('(shr_stream_findBounds) ',a,i4)"
     character(*),parameter :: F04   = "('(shr_stream_findBounds) ',2a,i4)"
     !-------------------------------------------------------------------------------
-
     if (debug>0 .and. isroot_task) then
        write(strm%logunit,F02) "DEBUG: ---------- enter ------------------"
     end if
@@ -901,7 +900,6 @@ contains
     !   extend -> use lvd value, set LB to 00000101
     !   cycle -> lvd is UB, gvd is LB, shift mDateLB by -nYears
     !-----------------------------------------------------------
-
     if (rDateIn < rDatelvd) then
        if (limit) then
           write(strm%logunit,*)  trim(subName)," ERROR: limit on and rDateIn lt rDatelvd",rDateIn,rDatelvd
@@ -1155,7 +1153,7 @@ contains
 
                    dDateLB = strm%file(k_lb)%date(n_lb)
                    call shr_cal_date2ymd(dDateLB,yy,mm,dd)
-                   yy = yy + (mYear-dYear)
+                   yy = yy + (mYear-dYear-nyears)
                    call shr_cal_ymd2date(yy,mm,dd,mDateLB)
                    secLB = strm%file(k_lb)%secs(n_lb)
                    fileLB = strm%file(k_lb)%name


### PR DESCRIPTION
### Description of changes
The calculation of ddateLB seems to be different in different parts of the file, at line 965 we have
yy = yy + (mYear-dYear-nYears)         while at line 1154 we had 
yy = yy + (mYear-dYear) changing the line at 1154 to match that at 965 seems to have solved the issue.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

