### PR TITLE
replace calls to esmf_logmsg_error with shr_abort

### DIFF
--- a/docn/docn_import_data_mod.F90
+++ b/docn/docn_import_data_mod.F90
@@ -1,7 +1,6 @@
 module docn_import_data_mod
 
    use ESMF             , only : ESMF_State, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
-   use ESMF             , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE
    use NUOPC            , only : NUOPC_Advertise
    use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
    use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
@@ -99,9 +98,7 @@ contains
          valid = .false.
       end if
       if (.not. valid) then
-         call ESMF_LogWrite("ERROR: invalid list = "//trim(str), ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort("ERROR: invalid list = "//trim(str))
       end if
       ! get number of fields in a colon delimited string list
       nflds = 0

--- a/docn/docn_import_data_mod.F90
+++ b/docn/docn_import_data_mod.F90
@@ -69,7 +69,7 @@ contains
 
    !===============================================================================
    subroutine docn_get_import_fields(str, flds, rc)
-
+      use shr_sys_mod          , only : shr_sys_abort
       ! input/output variables
       character(len=*)               , intent(in)  :: str     ! colon deliminted string to search
       character(len=*) , allocatable , intent(out) :: flds(:) ! memory will be allocate for flds

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -89,6 +89,7 @@ contains
 
   subroutine dshr_model_initphase(gcomp, importState, exportState, clock, rc)
     use ESMF, only : ESMF_ClockIsCreated, ESMF_StateIsCreated
+    use shr_sys_mod, only : shr_sys_abort
     ! input/output variables
     type(ESMF_GridComp)   :: gcomp
     type(ESMF_State)      :: importState, exportState
@@ -100,8 +101,7 @@ contains
     rc = ESMF_SUCCESS
     ! To prevent an unused variable warning
     if(.not. (ESMF_StateIsCreated(importState) .or. ESMF_StateIsCreated(exportState) .or. ESMF_ClockIsCreated(clock))) then
-       call ESMF_LogWrite(trim(subname)//' state or clock not created', ESMF_LOGMSG_ERROR)
-
+       call shr_sys_abort(trim(subname)//' state or clock not created', ESMF_LOGMSG_ERROR)
     endif
 
     ! Switch to IPDv01 by filtering all other phaseMap entries

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -101,7 +101,7 @@ contains
     rc = ESMF_SUCCESS
     ! To prevent an unused variable warning
     if(.not. (ESMF_StateIsCreated(importState) .or. ESMF_StateIsCreated(exportState) .or. ESMF_ClockIsCreated(clock))) then
-       call shr_sys_abort(trim(subname)//' state or clock not created', ESMF_LOGMSG_ERROR)
+       call shr_sys_abort(trim(subname)//' state or clock not created')
     endif
 
     ! Switch to IPDv01 by filtering all other phaseMap entries

--- a/share/nuopc_shr_methods.F90
+++ b/share/nuopc_shr_methods.F90
@@ -2,7 +2,7 @@ module nuopc_shr_methods
   use ESMF         , only : operator(<), operator(/=), operator(+)
   use ESMF         , only : operator(-), operator(*) , operator(>=)
   use ESMF         , only : operator(<=), operator(>), operator(==), MOD
-  use ESMF         , only : ESMF_LOGERR_PASSTHRU, ESMF_LogFoundError, ESMF_LOGMSG_ERROR, ESMF_MAXSTR
+  use ESMF         , only : ESMF_LOGERR_PASSTHRU, ESMF_LogFoundError, ESMF_MAXSTR
   use ESMF         , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_FAILURE
   use ESMF         , only : ESMF_State, ESMF_StateGet
   use ESMF         , only : ESMF_Field, ESMF_FieldGet
@@ -373,9 +373,7 @@ contains
              call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
           endif
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
        endif
     enddo
 
@@ -411,10 +409,8 @@ contains
     ! ----------------------------------------------
 
     if (.not.present(rc)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR rc not present ", &
-            ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//": ERROR rc not present ", &
+            line=__LINE__, file=u_FILE_u)
     endif
 
     rc = ESMF_SUCCESS
@@ -465,27 +461,21 @@ contains
                ESMF_LOGMSG_INFO)
        elseif (lrank == 1) then
           if (.not.present(fldptr1)) then
-             call ESMF_LogWrite(trim(subname)//": ERROR missing rank=1 array ", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-             rc = ESMF_FAILURE
-             return
+             call shr_abort_mod(trim(subname)//": ERROR missing rank=1 array ", &
+                  line=__LINE__, file=u_FILE_u)
           endif
           call ESMF_FieldGet(field, farrayPtr=fldptr1, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        elseif (lrank == 2) then
           if (.not.present(fldptr2)) then
-             call ESMF_LogWrite(trim(subname)//": ERROR missing rank=2 array ", &
-                  ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-             rc = ESMF_FAILURE
-             return
+             call shr_sys_abort(trim(subname)//": ERROR missing rank=2 array ", &
+                  line=__LINE__, file=u_FILE_u)
           endif
           call ESMF_FieldGet(field, farrayPtr=fldptr2, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR in rank ", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR in rank ", &
+               line=__LINE__, file=u_FILE_u)
        endif
 
     endif  ! status
@@ -566,14 +556,10 @@ contains
     ! Error checks
     if (trim(option) == optdate) then
        if (.not. present(opt_ymd)) then
-          call ESMF_LogWrite(trim(subname)//trim(option)//' requires opt_ymd', ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//trim(option)//' requires opt_ymd')
        end if
        if (lymd < 0 .or. ltod < 0) then
-          call ESMF_LogWrite(subname//trim(option)//'opt_ymd, opt_tod invalid', ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(subname//trim(option)//'opt_ymd, opt_tod invalid')
        end if
     else if (&
          trim(option) == optNSteps   .or. trim(option) == trim(optNSteps)//'s'   .or. &
@@ -584,14 +570,10 @@ contains
          trim(option) == optNMonths  .or. trim(option) == trim(optNMonths)//'s'  .or. &
          trim(option) == optNYears   .or. trim(option) == trim(optNYears)//'s' ) then
        if (.not.present(opt_n)) then
-          call ESMF_LogWrite(subname//trim(option)//' requires opt_n', ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(subname//trim(option)//' requires opt_n')
        end if
        if (opt_n <= 0) then
-          call ESMF_LogWrite(subname//trim(option)//' invalid opt_n', ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(subname//trim(option)//' invalid opt_n')
        end if
     end if
     call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
@@ -629,9 +611,7 @@ contains
       AlarmInterval = AlarmInterval * opt_n
       ! timestepinterval*0 is 0 of kind ESMF_TimeStepInterval
       if (mod(AlarmInterval, TimestepInterval) /= (TimestepInterval*0)) then
-         call ESMF_LogWrite(subname//'illegal Alarm setting for '//trim(alarmname), ESMF_LOGMSG_ERROR)
-         rc = ESMF_FAILURE
-         return
+         call shr_sys_abort(subname//'illegal Alarm setting for '//trim(alarmname))
       endif
       update_nextalarm  = .true.
 
@@ -691,9 +671,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        
     case default
-       call ESMF_LogWrite(subname//'unknown option '//trim(option), ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(subname//'unknown option '//trim(option))
 
     end select
 
@@ -804,14 +782,10 @@ contains
     enddo
 
     if(get_minimum_timestep == huge(1)) then
-       call ESMF_LogWrite('minimum_timestep_error: this option is not supported ', ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort('minimum_timestep_error: this option is not supported ')
     endif
     if(get_minimum_timestep <= 0) then
-       call ESMF_LogWrite('minimum_timestep_error ERROR ', ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort('minimum_timestep_error ERROR ')
     endif
   end function get_minimum_timestep
 

--- a/share/nuopc_shr_methods.F90
+++ b/share/nuopc_shr_methods.F90
@@ -461,7 +461,7 @@ contains
                ESMF_LOGMSG_INFO)
        elseif (lrank == 1) then
           if (.not.present(fldptr1)) then
-             call shr_abort_mod(trim(subname)//": ERROR missing rank=1 array ", &
+             call shr_sys_abort(trim(subname)//": ERROR missing rank=1 array ", &
                   line=__LINE__, file=u_FILE_u)
           endif
           call ESMF_FieldGet(field, farrayPtr=fldptr1, rc=rc)

--- a/share/shr_abort_mod.F90
+++ b/share/shr_abort_mod.F90
@@ -44,9 +44,6 @@ contains
     integer(shr_kind_in), intent(in), optional :: line
     character(len=*), intent(in), optional :: file
 
-    !----- local -----
-    logical :: flag
-
     ! Local version of the string.
     ! (Gets a default value if string is not present.)
     character(len=shr_kind_cx) :: local_string

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -6,14 +6,15 @@ module dshr_methods_mod
   use ESMF         , only : ESMF_LogWrite, ESMF_SUCCESS, ESMF_FAILURE
   use ESMF         , only : ESMF_StateRemove, ESMF_StateGet, ESMF_RouteHandle
   use ESMF         , only : ESMF_Region_Flag, ESMF_FieldStatus_Flag, ESMF_LOGMSG_INFO
-  use ESMF         , only : ESMF_MAXSTR, ESMF_LOGMSG_ERROR, ESMF_LOGERR_PASSTHRU
+  use ESMF         , only : ESMF_MAXSTR, ESMF_LOGERR_PASSTHRU
   use ESMF         , only : ESMF_FieldBundleGet, ESMF_FieldBundleAdd, ESMF_FieldGet
   use ESMF         , only : ESMF_REGION_TOTAL, ESMF_END_ABORT, ESMF_ITEMORDER_ADDORDER
   use ESMF         , only : ESMF_LogFoundError, ESMF_FieldRegrid, ESMF_Finalize, ESMF_FIELDSTATUS_COMPLETE
   use ESMF         , only : ESMF_TERMORDER_SRCSEQ, operator(/=)
   use ESMF         , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use shr_kind_mod , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl
-
+  use shr_sys_mod  , only : shr_sys_abort
+  
   implicit none
   public
 
@@ -139,9 +140,7 @@ contains
                 write(msgString,'(A,a)') trim(string)//': '//trim(lfieldnamelist(n))," no data"
              endif
           else
-             call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-             rc = ESMF_FAILURE
-             return
+             call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
           endif
           call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
        end if
@@ -177,9 +176,7 @@ contains
     rc = ESMF_SUCCESS
 
     if (.not. dshr_fldbun_FldChk(FB, trim(fldname), rc=rc)) then
-       call ESMF_LogWrite(trim(subname)//": ERROR field "//trim(fldname)//" not in FB ", ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+       call shr_sys_abort(trim(subname)//": ERROR field "//trim(fldname)//" not in FB ")
     endif
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), field=lfield, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -187,20 +184,16 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (ungriddedUBound(1) > 0) then
        if (.not.present(fldptr2)) then
-          call ESMF_LogWrite(trim(subname)//": ERROR missing rank=2 array ", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR missing rank=2 array ", &
+               line=__LINE__, file=u_FILE_u)
        endif
        call ESMF_FieldGet(lfield, farrayptr=fldptr2, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        lrank = 2
     else
        if (.not.present(fldptr1)) then
-          call ESMF_LogWrite(trim(subname)//": ERROR missing rank=1 array ", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR missing rank=1 array ", &
+               line=__LINE__, file=u_FILE_u)
        endif
        call ESMF_FieldGet(lfield, farrayptr=fldptr1, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -339,9 +332,7 @@ contains
     call ESMF_FieldBundleGet(FB, fieldCount=fieldCount, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     if (fieldnum > fieldCount) then
-      call ESMF_LogWrite(trim(subname)//": ERROR fieldnum > fieldCount ", ESMF_LOGMSG_ERROR)
-      rc = ESMF_FAILURE
-      return
+      call shr_sys_abort(trim(subname)//": ERROR fieldnum > fieldCount ")
     endif
 
     allocate(lfieldnamelist(fieldCount))
@@ -377,9 +368,7 @@ contains
 
     call ESMF_FieldBundleGet(FB, fieldName=trim(fldname), isPresent=isPresent, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) then
-       call ESMF_LogWrite(trim(subname)//" Error checking field: "//trim(fldname), ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//" Error checking field: "//trim(fldname))
     endif
 
     if (isPresent) then
@@ -434,9 +423,7 @@ contains
           write(msgString,'(A,a)') trim(subname)//' '//trim(lstring)//': '//trim(fieldname)," no data"
        endif
     else
-       call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-       rc = ESMF_FAILURE
-       return
+       call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
     endif
     call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
@@ -505,9 +492,7 @@ contains
           endif
 
        else
-          call ESMF_LogWrite(trim(subname)//": ERROR rank not supported ", ESMF_LOGMSG_ERROR)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": ERROR rank not supported ")
        endif
        call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
     enddo
@@ -557,9 +542,7 @@ contains
        if (labort) then
           call ESMF_FieldGet(field, name=name, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_LogWrite(trim(subname)//": field "//trim(name)//" has no data not allocated ", ESMF_LOGMSG_ERROR, rc=rc)
-          rc = ESMF_FAILURE
-          return
+          call shr_sys_abort(trim(subname)//": field "//trim(name)//" has no data not allocated ", rc=rc)
        else
           call ESMF_LogWrite(trim(subname)//": WARNING data not allocated ", ESMF_LOGMSG_INFO, rc=rc)
        endif
@@ -568,8 +551,8 @@ contains
         if (chkerr(rc,__LINE__,u_FILE_u)) return
         if (ungriddedUBound(1) > 0) then
            if (.not.present(fldptr2)) then
-              call ESMF_LogWrite(trim(subname)//": ERROR missing rank=2 array for "//trim(name), &
-                   ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+              call shr_sys_abort(trim(subname)//": ERROR missing rank=2 array for "//trim(name), &
+                   line=__LINE__, file=u_FILE_u)
               rc = ESMF_FAILURE
               return
            endif
@@ -578,8 +561,8 @@ contains
            lrank = 2
         else
            if (.not.present(fldptr1)) then
-              call ESMF_LogWrite(trim(subname)//": ERROR missing rank=1 array for "//trim(name), &
-                   ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+              call shr_sys_abort(trim(subname)//": ERROR missing rank=1 array for "//trim(name), &
+                   line=__LINE__, file=u_FILE_u)
               rc = ESMF_FAILURE
               return
            endif


### PR DESCRIPTION
### Description of changes
Replace calls to esmf_logwrite which are abort messages with calls to shr_sys_abort which now includes the esmf_logwrite call.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

