### PR TITLE
Fix/cdeps build concurancy

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -73,8 +73,10 @@ def buildlib(bldroot, libroot, case):
         strthread = "nothreads"
     mpilib = case.get_value("MPILIB")
     compiler = case.get_value("COMPILER")
-    sharedpath = os.path.join(compiler, mpilib, strdebug, strthread, "nuopc")
-
+    sharedpath = os.path.join(compiler, mpilib, strdebug, strthread)
+    sharedroot = case.get_value("SHAREDLIBROOT")
+    cdepsblddir = os.path.join(sharedroot, sharedpath, "CDEPS")
+    
     logger.info("Running cmake for CDEPS")
     srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     cmake_flags = get_standard_cmake_args(case, os.path.join(sharedpath, "cdeps"))
@@ -147,31 +149,47 @@ def buildlib(bldroot, libroot, case):
     else:
         bld_time = src_time - 1
 
-    # if any file in src is newer than CmakeFiles in the build directory, rerun cmake
-
-    if src_time > bld_time:
-        logger.info("cmake_flags {}".format(cmake_flags))
-        s, o, e = run_cmd(
-            "cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True
-        )
-        expect(not s, "ERROR from cmake output={}, error={}".format(o, e))
+    # Make sure that no other process is currently trying to build this library, done with a simple lockfile
+    if os.path.exists(cdepsblddir):
+        logger.info("{} already exists, checking for lockfile".format(cdepsblddir))
+        while os.path.exists(os.path.join(cdepsblddir,"lockfile")):
+            logger.info("Waiting for lockfile in {}".format(cdepsblddir))
+            time.sleep(10)
     else:
-        # The dwav_lib is the last file built in cdeps, wait for it to be built
-        dwav_lib = os.path.join(bldroot, "dwav", "libdwav.a")
-        time_to_wait = 300
-        time_counter = 0
-        while not os.path.exists(dwav_lib):
-            time.sleep(1)
-            time_counter += 1
-            if time_counter > time_to_wait:
-                break
-        expect(time_counter <= time_to_wait, " Timeout waiting for {}".format(dwav_lib))
+        logger.info("{} does not exist, creating lockfile".format(cdepsblddir))
+        os.makedirs(cdepsblddir)
+        with open(os.path.join(cdepsblddir,"lockfile"),"w") as fd:
+            fd.write(str(os.getpid()))
 
-    s, o, e = run_cmd(
-        "make install VERBOSE=1 DESTDIR={}".format(libroot),
-        from_dir=bldroot,
-        verbose=True,
-    )
+    try:
+        # if any file in src is newer than CmakeFiles in the build directory, rerun cmake
+        if src_time > bld_time:
+            logger.info("cmake_flags {}".format(cmake_flags))
+            s, o, e = run_cmd(
+                "cmake {} ".format(cmake_flags), from_dir=bldroot, verbose=True
+            )
+            expect(not s, "ERROR from cmake output={}, error={}".format(o, e))
+        else:
+            # The dwav_lib is the last file built in cdeps, wait for it to be built
+            dwav_lib = os.path.join(bldroot, "dwav", "libdwav.a")
+            time_to_wait = 300
+            time_counter = 0
+            while not os.path.exists(dwav_lib):
+                time.sleep(1)
+                time_counter += 1
+                if time_counter > time_to_wait:
+                    break
+            expect(time_counter <= time_to_wait, " Timeout waiting for {}".format(dwav_lib))
+
+        s, o, e = run_cmd(
+            "make install VERBOSE=1 DESTDIR={}".format(libroot),
+            from_dir=bldroot,
+            verbose=True,
+        )
+    finally:
+        if os.path.exists(os.path.join(cdepsblddir,"lockfile")):
+            os.remove(os.path.join(cdepsblddir,"lockfile"))
+
     expect(not s, "ERROR from make output={}, error={}".format(o, e))
     logger.info("make output={}\nerror={}".format(o, e))
     if compiler == "gnu" and case.get_value("DEBUG"):

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -172,7 +172,7 @@ def buildlib(bldroot, libroot, case):
         else:
             # The dwav_lib is the last file built in cdeps, wait for it to be built
             dwav_lib = os.path.join(bldroot, "dwav", "libdwav.a")
-            time_to_wait = 300
+            time_to_wait = 600
             time_counter = 0
             while not os.path.exists(dwav_lib):
                 time.sleep(1)


### PR DESCRIPTION
### Description of changes
Increase the timeout for building (needed for Izumi) and add code to make sure only one build process is running at a time.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

