### PR TITLE
Change hard-coded default for nextsw_cday_calc - important for UFS

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -246,7 +246,7 @@ contains
     rc = ESMF_SUCCESS
 
     ! Initialize locally-declared namelist items to default values
-    nextsw_cday_calc = nullstr
+    nextsw_cday_calc = 'cam6'
 
     call NUOPC_CompAttributeGet(gcomp, name='case_name', value=case_name, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
### Description of changes

Change hard-coded default for nextsw_cday_calc to be a valid option that will give backwards compatibility. This is needed for UFS, which doesn't add this to the namelist. This should have no impact for CESM.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): No

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Ran `SMS_D_Ld1.ne30pg3_t232.I1850Clm50BgcSpinup.derecho_intel.clm-cplhist` with comparison against baseline, where I removed the nextsw_cday_calc from the namelist with these diffs:

```diff
diff --git a/datm/cime_config/namelist_definition_datm.xml b/datm/cime_config/namelist_definition_datm.xml
index 40935cf..06f6d99 100644
--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -348,31 +348,6 @@
     </values>
   </entry>
 
-  <entry id="nextsw_cday_calc">
-    <type>char</type>
-    <category>datm</category>
-    <group>datm_nml</group>
-    <valid_values>cam6,cam7</valid_values>
-    <desc>
-      Logic to use for calculating nextsw_cday. This variable has no effect when iradsw is
-      0 or 1, so by default this only applies in CPLHIST cases.
-
-      For CPLHIST cases, this should agree with the version of CAM (or other atmosphere
-      model) used to generate the CPLHIST forcings; the valid values for this variable are
-      based on this: 'cam6' is appropriate for cases generated with the driver ordering in
-      CAM6 and earlier, and 'cam7' is appropriate for cases generated with the driver
-      ordering in CAM7 and later.
-
-      For 'cam6', the next radiation timestep is set to the present time plus 2 timesteps
-      when mod(tod+dtime,delta_radsw)==0. For 'cam7', the next radiation timestep is set
-      to the present time plus 1 timestep when mod(tod,delta_radsw)==0.
-    </desc>
-    <values>
-      <value>cam6</value>
-      <value datm_mode="CPLHIST">cam7</value>
-    </values>
-  </entry>
-
   <entry id="restfilm">
     <type>char</type>
     <category>datm</category>
```

I ensured this passed and was bit-for-bit.

Hashes used for testing:
CTSM at ctsm5.3.009. The latest CDEPS doesn't work in the context of that CTSM tag, so instead I cherry-picked this commit onto 1f317a3 (from the original nextsw_cday branch).
