### PR TITLE
update actions to use v3 for checkout and cache

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -25,11 +25,11 @@ jobs:
       PIO_VERSION: pio-2.5.4
       PIO_VERSION_DUMB: pio2_5_4
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # Build the ESMF library, if the cache contains a previous build
         # it will be used instead
       - id: cache-esmf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/ESMF
           key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF
@@ -52,7 +52,7 @@ jobs:
           make install
           popd
       - id: cache-pnetcdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/pnetcdf
           key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf
@@ -69,7 +69,7 @@ jobs:
           popd
       - name: Cache netcdf-fortran
         id: cache-netcdf-fortran
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/netcdf-fortran
           key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache PIO
         id: cache-PIO
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/pio
           key: ${{ runner.os }}-${{ env.PIO_VERSION }}.pio


### PR DESCRIPTION
### Description of changes
This PR aims to fix potential issue of using old version (v2) of checkout and cache actions.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): https://github.com/ESCOMP/CDEPS/issues/196

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

