### PR TITLE
update github to make cdeps ext build an action

### DIFF
--- a/.github/actions/buildcdeps/action.yaml
+++ b/.github/actions/buildcdeps/action.yaml
@@ -1,0 +1,41 @@
+name: CDEPS build and cache
+description: 'Build the CDEPS library'
+inputs:
+  cdeps_version:
+    description: 'Tag in the CDEPS repository to use'
+    default: main
+    required: False
+    type: string
+  pio_path:
+    description: 'Path to the installed parallelio code root'
+    default: $HOME/pio
+    required: False
+    type: string
+  esmfmkfile:
+    description: 'Path to the installed ESMF library mkfile'
+    default: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk 
+    required: False
+    type: string
+  src_root:
+    description: 'Path to cdeps source'
+    default: $GITHUB_WORKSPACE
+    required: False
+    type: string
+  install_prefix:
+    description: 'Install path of cdeps'
+    default: $HOME/cdeps
+    required: False
+    type: string
+runs:
+  using: composite
+  steps:
+    - id : Build-CDEPS
+      shell: bash
+      run: |
+        mkdir build-cdeps
+        pushd build-cdeps
+        export ESMFMKFILE=${{ inputs.esmfmkfile }}
+        export PIO=${{ inputs.pio_path }}
+        cmake -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-DCPRGNU -g -Wall -ffree-form -ffree-line-length-none -fallow-argument-mismatch " -DWERROR=ON ${{ inputs.src_root }}
+        make VERBOSE=1
+        popd

--- a/.github/actions/buildcdeps/action.yaml
+++ b/.github/actions/buildcdeps/action.yaml
@@ -42,4 +42,5 @@ runs:
         export ESMFMKFILE=${{ inputs.esmfmkfile }}
         export PIO=${{ inputs.pio_path }}
         cmake ${{ inputs.cmake_flags }} ${{ inputs.src_root }}
+        make VERBOSE=1
         popd

--- a/.github/actions/buildcdeps/action.yaml
+++ b/.github/actions/buildcdeps/action.yaml
@@ -21,6 +21,11 @@ inputs:
     default: $GITHUB_WORKSPACE
     required: False
     type: string
+  cmake_flags:
+    description: 'Extra flags for cmake command'
+    default: -Wno-dev
+    required: False
+    type: string
   install_prefix:
     description: 'Install path of cdeps'
     default: $HOME/cdeps
@@ -36,6 +41,5 @@ runs:
         pushd build-cdeps
         export ESMFMKFILE=${{ inputs.esmfmkfile }}
         export PIO=${{ inputs.pio_path }}
-        cmake -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-DCPRGNU -g -Wall -ffree-form -ffree-line-length-none -fallow-argument-mismatch " -DWERROR=ON ${{ inputs.src_root }}
-        make VERBOSE=1
+        cmake ${{ inputs.cmake_flags }} ${{ inputs.src_root }}
         popd

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -98,4 +98,9 @@ jobs:
           esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           pio_path: $HOME/pio
           src_root: $GITHUB_WORKSPACE
-
+          cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
+          -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""
+      - name: Test CDEPS
+        run:
+          cd build-cdeps
+          make VERBOSE=1

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -93,12 +93,9 @@ jobs:
           pnetcdf_path: /usr
           parallelio_path: $HOME/pio
       - name: Build CDEPS
-        run: |
-          export ESMFMKFILE=$HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
-          export PIO=$HOME/pio
-          export SRC_ROOT=
-          mkdir build-cdeps
-          pushd build-cdeps
-          cmake -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_Fortran_FLAGS="-DCPRGNU -g -Wall -ffree-form -ffree-line-length-none -fallow-argument-mismatch " -DWERROR=ON ../
-          make VERBOSE=1
-          popd
+        uses: ESCOMP/CDEPS/.github/actions/buildcdeps
+        with:
+          esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
+          pio_path: $HOME/pio
+          src_root: $GITHUB_WORKSPACE
+

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -101,6 +101,6 @@ jobs:
           cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
           -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""
       - name: Test CDEPS
-        run:
+        run: |
           cd build-cdeps
           make VERBOSE=1

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -93,7 +93,7 @@ jobs:
           pnetcdf_path: /usr
           parallelio_path: $HOME/pio
       - name: Build CDEPS
-        uses: ESCOMP/CDEPS/.github/actions/buildcdeps
+        uses: ./.github/actions/buildcdeps
         with:
           esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
           pio_path: $HOME/pio


### PR DESCRIPTION
### Description of changes
Updates github actions to make cdeps build available to other repos.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers:  bfb

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
github actions only

Hashes used for testing:
no external hashes required
