### PR TITLE
Bring support for configurable source and destination mask

### DIFF
--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -131,6 +131,8 @@ module dshr_stream_mod
      type(file_desc_t) :: currpioid                             ! current pio file desc
      type(shr_stream_file_type)    , allocatable :: file(:)     ! filenames of stream data files (full pathname)
      type(shr_stream_data_variable), allocatable :: varlist(:)  ! stream variable names (on file and in model)
+     integer           :: src_mask_val = 0                      ! mask value for src mesh
+     integer           :: dst_mask_val = 0                      ! mask value for dst mesh
   end type shr_stream_streamType
 
   !----- parameters -----
@@ -445,7 +447,7 @@ contains
        stream_yearFirst, stream_yearLast, stream_yearAlign, &
        stream_offset, stream_taxmode, stream_tintalgo, stream_dtlimit, &
        stream_fldlistFile, stream_fldListModel, stream_fileNames, &
-       logunit, compname)
+       logunit, compname, stream_src_mask_val, stream_dst_mask_val)
 
     ! --------------------------------------------------------
     ! set values of stream datatype independent of a reading in a stream text file
@@ -472,6 +474,8 @@ contains
     character(*)                ,intent(in)              :: stream_filenames(:)    ! stream data filenames (full pathnamesa)
     integer                     ,intent(in)              :: logunit                ! stdout unit
     character(len=*)            ,intent(in)              :: compname               ! component name (e.g. ATM, OCN...)
+    integer                     ,optional, intent(in)    :: stream_src_mask_val    ! source mask value
+    integer                     ,optional, intent(in)    :: stream_dst_mask_val    ! destination mask value
 
     ! local variables
     integer                :: n
@@ -534,9 +538,14 @@ contains
 
     ! Initialize logunit
     streamdat(:)%logunit = logunit
+
     ! Get stream calendar
     call shr_stream_getCalendar(streamdat(1), 1, calendar)
     streamdat(1)%calendar = trim(calendar)
+
+    ! Set source and destination mask
+    if (present(stream_src_mask_val)) streamdat(1)%src_mask_val = stream_src_mask_val
+    if (present(stream_dst_mask_val)) streamdat(1)%dst_mask_val = stream_dst_mask_val
 
     ! Initialize flag that stream has been set
     streamdat(1)%init = .true.
@@ -571,6 +580,8 @@ contains
     !! stream_data_files:
     !! stream_data_variables:
     !! stream_offset:
+    !! stream_src_mask:
+    !! stream_dst_mask:
     !!---------------------------------------------------------------------
 
     ! input/output variables
@@ -605,7 +616,6 @@ contains
     cf =  ESMF_ConfigCreate(rc=RC)
     call ESMF_ConfigLoadFile(config=CF ,filename=trim(streamfilename), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
 
     ! get number of streams
     nstrms = ESMF_ConfigGetLen(config=CF, label='stream_info:', rc=rc)
@@ -719,6 +729,13 @@ contains
       streamdat(i)%logunit = logunit
 
       call shr_stream_getCalendar(streamdat(i), 1, streamdat(i)%calendar)
+
+      ! Get source and destination mask, 0 by default
+      call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%src_mask_val,label="stream_src_mask"//mystrm//':', default=0, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+      call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%dst_mask_val,label="stream_dst_mask"//mystrm//':', default=0, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
       ! Error check
       if (trim(streamdat(i)%taxmode) == shr_stream_taxis_extend .and.  streamdat(i)%dtlimit < 1.e10) then


### PR DESCRIPTION
### Description of changes
This PR aims to bring feature of changing source and destination masks via configuration file (ESMF config). This is especially important for the CDEPS inline capability since we have no control in destination mask.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):
No

Any User Interface Changes (namelist or namelist defaults changes):
The two new optional namelist option is introduced to the ESMF config file: `stream_src_mask` and `stream_dst_mask` to control mask values. The deafest are zero which does not change the existing behavior. Additional code needs to be implemented if we want to support XML configuration files.

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
This is initially tested under UFS Weather Model and the modifications did not change the answer UFS Weather Model. CESM still need to be tested.

Hashes used for testing:


