### PR TITLE
make the amount of data required to download minimal for testing

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -204,6 +204,9 @@ class StreamCDEPS(GenericXML):
             data_year_first, data_year_last = self._get_stream_first_and_last_dates(
                 self.stream_nodes, case
             )
+            # If this is a test we don't need the full extent of the data
+            if case.get_value("TEST"):
+                data_year_first = max(data_year_last-2, data_year_first)
 
             # now write the data model streams xml file
             stream_vars = {}


### PR DESCRIPTION
### Description of changes
Require a minimal amount of data be downloaded for testing.
### Specific notes
Without this change some 60 years of data needs to be downloaded to test data components 

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

