### PR TITLE
update default SSTICE_DATA_FILENAME to match that previously used in cam

### DIFF
--- a/docn/cime_config/config_component.xml
+++ b/docn/cime_config/config_component.xml
@@ -148,7 +148,7 @@
   <entry id="SSTICE_DATA_FILENAME">
     <type>char</type>
     <valid_values></valid_values>
-    <default_value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029.nc</default_value>
+    <default_value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_2000climo_c180511.nc</default_value>
     <values match="last">
       <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_c050526.nc</value>
       <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_c061031.nc</value>


### PR DESCRIPTION
### Description of changes
Update the  SSTICE_DATA_FILENAME to that used in older cam tags. 

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed #255 

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers: new ssts will change F compsets

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Hand tested SMS.ne30pg3_ne30pg3_mg17.F2000dev.derecho_intel.

Hashes used for testing:

