### PR TITLE
Update stream definitions for new coupler history file format

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4546,10 +4546,10 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.3h.avrg.%ymd-10800.nc</file>
    </stream_datafiles>
     <stream_datavars>
-      <var>a2x3h_Sa_topo  Sa_topo</var>
+      <var>atmImp_Sa_topo  Sa_topo</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4576,23 +4576,23 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END" filename_add_days='1'>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.24h.avrg.%ymd-00000.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x1d_Faxa_bcphiwet  Faxa_bcphiwet</var>
-      <var>a2x1d_Faxa_bcphodry  Faxa_bcphodry</var>
-      <var>a2x1d_Faxa_bcphidry  Faxa_bcphidry</var>
-      <var>a2x1d_Faxa_ocphiwet  Faxa_ocphiwet</var>
-      <var>a2x1d_Faxa_ocphidry  Faxa_ocphidry</var>
-      <var>a2x1d_Faxa_ocphodry  Faxa_ocphodry</var>
-      <var>a2x1d_Faxa_dstwet1   Faxa_dstwet1</var>
-      <var>a2x1d_Faxa_dstdry1   Faxa_dstdry1</var>
-      <var>a2x1d_Faxa_dstwet2   Faxa_dstwet2</var>
-      <var>a2x1d_Faxa_dstdry2   Faxa_dstdry2</var>
-      <var>a2x1d_Faxa_dstwet3   Faxa_dstwet3</var>
-      <var>a2x1d_Faxa_dstdry3   Faxa_dstdry3</var>
-      <var>a2x1d_Faxa_dstwet4   Faxa_dstwet4</var>
-      <var>a2x1d_Faxa_dstdry4   Faxa_dstdry4</var>
+      <var>atmImp_Faxa_bcph1 Faxa_bcphidry</var>
+      <var>atmImp_Faxa_bcph2 Faxa_bcphodry</var>
+      <var>atmImp_Faxa_bcph3 Faxa_bcphiwet</var>
+      <var>atmImp_Faxa_ocph1 Faxa_ocphidry</var>
+      <var>atmImp_Faxa_ocph2 Faxa_ocphodry</var>
+      <var>atmImp_Faxa_ocph3 Faxa_ocphiwet</var>
+      <var>atmImp_Faxa_dstwet1 Faxa_dstwet1</var>
+      <var>atmImp_Faxa_dstdry1 Faxa_dstdry1</var>
+      <var>atmImp_Faxa_dstwet2 Faxa_dstwet2</var>
+      <var>atmImp_Faxa_dstdry2 Faxa_dstdry2</var>
+      <var>atmImp_Faxa_dstwet3 Faxa_dstwet3</var>
+      <var>atmImp_Faxa_dstdry3 Faxa_dstdry3</var>
+      <var>atmImp_Faxa_dstwet4 Faxa_dstwet4</var>
+      <var>atmImp_Faxa_dstdry4 Faxa_dstdry4</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4651,13 +4651,13 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.1h.inst.%ymd-03600.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x1hi_Faxa_swndr Faxa_swndr</var>
-      <var>a2x1hi_Faxa_swvdr Faxa_swvdr</var>
-      <var>a2x1hi_Faxa_swndf Faxa_swndf</var>
-      <var>a2x1hi_Faxa_swvdf Faxa_swvdf</var>
+      <var>atmImp_Faxa_swndr Faxa_swndr</var>
+      <var>atmImp_Faxa_swvdr Faxa_swvdr</var>
+      <var>atmImp_Faxa_swndf Faxa_swndf</var>
+      <var>atmImp_Faxa_swvdf Faxa_swvdf</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4667,7 +4667,7 @@
     <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>$DATM_YR_START</stream_year_first>
     <stream_year_last>$DATM_YR_END</stream_year_last>
-    <stream_offset>2700</stream_offset>
+    <stream_offset>-900</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
@@ -4685,14 +4685,14 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.3h.avrg.%ymd-10800.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x3h_Faxa_rainc Faxa_rainc</var>
-      <var>a2x3h_Faxa_rainl Faxa_rainl</var>
-      <var>a2x3h_Faxa_snowc Faxa_snowc</var>
-      <var>a2x3h_Faxa_snowl Faxa_snowl</var>
-      <var>a2x3h_Faxa_lwdn  Faxa_lwdn</var>
+      <var>atmImp_Faxa_rainc Faxa_rainc</var>
+      <var>atmImp_Faxa_rainl Faxa_rainl</var>
+      <var>atmImp_Faxa_snowc Faxa_snowc</var>
+      <var>atmImp_Faxa_snowl Faxa_snowl</var>
+      <var>atmImp_Faxa_lwdn  Faxa_lwdn</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4720,18 +4720,18 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.3h.avrg.%ymd-10800.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x3h_Sa_z       Sa_z</var>
-      <var>a2x3h_Sa_tbot    Sa_tbot</var>
-      <var>a2x3h_Sa_ptem    Sa_ptem</var>
-      <var>a2x3h_Sa_shum    Sa_shum</var>
-      <var>a2x3h_Sa_pbot    Sa_pbot</var>
-      <var>a2x3h_Sa_dens    Sa_dens</var>
-      <var>a2x3h_Sa_pslv    Sa_pslv</var>
-      <var>a2x3h_Sa_co2diag Sa_co2diag</var>
-      <var>a2x3h_Sa_co2prog Sa_co2prog</var>
+      <var>atmImp_Sa_z       Sa_z</var>
+      <var>atmImp_Sa_tbot    Sa_tbot</var>
+      <var>atmImp_Sa_ptem    Sa_ptem</var>
+      <var>atmImp_Sa_shum    Sa_shum</var>
+      <var>atmImp_Sa_pbot    Sa_pbot</var>
+      <var>atmImp_Sa_dens    Sa_dens</var>
+      <var>atmImp_Sa_pslv    Sa_pslv</var>
+      <var>atmImp_Sa_co2diag Sa_co2diag</var>
+      <var>atmImp_Sa_co2prog Sa_co2prog</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4759,11 +4759,11 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.1h.avrg.%ymd-03600.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x1h_Sa_u  Sa_u</var>
-      <var>a2x1h_Sa_v  Sa_v</var>
+      <var>atmImp_Sa_u  Sa_u</var>
+      <var>atmImp_Sa_v  Sa_v</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4576,7 +4576,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END" filename_add_days='1'>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.24h.avrg.%ymd-00000.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END" filename_advance_days='1'>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.24h.avrg.%ymd-00000.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>atmImp_Faxa_bcph1 Faxa_bcphidry</var>


### PR DESCRIPTION
### Description of changes

Modify stream_definition_datm.xml to generate a streams file (datm.streams.xml) with the new coupler history file format.

### Specific notes

Changes to accommodate new coupler history file names.
Change offset for solar stream from 2700 to -900 to accommodate changes due to time stamps.
These changes work in conjunction with CDEPS PR #224 and CDEPS PR #222 .
Note that I did not change the file names for ndep, or remove that stream.  Presumably, that stream will be removed at some point due to CAM now always sending ndep.

Contributors other than yourself, if any: @billsacks 

CDEPS Issues Fixed (include github issue #):  N/A

Are there dependencies on other component PRs (if so list):  No

Are changes expected to change answers (bfb, different to roundoff, more substantial):  Yes, in coupler history mode.

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):  I have conducted a pair of cases, an F-case to generate coupler history files, and an I-case to read those files, using the new file name convention, and compared the forcing output variables from clm history files between the two cases.  @billsacks and I reviewed these differences and found them to be acceptable.

@billsacks has agree to review these changes and perform more standard testing.

Hashes used for testing:  N/A

