### PR TITLE
update esmf bld to use official esmf action

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -74,12 +74,12 @@ jobs:
           parallelio_version: ${{ env.ParallelIO_VERSION }}
           enable_fortran: True
           install_prefix: $HOME/pio
-      - name: Cache ESMF
-        id: cache-esmf
-        uses: actions/cache@v3
-        with:
-          path: ~/ESMF
-          key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF2
+      # - name: Cache ESMF
+      #   id: cache-esmf
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/ESMF
+      #    key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF2
       # - name: Build ESMF
       #   if: steps.cache-esmf.outputs.cache-hit != 'true'
       #   uses: ./.github/actions/buildesmf
@@ -99,6 +99,7 @@ jobs:
           ESMF_BOPT: g
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
+          ESMF_PNETCDF: pnetcdf-config
           ESMF_INSTALL_PREFIX: /home/runner/ESMF
           ESMF_PIO: external
           ESMF_PIO_INCLUDE: /home/runner/pio/include

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -39,7 +39,7 @@ jobs:
         id: cache-PARALLELIO
         uses: actions/cache@v3
         with:
-          path: ~/pio
+          path: $GITHUB_WORKSPACE/pio
           key: ${{ runner.os }}-${{ env.ParallelIO_VERSION }}-parallelio2
       - name: Build ParallelIO
         if: steps.cache-PARALLELIO.outputs.cache-hit != 'true'
@@ -47,7 +47,7 @@ jobs:
         with:
           parallelio_version: ${{ env.ParallelIO_VERSION }}
           enable_fortran: True
-          install_prefix: $HOME/pio
+          install_prefix: $GITHUB_WORKSPACE/pio
       - name: Install ESMF
         uses: esmf-org/install-esmf-action@v1
         env:
@@ -56,10 +56,10 @@ jobs:
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
           ESMF_PNETCDF: pnetcdf-config
-          ESMF_INSTALL_PREFIX: /home/runner/ESMF
+          ESMF_INSTALL_PREFIX: $GITHUB_WORKSPACE/ESMF
           ESMF_PIO: external
-          ESMF_PIO_INCLUDE: /home/runner/pio/include
-          ESMF_PIO_LIBPATH: /home/runner/pio/lib
+          ESMF_PIO_INCLUDE: $GITHUB_WORKSPACE/pio/include
+          ESMF_PIO_LIBPATH: $GITHUB_WORKSPACE/pio/lib
         with:
           version: ${{ env.ESMF_VERSION }}
           esmpy: false
@@ -68,8 +68,8 @@ jobs:
       - name: Build CDEPS
         uses: ./.github/actions/buildcdeps
         with:
-          esmfmkfile: $HOME/ESMF/lib/esmf.mk
-          pio_path: $HOME/pio
+          esmfmkfile: $ESMFMKFILE
+          pio_path: $GITHUB_WORKSPACE/pio
           src_root: $GITHUB_WORKSPACE
           cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
           -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -100,6 +100,9 @@ jobs:
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
           ESMF_INSTALL_PREFIX: $HOME/ESMF
+          ESMF_PIO: external
+          ESMF_PIO_INCLUDE: $HOME/pio/include
+          ESMF_PIO_LIBPATH: $HOME/pio/lib
         with:
           version: ${{ env.ESMF_VERSION }}
           esmpy: false
@@ -108,7 +111,7 @@ jobs:
       - name: Build CDEPS
         uses: ./.github/actions/buildcdeps
         with:
-          esmfmkfile: $HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
+          esmfmkfile: $HOME/ESMF/lib/esmf.mk
           pio_path: $HOME/pio
           src_root: $GITHUB_WORKSPACE
           cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -20,8 +20,6 @@ jobs:
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu "
       # Versions of all dependencies can be updated here - these match tag names in the github repo
       ESMF_VERSION: v8.5.0
-      #PNETCDF_VERSION: checkpoint.1.12.3
-      #NETCDF_FORTRAN_VERSION: v4.6.0
       ParallelIO_VERSION: pio2_6_0
     steps:
       - id: checkout-CDEPS
@@ -37,30 +35,6 @@ jobs:
           sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev
           sudo apt-get install pnetcdf-bin libpnetcdf-dev
           sudo apt-get install autotools-dev autoconf
-      # - id: cache-pnetcdf
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/pnetcdf
-      #     key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf1
-      # - name: Build PNetCDF
-      #   if: steps.cache-pnetcdf.outputs.cache-hit != 'true'
-      #   uses: ./.github/actions/buildpnetcdf
-      #   with:
-      #     pnetcdf_version: ${{ env.PNETCDF_VERSION }}
-      #     install_prefix: $HOME/pnetcdf
-      # - name: Cache netcdf-fortran
-      #   id: cache-netcdf-fortran
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/netcdf-fortran
-      #     key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran1
-      # - name: Build NetCDF Fortran
-      #   if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
-      #   uses: ./.github/actions/buildnetcdff
-      #   with:
-      #     netcdf_fortran_version: ${{ env.NETCDF_FORTRAN_VERSION }}
-      #     install_prefix: $HOME/netcdf-fortran
-      #     netcdf_c_path: /usr
       - name: Cache PARALLELIO
         id: cache-PARALLELIO
         uses: actions/cache@v3
@@ -74,24 +48,6 @@ jobs:
           parallelio_version: ${{ env.ParallelIO_VERSION }}
           enable_fortran: True
           install_prefix: $HOME/pio
-      # - name: Cache ESMF
-      #   id: cache-esmf
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/ESMF
-      #    key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF2
-      # - name: Build ESMF
-      #   if: steps.cache-esmf.outputs.cache-hit != 'true'
-      #   uses: ./.github/actions/buildesmf
-      #   with:
-      #     esmf_version: ${{ env.ESMF_VERSION }}
-      #     esmf_bopt: g
-      #     esmf_comm: openmpi
-      #     install_prefix: $HOME/ESMF
-      #     netcdf_c_path: /usr
-      #     netcdf_fortran_path: /usr
-      #     pnetcdf_path: /usr
-      #     parallelio_path: $HOME/pio
       - name: Install ESMF
         uses: esmf-org/install-esmf-action@v1
         env:
@@ -107,7 +63,7 @@ jobs:
         with:
           version: ${{ env.ESMF_VERSION }}
           esmpy: false
-          cache: false
+          cache: true
       
       - name: Build CDEPS
         uses: ./.github/actions/buildcdeps

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -19,10 +19,10 @@ jobs:
       CPPFLAGS: "-I/usr/include -I/usr/local/include "
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu "
       # Versions of all dependencies can be updated here - these match tag names in the github repo
-      ESMF_VERSION: v8.4.0
+      ESMF_VERSION: v8.5.0
       #PNETCDF_VERSION: checkpoint.1.12.3
       #NETCDF_FORTRAN_VERSION: v4.6.0
-      ParallelIO_VERSION: pio2_5_10
+      ParallelIO_VERSION: pio2_6_0
     steps:
       - id: checkout-CDEPS
         uses: actions/checkout@v3
@@ -100,10 +100,10 @@ jobs:
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
           ESMF_INSTALL_PREFIX: $HOME/ESMF
-          with:
-            version: ${{ env.ESMF_VERSION }}
-            esmpy: false
-            cache: false
+        with:
+          version: ${{ env.ESMF_VERSION }}
+          esmpy: false
+          cache: false
       
       - name: Build CDEPS
         uses: ./.github/actions/buildcdeps

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -99,10 +99,10 @@ jobs:
           ESMF_BOPT: g
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
-          ESMF_INSTALL_PREFIX: $HOME/ESMF
+          ESMF_INSTALL_PREFIX: /home/runner/ESMF
           ESMF_PIO: external
-          ESMF_PIO_INCLUDE: $HOME/pio/include
-          ESMF_PIO_LIBPATH: $HOME/pio/lib
+          ESMF_PIO_INCLUDE: /home/runner/pio/include
+          ESMF_PIO_LIBPATH: /home/runner/pio/lib
         with:
           version: ${{ env.ESMF_VERSION }}
           esmpy: false

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -39,7 +39,7 @@ jobs:
         id: cache-PARALLELIO
         uses: actions/cache@v3
         with:
-          path: $GITHUB_WORKSPACE/pio
+          path: ${GITHUB_WORKSPACE}/pio
           key: ${{ runner.os }}-${{ env.ParallelIO_VERSION }}-parallelio2
       - name: Build ParallelIO
         if: steps.cache-PARALLELIO.outputs.cache-hit != 'true'
@@ -47,7 +47,7 @@ jobs:
         with:
           parallelio_version: ${{ env.ParallelIO_VERSION }}
           enable_fortran: True
-          install_prefix: $GITHUB_WORKSPACE/pio
+          install_prefix: ${GITHUB_WORKSPACE}/pio
       - name: Install ESMF
         uses: esmf-org/install-esmf-action@v1
         env:
@@ -56,10 +56,10 @@ jobs:
           ESMF_COMM: openmpi
           ESMF_NETCDF: nc-config
           ESMF_PNETCDF: pnetcdf-config
-          ESMF_INSTALL_PREFIX: $GITHUB_WORKSPACE/ESMF
+          ESMF_INSTALL_PREFIX: ${GITHUB_WORKSPACE}/ESMF
           ESMF_PIO: external
-          ESMF_PIO_INCLUDE: $GITHUB_WORKSPACE/pio/include
-          ESMF_PIO_LIBPATH: $GITHUB_WORKSPACE/pio/lib
+          ESMF_PIO_INCLUDE: ${GITHUB_WORKSPACE}/pio/include
+          ESMF_PIO_LIBPATH: ${GITHUB_WORKSPACE}/pio/lib
         with:
           version: ${{ env.ESMF_VERSION }}
           esmpy: false
@@ -69,8 +69,8 @@ jobs:
         uses: ./.github/actions/buildcdeps
         with:
           esmfmkfile: $ESMFMKFILE
-          pio_path: $GITHUB_WORKSPACE/pio
-          src_root: $GITHUB_WORKSPACE
+          pio_path: ${GITHUB_WORKSPACE}/pio
+          src_root: ${GITHUB_WORKSPACE}
           cmake_flags: " -Wno-dev -DCMAKE_BUILD_TYPE=DEBUG -DWERROR=ON  -DCMAKE_Fortran_FLAGS=\"-DCPRGNU -g -Wall \
           -ffree-form -ffree-line-length-none -fallow-argument-mismatch \""
       - name: Test CDEPS

--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -80,18 +80,31 @@ jobs:
         with:
           path: ~/ESMF
           key: ${{ runner.os }}-${{ env.ESMF_VERSION }}-ESMF2
-      - name: Build ESMF
-        if: steps.cache-esmf.outputs.cache-hit != 'true'
-        uses: ./.github/actions/buildesmf
-        with:
-          esmf_version: ${{ env.ESMF_VERSION }}
-          esmf_bopt: g
-          esmf_comm: openmpi
-          install_prefix: $HOME/ESMF
-          netcdf_c_path: /usr
-          netcdf_fortran_path: /usr
-          pnetcdf_path: /usr
-          parallelio_path: $HOME/pio
+      # - name: Build ESMF
+      #   if: steps.cache-esmf.outputs.cache-hit != 'true'
+      #   uses: ./.github/actions/buildesmf
+      #   with:
+      #     esmf_version: ${{ env.ESMF_VERSION }}
+      #     esmf_bopt: g
+      #     esmf_comm: openmpi
+      #     install_prefix: $HOME/ESMF
+      #     netcdf_c_path: /usr
+      #     netcdf_fortran_path: /usr
+      #     pnetcdf_path: /usr
+      #     parallelio_path: $HOME/pio
+      - name: Install ESMF
+        uses: esmf-org/install-esmf-action@v1
+        env:
+          ESMF_COMPILER: gfortran
+          ESMF_BOPT: g
+          ESMF_COMM: openmpi
+          ESMF_NETCDF: nc-config
+          ESMF_INSTALL_PREFIX: $HOME/ESMF
+          with:
+            version: ${{ env.ESMF_VERSION }}
+            esmpy: false
+            cache: false
+      
       - name: Build CDEPS
         uses: ./.github/actions/buildcdeps
         with:


### PR DESCRIPTION
### Description of changes
Updates the esmf build action to use one supported by the esmf developers. 
### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

