### PR TITLE
fix minor typo in drof modifier mode

### DIFF
--- a/drof/cime_config/config_component.xml
+++ b/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>


### PR DESCRIPTION
### Description of changes

Fixes a minor typo in drof modifier mode that was caught by the visualCaseGen unit tests.

### Specific notes

This typo breaks visualCaseGen, though I am surprised that it doesn't break cime (?).

Are changes expected to change answers (bfb, different to roundoff, more substantial): no

Any User Interface Changes (namelist or namelist defaults changes): none 

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): visualCaseGen unittests

Hashes used for testing: cesm2.3alpha16e

