### PR TITLE
Katetc/dglc negfluxes

### DIFF
--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -398,9 +398,8 @@ contains
             ! Get mesh info
             call ESMF_MeshGet(model_meshes(ns), elementdistGrid=distGrid, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            call ESMF_DistGridGet(distGrid, localDe=0, elementCount=lsize, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
+            lsize = size(Fgrg_rofi(ns)%ptr)
+            
             allocate(ice_runoff_out(lsize))
             ice_runoff_out(:) = 0.d0
             loc_pos_smb(1) = 0.d0

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -436,8 +436,8 @@ contains
                do ng = 1,lsize             
                   if (Sg_icemask_coupled_fluxes(ns)%ptr(ng).gt.0.d0) then
                      if(Flgl_qice(ns)%ptr(ng) > 0.d0) then
-                        rat = Flgl_qice(ns)%ptr(ng)/Tot_pos_smb(1)
-                        Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_neg_smb(1)/Sg_area(ns)%ptr(ng)
+                        rat = Flgl_qice(ns)%ptr(ng)*Sg_area(ns)%ptr(ng)/Tot_pos_smb(1)
+                        Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_neg_smb(1)
                      else if (Flgl_qice(ns)%ptr(ng) < 0.d0) then
                         Fgrg_rofi(ns)%ptr(ng) = 0.d0
                      end if
@@ -453,8 +453,8 @@ contains
                do ng = 1,lsize
                   if (Sg_icemask_coupled_fluxes(ns)%ptr(ng).gt.0.d0) then
                      if(Flgl_qice(ns)%ptr(ng) < 0.d0) then
-                        rat = Flgl_qice(ns)%ptr(ng)/Tot_neg_smb(1)
-                        Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_pos_smb(1)/Sg_area(ns)%ptr(ng)
+                        rat = Flgl_qice(ns)%ptr(ng)*Sg_area(ns)%ptr(ng)/Tot_neg_smb(1)
+                        Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_pos_smb(1)
                      else if (Flgl_qice(ns)%ptr(ng) > 0.d0) then
                         Fgrg_rofi(ns)%ptr(ng) = 0.d0
                      end if

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -436,9 +436,9 @@ contains
                do ng = 1,lsize             
                   if (Sg_icemask_coupled_fluxes(ns)%ptr(ng).gt.0.d0) then
                      if(Flgl_qice(ns)%ptr(ng) > 0.d0) then
-                        rat = Flgl_qice(ns)%ptr(ng)*Sg_area(ns)%ptr(ng)/Tot_pos_smb(1)
+                        rat = Flgl_qice(ns)%ptr(ng)/Tot_pos_smb(1)
                         Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_neg_smb(1)
-                     else if (Flgl_qice(ns)%ptr(ng) < 0.d0) then
+                     else
                         Fgrg_rofi(ns)%ptr(ng) = 0.d0
                      end if
                   else
@@ -453,9 +453,9 @@ contains
                do ng = 1,lsize
                   if (Sg_icemask_coupled_fluxes(ns)%ptr(ng).gt.0.d0) then
                      if(Flgl_qice(ns)%ptr(ng) < 0.d0) then
-                        rat = Flgl_qice(ns)%ptr(ng)*Sg_area(ns)%ptr(ng)/Tot_neg_smb(1)
+                        rat = Flgl_qice(ns)%ptr(ng)/Tot_neg_smb(1)
                         Fgrg_rofi(ns)%ptr(ng) = Flgl_qice(ns)%ptr(ng) + rat*Tot_pos_smb(1)
-                     else if (Flgl_qice(ns)%ptr(ng) > 0.d0) then
+                     else
                         Fgrg_rofi(ns)%ptr(ng) = 0.d0
                      end if
                   else

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -430,7 +430,7 @@ contains
     end do ! end loop over ice sheets
 
     ! Run dglc
-    call dglc_comp_run(clock, current_ymd, current_tod, restart_write=.false., valid_inputs=.true., rc=rc)
+    call dglc_comp_run(gcomp, clock, current_ymd, current_tod, restart_write=.false., valid_inputs=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call ESMF_TraceRegionExit('dglc_strdata_init')
@@ -498,19 +498,20 @@ contains
     restart_write = dshr_check_restart_alarm(clock, rc=rc)
 
     ! run dglc
-    call dglc_comp_run(clock, next_ymd, next_tod, restart_write, valid_inputs, rc=rc)
+    call dglc_comp_run(gcomp, clock, next_ymd, next_tod, restart_write, valid_inputs, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine ModelAdvance
 
   !===============================================================================
-  subroutine dglc_comp_run(clock, target_ymd, target_tod, restart_write, valid_inputs, rc)
+  subroutine dglc_comp_run(gcomp, clock, target_ymd, target_tod, restart_write, valid_inputs, rc)
 
     ! --------------------------
     ! advance dglc
     ! --------------------------
 
     ! input/output variables:
+    type(ESMF_GridComp)              :: gcomp
     type(ESMF_Clock) , intent(in)    :: clock
     integer          , intent(in)    :: target_ymd       ! model date
     integer          , intent(in)    :: target_tod       ! model sec into model date
@@ -589,7 +590,7 @@ contains
     select case (trim(datamode))
     case('noevolve')
       if (valid_inputs) then
-         call dglc_datamode_noevolve_advance(sdat(1)%pio_subsystem, sdat(1)%io_type, sdat(1)%io_format, &
+         call dglc_datamode_noevolve_advance(gcomp, sdat(1)%pio_subsystem, sdat(1)%io_type, sdat(1)%io_format, &
               logunit, model_meshes, model_internal_gridsize, model_datafiles, rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -590,7 +590,7 @@ contains
     case('noevolve')
       if (valid_inputs) then
          call dglc_datamode_noevolve_advance(sdat(1)%pio_subsystem, sdat(1)%io_type, sdat(1)%io_format, &
-              model_meshes, model_internal_gridsize, model_datafiles, rc)
+              logunit, model_meshes, model_internal_gridsize, model_datafiles, rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
     end select


### PR DESCRIPTION
### Description of changes

Add code to Dglc to balance neg and positive ice fluxes and reduce the amount of negative water fluxes coming from each ice sheet to the ocean.

### Specific notes

- Fixes https://github.com/ESCOMP/CDEPS/issues/301 by making usrf a local variable instead of module-level
- Adds in global sums to balance fluxes across processors on the ice sheet

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): #301

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial): 
- Changes answers for any compset using DGLC

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
- Only prelimary testing at this point. This PR is for discussion and review.

Hashes used for testing:

