### PR TITLE
correct docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Community Data Models for Earth Prediction Systems
 
 For documentation see
 
-https://escomp.github.io/CDEPS/html/index.html
+https://escomp.github.io/CDEPS/versions/master/html/index.html
 
 ## A note on github tag action
 


### PR DESCRIPTION
### Description of changes

The docs link in README.md is broken, i.e., yields 404 error.
This PR copies the working docs link from the repo's About into README.md.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): none

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): no

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): none

Hashes used for testing: N/A

