### PR TITLE
rename Fogg rofi to Fgrg_rofi

### DIFF
--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -178,7 +178,7 @@ contains
          call dshr_state_getfldptr(NStateExp(ns), field_out_rofi, fldptr1=Fgrg_rofi(ns)%ptr, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-         Fogg_rofi(ns)%ptr(:) = 0._r8
+         Fgrg_rofi(ns)%ptr(:) = 0._r8
       end do
 
       ! initialize pointers to import fields if appropriate

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -40,7 +40,7 @@ module dglc_datamode_noevolve_mod
    type(icesheet_ptr_t), allocatable :: Sg_ice_covered(:)
    type(icesheet_ptr_t), allocatable :: Sg_icemask(:)
    type(icesheet_ptr_t), allocatable :: Sg_icemask_coupled_fluxes(:)
-   type(icesheet_ptr_t), allocatable :: Fogg_rofi(:)
+   type(icesheet_ptr_t), allocatable :: Fgrg_rofi(:)
 
    ! Import fields
    integer, parameter :: nlev_import = 30
@@ -55,7 +55,7 @@ module dglc_datamode_noevolve_mod
    character(len=*), parameter :: field_out_ice_covered            = 'Sg_ice_covered'
    character(len=*), parameter :: field_out_icemask                = 'Sg_icemask'
    character(len=*), parameter :: field_out_icemask_coupled_fluxes = 'Sg_icemask_coupled_fluxes'
-   character(len=*), parameter :: field_out_rofi                   = 'Fogg_rofi'
+   character(len=*), parameter :: field_out_rofi                   = 'Fgrg_rofi'
 
    ! Import Field names
    character(len=*), parameter :: field_in_tsrf                    = 'Sl_tsrf'
@@ -162,7 +162,7 @@ contains
       allocate(Sg_ice_covered(num_icesheets))
       allocate(Sg_icemask(num_icesheets))
       allocate(Sg_icemask_coupled_fluxes(num_icesheets))
-      allocate(Fogg_rofi(num_icesheets))
+      allocate(Fgrg_rofi(num_icesheets))
 
       do ns = 1,num_icesheets
          call dshr_state_getfldptr(NStateExp(ns), field_out_area, fldptr1=Sg_area(ns)%ptr, rc=rc)
@@ -175,7 +175,7 @@ contains
          if (chkerr(rc,__LINE__,u_FILE_u)) return
          call dshr_state_getfldptr(NStateExp(ns), field_out_icemask_coupled_fluxes, fldptr1=Sg_icemask_coupled_fluxes(ns)%ptr, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
-         call dshr_state_getfldptr(NStateExp(ns), field_out_rofi, fldptr1=Fogg_rofi(ns)%ptr, rc=rc)
+         call dshr_state_getfldptr(NStateExp(ns), field_out_rofi, fldptr1=Fgrg_rofi(ns)%ptr, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
       end do
 
@@ -365,10 +365,10 @@ contains
       end if
 
       if (initialized_noevolve) then
-         ! Compute Fogg_rofi
+         ! Compute Fgrg_rofi
          do ns = 1,num_icesheets
-            do ng = 1,size(Fogg_rofi(ns)%ptr)
-               Fogg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng)
+            do ng = 1,size(Fgrg_rofi(ns)%ptr)
+               Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng)
             end do
          end do
       end if


### PR DESCRIPTION
### Description of changes
renamed Fogg_rofi to Fgrg_rofi

### Specific notes
This changes is needed to have dglc provide runoff to river component rather than ocean.

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

