### PR TITLE
the build in github was not consistant with that outside github

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -99,6 +99,6 @@ jobs:
           export SRC_ROOT=
           mkdir build-cdeps
           pushd build-cdeps
-          cmake -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-DCPRGNU -g -Wall -ffree-form -ffree-line-length-none -fallow-argument-mismatch -Wno-unused-dummy-argument " -DWERROR=ON ../
+          cmake -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-DCPRGNU -g -Wall -ffree-form -ffree-line-length-none -fallow-argument-mismatch " -DWERROR=ON ../
           make VERBOSE=1
           popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ foreach(COMP datm dice dlnd docn drof dwav)
                                             $<INSTALL_INTERFACE:mod>)
 
   if(WERROR)
-     target_compile_options(${COMP} PRIVATE -Werror)
+     target_compile_options(${COMP} PRIVATE -Werror --warn-no-unused-dummy-argument)
   endif()
   install(TARGETS ${COMP}
           EXPORT  ${COMP}
@@ -118,7 +118,7 @@ foreach(DEPS streams dshr cdeps_share FoX_dom FoX_wxml FoX_sax FoX_common FoX_ut
   string(SUBSTRING ${DEPS} 0 3 fox)
   if(WERROR AND NOT ${fox} STREQUAL "FoX")
      message("Adding Werror flag to ${DEPS} (fox = ${fox})")
-     target_compile_options(${DEPS} PRIVATE -Werror)
+     target_compile_options(${DEPS} PRIVATE -Werror --warn-no-unused-dummy-argument)
   endif()
 
   install(TARGETS ${DEPS}


### PR DESCRIPTION
Build with gnu debug consistantly 
### Description of changes

The github action was passing but the gnu debug build outside was failing broken in cdeps1.0.1

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixes #210 

Are there dependencies on other component PRs (if so list): NO

Are changes expected to change answers (bfb, different to roundoff, more substantial): BFB

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):  SMS_D.T62_t061.CMOM_IAF.cheyenne_gnu

Hashes used for testing:

