### PR TITLE
Fix iradsw logic for CPLHIST mode

### DIFF
--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -333,7 +333,7 @@
     </desc>
     <values>
       <value>1</value>
-      <value datm_mode="CPLHISTForcing">-1</value>
+      <value datm_mode="CPLHIST">-1</value>
     </values>
   </entry>
 


### PR DESCRIPTION
### Description of changes

CPLHIST mode has DATM_MODE=CPLHIST, *not* CPLHISTForcing.

### Specific notes

Contributors other than yourself, if any: @olyson 

CDEPS Issues Fixed (include github issue #):
Resolves ESCOMP/CDEPS#221

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): more substantial, but just when running datm in CPLHIST mode

Any User Interface Changes (namelist or namelist defaults changes): none

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): just checked datm_in for two compsets: I1850Clm50BgcSpinup (fixed as intended) and I2000Clm50BgcCropQianRs (unchanged, as intended).

Hashes used for testing:

