### PR TITLE
backout the timestamp on rpointer files until alpha05c,

### DIFF
--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -102,7 +102,6 @@ module datm_datamode_clmncep_mod
 
 
   character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -41,7 +41,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swnet(:)        => null()
 
   character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -59,7 +59,6 @@ module datm_datamode_era5_mod
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
   character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/datm/datm_datamode_gefs_mod.F90
+++ b/datm/datm_datamode_gefs_mod.F90
@@ -49,7 +49,6 @@ module datm_datamode_gefs_mod
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
   character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -58,7 +58,6 @@ module datm_datamode_jra_mod
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
   character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -76,7 +76,6 @@ module datm_datamode_simple_mod
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
   character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: rpfile  = 'rpointer.atm'
   character(*), parameter :: u_FILE_u = &
        __FILE__
 

--- a/docn/docn_datamode_copyall_mod.F90
+++ b/docn/docn_datamode_copyall_mod.F90
@@ -27,7 +27,6 @@ module docn_datamode_copyall_mod
   real(r8) , parameter :: ocnsalt = shr_const_ocn_ref_sal ! ocean reference salinity
 
   character(*) , parameter :: nullstr = 'null'
-  character(*) , parameter :: rpfile  = 'rpointer.ocn'
   character(*) , parameter :: u_FILE_u = &
        __FILE__
 

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -27,7 +27,6 @@ module docn_datamode_cplhist_mod
   real(r8) , parameter :: ocnsalt = shr_const_ocn_ref_sal ! ocean reference salinity
 
   character(*) , parameter :: nullstr = 'null'
-  character(*) , parameter :: rpfile  = 'rpointer.ocn'
   character(*) , parameter :: u_FILE_u = &
        __FILE__
 

--- a/docn/docn_datamode_multilev_dom_mod.F90
+++ b/docn/docn_datamode_multilev_dom_mod.F90
@@ -40,7 +40,6 @@ module docn_datamode_multilev_dom_mod
 
   ! constants
   character(*) , parameter :: nullstr = 'null'
-  character(*) , parameter :: rpfile  = 'rpointer.ocn'
   character(*) , parameter :: u_FILE_u = &
        __FILE__
 

--- a/docn/docn_datamode_multilev_mod.F90
+++ b/docn/docn_datamode_multilev_mod.F90
@@ -32,7 +32,6 @@ module docn_datamode_multilev_mod
 
   ! constants
   character(*) , parameter :: nullstr = 'null'
-  character(*) , parameter :: rpfile  = 'rpointer.ocn'
   character(*) , parameter :: u_FILE_u = &
        __FILE__
 

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -81,7 +81,6 @@ module cdeps_drof_comp
 
   logical                      :: diagnose_data = .true.
   integer      , parameter     :: main_task=0                       ! task number of main task
-  character(*) , parameter     :: rpfile = 'rpointer.rof'
 #ifdef CESMCOUPLED
   character(*) , parameter     :: modName =  "(rof_comp_nuopc)"
 #else

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1058,6 +1058,7 @@ contains
     type(io_desc_t)   :: pio_iodesc
     integer           :: oldmode
     integer           :: rcode
+    character(len=CS) :: lrpfile
     character(*), parameter :: F00   = "('(dshr_restart_write) ',2a,2(i0,2x))"
     !-------------------------------------------------------------------------------
 
@@ -1067,10 +1068,11 @@ contains
 
     call shr_cal_datetod2string(date_str, ymd, tod)
     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
-
+    ! temporarily turn off timestamp, remove this code and comment in alpha05c
+    lrpfile = rpfile(:len_trim(rpfile)-17)
     ! write restart info to rpointer file
     if (my_task == main_task) then
-       open(newunit=nu, file=trim(rpfile), form='formatted')
+       open(newunit=nu, file=trim(lrpfile), form='formatted')
        write(nu,'(a)') rest_file_model
        close(nu)
        write(logunit,F00)' writing ',trim(rest_file_model)

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -83,7 +83,6 @@ module cdeps_dwav_comp
   ! constants
   logical                      :: diagnose_data = .true.
   integer      , parameter     :: main_task=0                       ! task number of main task
-  character(*) , parameter     :: rpfile = 'rpointer.wav'
 #ifdef CESMCOUPLED
   character(*) , parameter     :: modName =  "(wav_comp_nuopc)"
 #else


### PR DESCRIPTION
remove unused rpfile parameters
The change in dshr_mod.F90 should be undone in cesm3_0_alpha05c

### Description of changes
Remove the timestamp from rpointer files, it was brought in before other components are ready.
### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

