### PR TITLE
add back rpointer timestamps

### DIFF
--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1068,8 +1068,7 @@ contains
 
     call shr_cal_datetod2string(date_str, ymd, tod)
     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
-    ! temporarily turn off timestamp, remove this code and comment in alpha05c
-    lrpfile = rpfile(:len_trim(rpfile)-17)
+
     ! write restart info to rpointer file
     if (my_task == main_task) then
        open(newunit=nu, file=trim(lrpfile), form='formatted')


### PR DESCRIPTION
### Description of changes
add rpointers to timestamps.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

