### PR TITLE
bug fix for single level log output

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -720,7 +720,9 @@ contains
     end if
     if (sdat%mainproc) then
        write(sdat%stream(1)%logunit,*) trim(subname)//' stream_nlev = ',stream_nlev
-       write(sdat%stream(1)%logunit,*)' stream vertical levels = ',sdat%pstrm(stream_index)%stream_vlevs
+       if (stream_nlev /= 1) then
+          write(sdat%stream(1)%logunit,*)' stream vertical levels = ',sdat%pstrm(stream_index)%stream_vlevs
+       end if
     end if
 
     ! Set stream_nlev in the per-stream sdat info


### PR DESCRIPTION
### Description of changes
This is a fix where the log output was trying to write out the  value of the vertical levels even if they were not allocated.

### Specific notes

Contributors other than yourself, if any: None

CDEPS Issues Fixed:

Are there dependencies on other component PRs (if so list): None

Are changes expected to change answers bfb

Any User Interface Changes: None (namelist or namelist defaults changes):

Testing performed: Verified that this was working now

Hashes used for testing:

