### PR TITLE
Fix missing field width for L edit descriptor for NAG

### DIFF
--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -491,7 +491,7 @@ contains
     if (my_task == main_task) then
        call ESMF_TimeGet(currTime, timestring=timestring, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       write(logunit,'(a,l)') trim(timestring)//': valid_input for dglc is ',valid_inputs
+       write(logunit,'(a,l6)') trim(timestring)//': valid_input for dglc is ',valid_inputs
     end if
 
     ! determine if will write restart


### PR DESCRIPTION
### Description of changes
  Fix missing field width for L edit descriptor for NAG

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):  
  BFB

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): 
 SMS_D_Ln9.f19_f19_mg17.FKESSLER.izumi_nag.cam-outfrq9s

Hashes used for testing:

