### PR TITLE
get_standard_cmake_args no longer takes a shared_lib argument

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -78,7 +78,7 @@ def buildlib(bldroot, libroot, case):
     logger.info("Running cmake for CDEPS")
     srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     cmake_flags = get_standard_cmake_args(
-        case, os.path.join(sharedpath, "cdeps"), shared_lib=True
+        case, os.path.join(sharedpath, "cdeps")
     )
     # base path of install to be completed by setting DESTDIR in make install
     cmake_flags += " -DCMAKE_INSTALL_PREFIX:PATH=/"


### PR DESCRIPTION
### Description of changes

Remove use of shared_lib arg that is no longer supported in CIME.

### Specific notes

Contributors other than yourself, if any: None

CDEPS Issues Fixed (include github issue #): None

Are there dependencies on other component PRs (if so list): 
https://github.com/ESMCI/cime/pull/4360

Are changes expected to change answers (bfb, different to roundoff, more substantial): No

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): None

Hashes used for testing:

