### PR TITLE
allow input of stream on unstructured mesh (e.g. mpas)

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1933,6 +1933,7 @@ contains
     character(*), parameter :: F00  = "('(shr_strdata_set_stream_iodesc) ',a,i8,2x,i8,2x,a)"
     character(*), parameter :: F01  = "('(shr_strdata_set_stream_iodesc) ',a,i8,2x,i8,2x,a)"
     character(*), parameter :: F02  = "('(shr_strdata_set_stream_iodesc) ',a,i8,2x,i8,2x,i8,2x,a)"
+    character(*), parameter :: F03  = "('(shr_strdata_set_stream_iodesc) ',a,i8,2x,a)"
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1982,13 +1983,23 @@ contains
 
     ! determine io descriptor
     if (ndims == 2) then
-       if (sdat%mainproc) then
-          write(sdat%stream(1)%logunit,F00) 'setting iodesc for : '//trim(fldname)// &
-               ' with dimlens(1), dimlens2 = ',dimlens(1),dimlens(2),&
-               ' variable has no time dimension '
+       rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
+       if (trim(dimname) == 'time' .or. trim(dimname) == 'nt') then
+          if (sdat%mainproc) then
+             write(sdat%stream(1)%logunit,F03) 'setting iodesc for : '//trim(fldname)// &
+                  ' with dimlens(1) = ',dimlens(1),' and the variable has a time dimension '
+          end if
+          call pio_initdecomp(sdat%pio_subsystem, pio_iovartype, (/dimlens(1)/), compdof, &
+               per_stream%stream_pio_iodesc)
+       else
+          if (sdat%mainproc) then
+             write(sdat%stream(1)%logunit,F00) 'setting iodesc for : '//trim(fldname)// &
+                  ' with dimlens(1), dimlens(2) = ',dimlens(1),dimlens(2),&
+                  ' variable has no time dimension '
+          end if
+          call pio_initdecomp(sdat%pio_subsystem, pio_iovartype, (/dimlens(1),dimlens(2)/), compdof, &
+               per_stream%stream_pio_iodesc)
        end if
-       call pio_initdecomp(sdat%pio_subsystem, pio_iovartype, (/dimlens(1),dimlens(2)/), compdof, &
-            per_stream%stream_pio_iodesc)
 
     else if (ndims == 3) then
        rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)


### PR DESCRIPTION
### Description of changes
This permits use of an unstructured mpas grid as input.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed:  #249
also fixes CTSM Issue https://github.com/ESCOMP/CTSM/issues/2518

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers: bfb

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
Verified that with this change cdeps could ingest unstructured input.

Hashes used for testing:

