### PR TITLE
Readd rpointer timestamps

### DIFF
--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1068,7 +1068,8 @@ contains
 
     call shr_cal_datetod2string(date_str, ymd, tod)
     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
-
+    ! temporarily turn off timestamp, remove this code and comment in alpha05c
+    lrpfile = rpfile(:len_trim(rpfile)-17)
     ! write restart info to rpointer file
     if (my_task == main_task) then
        open(newunit=nu, file=trim(lrpfile), form='formatted')

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -1058,7 +1058,6 @@ contains
     type(io_desc_t)   :: pio_iodesc
     integer           :: oldmode
     integer           :: rcode
-    character(len=CS) :: lrpfile
     character(*), parameter :: F00   = "('(dshr_restart_write) ',2a,2(i0,2x))"
     !-------------------------------------------------------------------------------
 
@@ -1068,11 +1067,9 @@ contains
 
     call shr_cal_datetod2string(date_str, ymd, tod)
     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
-    ! temporarily turn off timestamp, remove this code and comment in alpha05c
-    lrpfile = rpfile(:len_trim(rpfile)-17)
     ! write restart info to rpointer file
     if (my_task == main_task) then
-       open(newunit=nu, file=trim(lrpfile), form='formatted')
+       open(newunit=nu, file=trim(rpfile), form='formatted')
        write(nu,'(a)') rest_file_model
        close(nu)
        write(logunit,F00)' writing ',trim(rest_file_model)


### PR DESCRIPTION
### Description of changes
The previous tag left variable lrpfile undefined but still used, this removes the 
lrpfile variable and corrects the problem.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

