### PR TITLE
Increase stream filename length to CX (512) from CL (256)

### DIFF
--- a/cime_config/testdefs/testlist_cdeps.xml
+++ b/cime_config/testdefs/testlist_cdeps.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -9,7 +9,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -17,7 +17,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -25,7 +25,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -33,7 +33,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -41,7 +41,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -49,7 +49,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -57,7 +57,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -65,7 +65,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -73,7 +73,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -81,7 +81,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -89,7 +89,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Vnuopc_Ld5_P1" testmods="datm/1PT">
+  <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Ld5_P1" testmods="datm/1PT">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -100,7 +100,7 @@
   <!-- ================================= -->
   <!-- DOCN testing -->
   <!-- ================================= -->
-  <test compset="2000_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="2000_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -108,7 +108,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="HIST_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -116,7 +116,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -127,7 +127,7 @@
   <!-- ================================= -->
   <!-- DLND testing -->
   <!-- ================================= -->
-  <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
+  <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Ld3">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -138,7 +138,7 @@
   <!-- ================================= -->
   <!-- DWAV testing -->
   <!-- ================================= -->
-  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Vnuopc_Ld2">
+  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Ld2">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/cime_config/testdefs/testlist_cdeps.xml
+++ b/cime_config/testdefs/testlist_cdeps.xml
@@ -3,7 +3,7 @@
 
   <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -11,7 +11,7 @@
   </test>
   <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -19,7 +19,7 @@
   </test>
   <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -27,7 +27,7 @@
   </test>
   <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -35,7 +35,7 @@
   </test>
   <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -43,7 +43,7 @@
   </test>
   <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -51,7 +51,7 @@
   </test>
   <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -59,7 +59,7 @@
   </test>
   <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -67,7 +67,7 @@
   </test>
   <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -75,7 +75,7 @@
   </test>
   <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -83,7 +83,7 @@
   </test>
   <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -91,7 +91,7 @@
   </test>
   <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Vnuopc_Ld5_P1" testmods="datm/1PT">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -102,7 +102,7 @@
   <!-- ================================= -->
   <test compset="2000_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -110,7 +110,7 @@
   </test>
   <test compset="HIST_SATM_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -118,7 +118,7 @@
   </test>
   <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -129,7 +129,7 @@
   <!-- ================================= -->
   <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -140,7 +140,7 @@
   <!-- ================================= -->
   <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Vnuopc_Ld2">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -6,7 +6,7 @@
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
   </test>
-  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -14,7 +14,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -22,7 +22,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -30,7 +30,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -38,7 +38,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -46,7 +46,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -54,7 +54,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -62,7 +62,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -70,7 +70,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -78,7 +78,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -86,7 +86,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -94,7 +94,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Vnuopc_Ld5_P1" testmods="datm/1PT">
+  <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Ld5_P1" testmods="datm/1PT">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -102,7 +102,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%ERA5_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%ERA5_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -3,12 +3,12 @@
 
   <test compset="2000_DATM%QIA_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV" grid="T42_T42" name="SMS_Ln9_P1" testmods="datm/scam">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
   </test>
   <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -16,7 +16,7 @@
   </test>
   <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -24,7 +24,7 @@
   </test>
   <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -32,7 +32,7 @@
   </test>
   <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -40,7 +40,7 @@
   </test>
   <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -48,7 +48,7 @@
   </test>
   <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -56,7 +56,7 @@
   </test>
   <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -64,7 +64,7 @@
   </test>
   <test compset="2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -72,7 +72,7 @@
   </test>
   <test compset="2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -80,7 +80,7 @@
   </test>
   <test compset="2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -88,7 +88,7 @@
   </test>
   <test compset="2000_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -96,7 +96,7 @@
   </test>
   <test compset="2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="1x1_mexicocityMEX" name="SMS_Vnuopc_Ld5_P1" testmods="datm/1PT">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -104,7 +104,7 @@
   </test>
   <test compset="2000_DATM%ERA5_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="TL319_t061" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/dice/cime_config/testdefs/testlist_dice.xml
+++ b/dice/cime_config/testdefs/testlist_dice.xml
@@ -3,7 +3,7 @@
 
   <test compset="2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -11,7 +11,7 @@
   </test>
   <test compset="2000_DATM%NYF_SLND_DICE%IAF_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/dice/cime_config/testdefs/testlist_dice.xml
+++ b/dice/cime_config/testdefs/testlist_dice.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -9,7 +9,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NYF_SLND_DICE%IAF_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NYF_SLND_DICE%IAF_DOCN%DOM_SROF_SGLC_SWAV_SESP" grid="T62_g17" name="SMS_Ld5">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/dlnd/cime_config/testdefs/testlist_dlnd.xml
+++ b/dlnd/cime_config/testdefs/testlist_dlnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
+  <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Ld3">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/dlnd/cime_config/testdefs/testlist_dlnd.xml
+++ b/dlnd/cime_config/testdefs/testlist_dlnd.xml
@@ -3,7 +3,7 @@
 
   <test compset="1850_SATM_DLND%SCPL_SICE_SOCN_SROF_SGLC_SWAV" grid="f09_f09_mg17" name="SMS_Vnuopc_Ld3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/doc/source/datm.rst
+++ b/doc/source/datm.rst
@@ -60,7 +60,7 @@ ERA5 (``datm_datamode_era5_mod.F90``)
 
 .. note::
   Due to the high temporal and spatial resoultion of ERA5 dataset, only 2019
-  data is staged on NCAR's Cheyenne platform under
+  data is staged on NCAR's Derecho platform under
   `$CESMDATAROOT/inputdata/atm/datm7/ERA5`
 
 .. note::

--- a/docn/cime_config/testdefs/testlist_docn.xml
+++ b/docn/cime_config/testdefs/testlist_docn.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -9,7 +9,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="HIST_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -17,7 +17,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
+  <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Ln5">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/docn/cime_config/testdefs/testlist_docn.xml
+++ b/docn/cime_config/testdefs/testlist_docn.xml
@@ -3,7 +3,7 @@
 
   <test compset="2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -11,7 +11,7 @@
   </test>
   <test compset="HIST_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -19,7 +19,7 @@
   </test>
   <test compset="2000_DATM%QIA_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV" grid="f19_f19_mg17" name="SMS_Vnuopc_Ln5">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/drof/cime_config/testdefs/testlist_drof.xml
+++ b/drof/cime_config/testdefs/testlist_drof.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_SATM_SLND_SICE_SOCN_DROF%NYF_SGLC_SWAV" grid="f19_g17_rx1" name="SMS_Vnuopc_Ld3">
+  <test compset="2000_SATM_SLND_SICE_SOCN_DROF%NYF_SGLC_SWAV" grid="f19_g17_rx1" name="SMS_Ld3">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/drof/cime_config/testdefs/testlist_drof.xml
+++ b/drof/cime_config/testdefs/testlist_drof.xml
@@ -3,7 +3,7 @@
 
   <test compset="2000_SATM_SLND_SICE_SOCN_DROF%NYF_SGLC_SWAV" grid="f19_g17_rx1" name="SMS_Vnuopc_Ld3">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/dwav/cime_config/testdefs/testlist_dwav.xml
+++ b/dwav/cime_config/testdefs/testlist_dwav.xml
@@ -3,7 +3,7 @@
 
   <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Vnuopc_Ld2">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
+      <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/dwav/cime_config/testdefs/testlist_dwav.xml
+++ b/dwav/cime_config/testdefs/testlist_dwav.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Vnuopc_Ld2">
+  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_SGLC_DWAV%CLIMO" grid="ww3a" name="SMS_Ld2">
     <machines>
       <machine name="derecho"compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -21,7 +21,7 @@ module dshr_strdata_mod
   use ESMF             , only : ESMF_REGION_TOTAL, ESMF_FieldGet, ESMF_TraceRegionExit, ESMF_TraceRegionEnter
   use ESMF             , only : ESMF_LOGMSG_INFO, ESMF_LogWrite
   use shr_kind_mod     , only : r8=>shr_kind_r8, r4=>shr_kind_r4, i2=>shr_kind_I2
-  use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
+  use shr_kind_mod     , only : cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx, cx=>shr_kind_cx
   use shr_sys_mod      , only : shr_sys_abort
   use shr_const_mod    , only : shr_const_pi, shr_const_cDay, shr_const_spval
   use shr_cal_mod      , only : shr_cal_calendarname, shr_cal_timeSet
@@ -389,7 +389,7 @@ contains
     character(CS)                :: calendar        ! calendar name
     integer                      :: ns              ! stream index
     integer                      :: m               ! generic index
-    character(CL)                :: fileName        ! generic file name
+    character(CX)                :: fileName        ! generic file name
     integer                      :: nfld            ! loop stream field index
     type(ESMF_Field)             :: lfield          ! temporary
     type(ESMF_Field)             :: lfield_dst      ! temporary
@@ -677,7 +677,7 @@ contains
     type(ESMF_VM)           :: vm
     type(file_desc_t)       :: pioid
     integer                 :: rcode
-    character(CL)           :: filename
+    character(CX)           :: filename
     integer                 :: dimid
     integer                 :: stream_nlev
     character(*), parameter :: subname = '(shr_strdata_set_stream_domain) '
@@ -694,7 +694,7 @@ contains
        if (sdat%mainproc) then
           call shr_stream_getData(sdat%stream(stream_index), 1, filename)
        end if
-       call ESMF_VMBroadCast(vm, filename, CL, 0, rc=rc)
+       call ESMF_VMBroadCast(vm, filename, CX, 0, rc=rc)
        rcode = pio_openfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(filename), pio_nowrite)
        rcode = pio_inq_dimid(pioid, trim(sdat%stream(stream_index)%lev_dimname), dimid)
        rcode = pio_inq_dimlen(pioid, dimid, stream_nlev)
@@ -726,7 +726,7 @@ contains
     type(var_desc_t)        :: varid
     type(file_desc_t)       :: pioid
     integer                 :: rcode
-    character(CL)           :: filename
+    character(CX)           :: filename
     type(io_desc_t)         :: pio_iodesc
     real(r4), allocatable   :: data_real(:)
     real(r8), allocatable   :: data_double(:)
@@ -743,7 +743,7 @@ contains
     if (sdat%mainproc) then
        call shr_stream_getData(sdat%stream(stream_index), 1, filename)
     end if
-    call ESMF_VMBroadCast(vm, filename, CL, 0, rc=rc)
+    call ESMF_VMBroadCast(vm, filename, CX, 0, rc=rc)
 
     ! Open the file
     rcode = pio_openfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(filename), pio_nowrite)
@@ -1305,10 +1305,10 @@ contains
     real(r8)                             :: rDateM,rDateLB,rDateUB  ! model,LB,UB dates with fractional days
     integer                              :: n_lb, n_ub
     integer                              :: i
-    character(CL)                        :: filename_lb
-    character(CL)                        :: filename_ub
-    character(CL)                        :: filename_next
-    character(CL)                        :: filename_prev
+    character(CX)                        :: filename_lb
+    character(CX)                        :: filename_ub
+    character(CX)                        :: filename_next
+    character(CX)                        :: filename_prev
     logical                              :: find_bounds
     character(*), parameter              :: subname = '(shr_strdata_readLBUB) '
     character(*), parameter              :: F00   = "('(shr_strdata_readLBUB) ',8a)"
@@ -1432,7 +1432,7 @@ contains
     ! local variables
     integer                  :: stream_nlev
     type(ESMF_Field)         :: field_dst, field_vector_dst
-    character(CL)            :: currfile
+    character(CX)            :: currfile
     logical                  :: fileexists
     logical                  :: fileopen
     type(file_desc_t)        :: pioid

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -15,7 +15,7 @@ module dshr_stream_mod
   ! containing those dates.
   ! -------------------------------------------------------------------------------
 
-  use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
+  use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx, cx=>shr_kind_cx
   use shr_sys_mod      , only : shr_sys_abort
   use shr_const_mod    , only : shr_const_cday
   use shr_string_mod   , only : shr_string_leftalign_and_convert_tabs, shr_string_parseCFtunit
@@ -85,7 +85,7 @@ module dshr_stream_mod
 
   ! a useful derived type to use inside shr_streamType ---
   type shr_stream_file_type
-     character(CL)         :: name = shr_stream_file_null ! the file name (full pathname)
+     character(CX)         :: name = shr_stream_file_null ! the file name (full pathname)
      logical               :: haveData = .false.          ! has t-coord data been read in?
      integer               :: nt = 0                      ! size of time dimension
      integer  ,allocatable :: date(:)                     ! t-coord date: yyyymmdd
@@ -125,7 +125,7 @@ module dshr_stream_mod
      integer           :: n_gvd        = -1                     ! file/sample of greatest valid date
      logical           :: found_gvd    = .false.                ! T <=> k_gvd,n_gvd have been set
      logical           :: fileopen     = .false.                ! is current file open
-     character(CL)     :: currfile     = ' '                    ! current filename
+     character(CX)     :: currfile     = ' '                    ! current filename
      integer           :: nvars                                 ! number of stream variables
      character(CL)     :: stream_vectors = 'null'               ! stream vectors names
      type(file_desc_t) :: currpioid                             ! current pio file desc
@@ -379,7 +379,7 @@ contains
           allocate(streamdat(i)%varlist(streamdat(i)%nvars))
        endif
        do n=1,streamdat(i)%nfiles
-          call ESMF_VMBroadCast(vm, streamdat(i)%file(n)%name, CL, 0, rc=rc)
+          call ESMF_VMBroadCast(vm, streamdat(i)%file(n)%name, CX, 0, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        enddo
        do n=1,streamdat(i)%nvars
@@ -1219,7 +1219,7 @@ contains
     integer,optional            ,intent(out)   :: rc   ! return code
 
     ! local variables
-    character(CL)          :: fileName    ! filename to read
+    character(CX)          :: fileName    ! filename to read
     integer                :: nt
     integer                :: num,n
     integer                :: din,dout
@@ -1513,7 +1513,7 @@ contains
     type(ESMF_VM)          :: vm
     integer                :: myid
     integer                :: vid, n
-    character(CL)          :: fileName
+    character(CX)          :: fileName
     character(CL)          :: lcal
     integer(PIO_OFFSET_KIND) :: attlen
     integer                :: old_handle
@@ -1745,13 +1745,13 @@ contains
     integer              :: maxnt = 0
     integer, allocatable :: tmp(:)
     integer              :: logunit
-    character(len=CL)    :: fname, rfname, rsfname
+    character(len=CX)    :: fname, rfname, rsfname
 
     !-------------------------------------------------------------------------------
 
     if (mode .eq. 'define') then
 
-       rcode = pio_def_dim(pioid, 'strlen',   CL, dimid_str)
+       rcode = pio_def_dim(pioid, 'strlen',   CX, dimid_str)
        do k=1,size(streams)
           ! maxnfiles is the maximum number of files across all streams
           logunit = streams(k)%logunit


### PR DESCRIPTION
### Description of changes

Increase stream filename lengths to shr_kind_CX
Also update component test specifications for derecho

### Specific notes

Contributors other than yourself, if any: None (was discussed in the CTSM SE and CSEG groups though)

CDEPS Issues Fixed (include github issue #):
  Fixes #263 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): aux_clm

Hashes used for testing:

based on cdeps1.0.28

CTSM branch:ekluzek:mergetodev174
share1.0.18
cmeps0.14.50
cime6.0.217_httpsbranch03
ccs_config_cesm0.0.92