### PR TITLE
Include PRISM precipitation datm streams

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -95,6 +95,7 @@ class StreamCDEPS(GenericXML):
                 # endif
             # end while
             index += 1
+            line = case.get_resolved_value(line)
             lines_input_new.append(line)
         #end while
 

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -38,7 +38,7 @@
         1PT.urbanc_alpha
       </value>
       <value datm_mode="1PT" model_grid="CLM_USRDAT" neon="True">
-        NEON.$NEONSITE
+        NEON.$NEONSITE,NEON.$NEONSITE.PRECIP
       </value>
       <value datm_mode="1PT" model_grid="CLM_USRDAT">
         CLM_USRDAT.$CLM_USRDAT_NAME

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -236,7 +236,7 @@
       <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/cdeps/v1/$NEONSITE/%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>PRECTmms Faxa_precn</var>
+      <!-- <var>PRECTmms Faxa_precn</var> -->   <!-- COMMENT THIS OUT WHEN RUNNING WITH PRISM-->
       <var>FSDS     Faxa_swdn </var>
       <var>ZBOT     Sa_z    </var>
       <var>TBOT     Sa_tbot </var>
@@ -266,6 +266,44 @@
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
+
+
+  <!-- ===================================  -->
+  <!-- datm_mode NEON.$NEONSITE.PRECIP           -->
+  <!-- ===================================  -->
+
+  <stream_entry name="NEON.$NEONSITE.PRECIP">
+    <stream_meshfile>
+      <meshfile>none</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="2018" last_year="2021">/glade/u/home/tking/neon/prism_$NEONSITE_%y.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>PRECIP   Faxa_precn</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>none</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode               >cycle</taxmode>
+      <taxmode compset="HIST">limit</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
 
   <!-- ===================================  -->
   <!-- datm_mode CLMGSWP3v1                 -->


### PR DESCRIPTION
### Description of changes
This PR includes changes that allow PRISM precipitation to be used as a new datm stream.

Updates to `cime_config/stream_cdeps.py` allow stream names to be variables. Changes in `datm/cime_config/namelist_definition_datm.xml` include a new stream for PRECIP so that other variables can use the regular NEON datm stream while PRECIP uses this PRISM datm stream; note that this is a user interface change. The file `datm/cime_config/stream_definition_datm.xml` now includes an additional datm mode for PRISM.

Using PRISM precipitation instead of NEON precipitation does have a substantial impact on CTSM output (eg. latent heat flux biases).

### Note:
This PR's functionality also depends on the PRISM PRECIP CTSM PR as well as input data availability.

Contributors other than yourself, if any: @jedwards4b @wwieder @ekluzek 

CDEPS Issues Fixed: #212 

To Do:
-[] Implement namelist switches to allow users to easily choose between using PRISM or NEON precipitation
-[] Determine where to store initial condition files. Also, I have some scripts for processing the data directly from PRISM; we should determine if we want to include these auxiliary scripts somewhere.
-[] Think about generalizing to reading in other 'alternative' input data (eg, simulations from ESPWG)