### PR TITLE
shr_log_error and return up stack

### DIFF
--- a/datm/datm_datamode_cfsr_mod.F90
+++ b/datm/datm_datamode_cfsr_mod.F90
@@ -3,7 +3,6 @@ module datm_datamode_cfsr_mod
   use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_precip_mod   , only : shr_precip_partition_rain_snow_ramp
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_rhofw, shr_const_rdair
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr

--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -4,7 +4,7 @@ module datm_datamode_clmncep_mod
   use ESMF             , only : ESMF_STATEITEM_NOTFOUND, ESMF_LOGMSG_INFO, ESMF_StateGet, operator(/=)
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use shr_precip_mod   , only : shr_precip_partition_rain_snow_ramp
   use shr_const_mod    , only : shr_const_spval, shr_const_tkfrz, shr_const_pi
   use shr_const_mod    , only : shr_const_pstd, shr_const_stebol, shr_const_rdair
@@ -319,7 +319,8 @@ contains
 
     ! error check
     if (.not. associated(strm_wind) .or. .not. associated(strm_tbot)) then
-       call shr_sys_abort(trim(subname)//' ERROR: wind and tbot must be in streams for CLMNCEP')
+       call shr_log_error(trim(subname)//' ERROR: wind and tbot must be in streams for CLMNCEP', rc=rc)
+       return
     endif
 
     ! determine anidrmax (see below for use)
@@ -380,7 +381,8 @@ contains
        tbotmax = rtmp(2)
        if (mainproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
        if(tbotmax <= 0) then
-          call shr_sys_abort(subname//'ERROR: bad value in tbotmax')
+          call shr_log_error(subname//'ERROR: bad value in tbotmax', rc=rc)
+          return
        endif
 
        ! determine anidrmax (see below for use)
@@ -456,7 +458,8 @@ contains
           qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
           Sa_shum(n) = qsat
        else
-          call shr_sys_abort(subname//'ERROR: cannot compute shum')
+          call shr_log_error(subname//'ERROR: cannot compute shum', rc=rc)
+          return
        endif
        !--- density ---
        vp = (Sa_shum(n)*pbot) / (0.622_r8 + 0.378_r8 * Sa_shum(n))
@@ -493,7 +496,8 @@ contains
           swvdf = strm_swdn(n) * 0.50_r8
           Faxa_swvdf(n) = (1._r8 - ratio_rvrf)*swvdf
        else
-          call shr_sys_abort(subName//'ERROR: cannot compute short-wave down')
+          call shr_log_error(subName//'ERROR: cannot compute short-wave down', rc=rc)
+          return
        endif
 
        !--- swnet: a diagnostic quantity ---
@@ -517,7 +521,8 @@ contains
           Faxa_rainc(n) = strm_precn(n)*0.1_r8
           Faxa_rainl(n) = strm_precn(n)*0.9_r8
        else
-          call shr_sys_abort(subName//'ERROR: cannot compute rain and snow')
+          call shr_log_error(subName//'ERROR: cannot compute rain and snow', rc=rc)
+          return
        endif
 
        !--- split precip between rain & snow ---

--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -17,7 +17,7 @@ module datm_datamode_core2_mod
   use pio              , only : pio_closefile
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use shr_cal_mod      , only : shr_cal_date2julian
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_pi
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type
@@ -262,12 +262,14 @@ contains
     end if
 
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
-       call shr_sys_abort(trim(subname)//'ERROR: prec and swdn must be in streams for CORE2')
+       call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE2', rc=rc)
+       return
     endif
 
     if (trim(datamode) == 'CORE2_IAF' ) then
        if (.not. associated(strm_tarcf)) then
-          call shr_sys_abort(trim(subname)//'tarcf must be in an input stream for CORE2_IAF')
+          call shr_log_error(trim(subname)//'tarcf must be in an input stream for CORE2_IAF', rc=rc)
+          return
        endif
     endif
 

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -4,7 +4,6 @@ module datm_datamode_cplhist_mod
   use ESMF             , only : ESMF_StateItem_Flag
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
   use dshr_strdata_mod , only : shr_strdata_type

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -3,7 +3,6 @@ module datm_datamode_era5_mod
   use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_precip_mod   , only : shr_precip_partition_rain_snow_ramp
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_rhofw, shr_const_rdair
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr

--- a/datm/datm_datamode_gefs_mod.F90
+++ b/datm/datm_datamode_gefs_mod.F90
@@ -3,7 +3,6 @@ module datm_datamode_gefs_mod
   use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_precip_mod   , only : shr_precip_partition_rain_snow_ramp
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_rhofw, shr_const_rdair
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -5,7 +5,7 @@ module datm_datamode_jra_mod
   use ESMF             , only : ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND, operator(/=)
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use shr_cal_mod      , only : shr_cal_date2julian
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_pi, shr_const_rdair
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type
@@ -226,7 +226,7 @@ contains
 
     ! erro check
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
-       call shr_sys_abort(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA')
+       call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
     endif
 
   end subroutine datm_datamode_jra_init_pointers

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -227,6 +227,7 @@ contains
     ! erro check
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
        call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
+       return
     endif
 
   end subroutine datm_datamode_jra_init_pointers

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -18,7 +18,6 @@ module datm_datamode_simple_mod
   use pio              , only : pio_closefile
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_cal_mod      , only : shr_cal_date2julian
   use shr_const_mod    , only : shr_const_tkfrz, shr_const_pi
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -25,7 +25,8 @@ module datm_datamode_simple_mod
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, dshr_fldbun_regrid, chkerr
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
-
+  use shr_log_mod      , only : shr_log_error
+  
   implicit none
   private ! except
 
@@ -117,7 +118,9 @@ contains
        read (nu,nml=const_forcing_nml,iostat=ierr)
        close(nu)
        if (ierr > 0) then
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          rc = ierr
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
 
       bcasttmp = 0

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -9,7 +9,7 @@ module dglc_datamode_noevolve_mod
    use ESMF             , only : ESMF_VMGetCurrent, ESMF_VMBroadCast
    use NUOPC            , only : NUOPC_Advertise, NUOPC_IsConnected
    use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-   use shr_sys_mod      , only : shr_sys_abort
+   use shr_log_mod      , only : shr_log_error
    use shr_const_mod    , only : SHR_CONST_RHOICE, SHR_CONST_RHOSW, SHR_CONST_REARTH, SHR_CONST_TKFRZ
    use shr_const_mod    , only : SHR_CONST_SPVAL
    use shr_cal_mod      , only : shr_cal_datetod2string
@@ -204,7 +204,8 @@ contains
          if (.not. NUOPC_IsConnected(NStateImp(ns), fieldName=field_in_tsrf)) then
             ! NOTE: the field is connected ONLY if the MED->GLC entry is in the nuopc.runconfig file
             ! This restriction occurs even if the field was advertised
-            call shr_sys_abort(trim(subname)//": MED->GLC must appear in run sequence")
+            call shr_log_error(trim(subname)//": MED->GLC must appear in run sequence", rc=rc)
+            return
          end if
          call dshr_state_getfldptr(NStateImp(ns), field_in_tsrf, fldptr1=Sl_tsrf(ns)%ptr, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -309,8 +310,8 @@ contains
             ! Create pioid and pio_iodesc at the module level
             inquire(file=trim(model_datafiles(ns)), exist=exists)
             if (.not.exists) then
-               write(6,'(a)')' ERROR: model input file '//trim(model_datafiles(ns))//' does not exist'
-               call shr_sys_abort()
+               call shr_log_error(' ERROR: model input file '//trim(model_datafiles(ns))//' does not exist', rc=rc)
+               return
             end if
             rcode = pio_openfile(pio_subsystem, pioid, io_type, trim(model_datafiles(ns)), pio_nowrite)
             call pio_seterrorhandling(pioid, PIO_BCAST_ERROR)

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -28,9 +28,8 @@ module cdeps_dglc_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_cal_mod      , only : shr_cal_ymd2date
-  use shr_log_mod      , only : shr_log_setLogUnit
+  use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use shr_string_mod   , only : shr_string_listGetNum, shr_string_listGetName
 #ifdef CESMCOUPLED
   use shr_pio_mod      , only : shr_pio_getiosys, shr_pio_getiotype, shr_pio_getioformat
@@ -225,8 +224,8 @@ contains
       read (nu,nml=dglc_nml,iostat=ierr)
       close(nu)
       if (ierr > 0) then
-        write(logunit,'(a,i8)') 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-        call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+         call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+         return
       end if
 
       ! Determine number of ice sheets
@@ -284,7 +283,8 @@ contains
     if ( trim(datamode) == 'noevolve') then  ! read stream, no import data
       ! do nothing
     else
-      call shr_sys_abort(' ERROR illegal dglc datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal dglc datamode = '//trim(datamode), rc=rc)
+       return
     endif
 
     ! Allocate module variables
@@ -362,7 +362,8 @@ contains
     if (isPresent .and. isSet) then
        read(cvalue,*) restart_read
     else
-       call shr_sys_abort(subname//' ERROR: read restart flag must be present')
+       call shr_log_error(subname//' ERROR: read restart flag must be present', rc=rc)
+       return
     end if
 
     ! Get the time to interpolate the stream data to
@@ -390,8 +391,8 @@ contains
        if (my_task == main_task) then
           inquire(file=trim(model_meshfiles(ns)), exist=exists)
           if (.not.exists) then
-             write(logunit,'(a)')' ERROR: model_meshfile '//trim(model_meshfiles(ns))//' does not exist'
-             call shr_sys_abort(trim(subname)//' ERROR: model_meshfile '//trim(model_meshfiles(ns))//' does not exist')
+             call shr_log_error(trim(subname)//' ERROR: model_meshfile '//trim(model_meshfiles(ns))//' does not exist', rc=rc)
+             return
           end if
        endif
 

--- a/dice/dice_datamode_ssmi_mod.F90
+++ b/dice/dice_datamode_ssmi_mod.F90
@@ -5,7 +5,6 @@ module dice_datamode_ssmi_mod
   use ESMF                 , only : ESMF_ArrayCreate, ESMF_ArrayDestroy, ESMF_GridComp
   use NUOPC                , only : NUOPC_Advertise
   use shr_kind_mod         , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod          , only : shr_sys_abort
   use shr_const_mod        , only : shr_const_pi, shr_const_spval, shr_const_tkfrz, shr_const_latice
   use shr_frz_mod          , only : shr_frz_freezetemp
   use dshr_strdata_mod     , only : shr_strdata_get_stream_pointer, shr_strdata_type

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -26,8 +26,7 @@ module cdeps_dice_comp
   use NUOPC_Model          , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod         , only : r8=>shr_kind_r8, cxx=>shr_kind_cxx, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod        , only : shr_const_pi
-  use shr_log_mod         , only : shr_log_setLogUnit
-  use shr_sys_mod          , only : shr_sys_abort
+  use shr_log_mod          , only : shr_log_setLogUnit, shr_log_error
   use shr_cal_mod          , only : shr_cal_ymd2date, shr_cal_ymd2julian
   use dshr_mod             , only : dshr_model_initphase, dshr_init, dshr_mesh_init, dshr_check_restart_alarm
   use dshr_mod             , only : dshr_state_setscalar, dshr_set_runclock, dshr_log_clock_advance
@@ -212,8 +211,9 @@ contains
        read (nu,nml=dice_nml,iostat=ierr)
        close(nu)
        if (ierr > 0) then
-          write(logunit,*) 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          rc = ierr
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
 
        ! write namelist input to standard out
@@ -268,7 +268,8 @@ contains
     if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf') then
        if (my_task == main_task) write(logunit,*) ' dice datamode = ',trim(datamode)
     else
-       call shr_sys_abort(' ERROR illegal dice datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal dice datamode = '//trim(datamode), rc=rc)
+       return
     endif
 
     ! Advertise import and export fields

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -23,9 +23,8 @@ module cdeps_dlnd_comp
   use NUOPC_Model       , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod       , only : shr_sys_abort
   use shr_cal_mod       , only : shr_cal_ymd2date
-  use shr_log_mod       , only : shr_log_setLogUnit
+  use shr_log_mod       , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod  , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
   use dshr_strdata_mod  , only : shr_strdata_type, shr_strdata_advance, shr_strdata_get_stream_domain
   use dshr_strdata_mod  , only : shr_strdata_init_from_config
@@ -204,8 +203,9 @@ contains
        read (nu,nml=dlnd_nml,iostat=ierr)
        close(nu)
        if (ierr > 0) then
-          write(logunit,*) 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          rc = ierr
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
        bcasttmp = 0
        bcasttmp(1) = nx_global
@@ -248,7 +248,8 @@ contains
     if (trim(datamode) == 'copyall') then
        if (my_task == main_task) write(logunit,*) 'dlnd datamode = ',trim(datamode)
     else
-       call shr_sys_abort(' ERROR illegal dlnd datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal dlnd datamode = '//trim(datamode), rc=rc)
+       return
     end if
     call NUOPC_CompAttributeGet(gcomp, name='glc_nec', value=cvalue, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/docn/docn_datamode_aquaplanet_mod.F90
+++ b/docn/docn_datamode_aquaplanet_mod.F90
@@ -307,6 +307,7 @@ contains
 
     else
        call shr_log_error("ERROR: either sst_constant value or sst_option must be input", rc=rc)
+       return
     end if
 
   end subroutine docn_datamode_aquaplanet_advance

--- a/docn/docn_datamode_aquaplanet_mod.F90
+++ b/docn/docn_datamode_aquaplanet_mod.F90
@@ -4,7 +4,7 @@ module docn_datamode_aquaplanet_mod
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
@@ -167,7 +167,8 @@ contains
 
        ! Error checks
        if (sst_option < 1 .or. sst_option > 10) then
-          call shr_sys_abort ('docn_prescribed_sst: ERROR: sst_option must be between 1 and 10')
+          call shr_log_error ('docn_prescribed_sst: ERROR: sst_option must be between 1 and 10', rc=rc)
+          return
        end if
 
        ! Determine So_t in degrees C
@@ -305,7 +306,7 @@ contains
        So_t(:) = So_t(:) + TkFrz
 
     else
-       call shr_sys_abort("ERROR: either sst_constant value or sst_option must be input")
+       call shr_log_error("ERROR: either sst_constant value or sst_option must be input", rc=rc)
     end if
 
   end subroutine docn_datamode_aquaplanet_advance

--- a/docn/docn_datamode_copyall_mod.F90
+++ b/docn/docn_datamode_copyall_mod.F90
@@ -4,7 +4,6 @@ module docn_datamode_copyall_mod
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
-  use shr_sys_mod      , only : shr_sys_abort
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use dshr_strdata_mod , only : shr_strdata_type

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -4,7 +4,6 @@ module docn_datamode_cplhist_mod
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
-  use shr_sys_mod      , only : shr_sys_abort
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use dshr_strdata_mod , only : shr_strdata_type

--- a/docn/docn_datamode_iaf_mod.F90
+++ b/docn/docn_datamode_iaf_mod.F90
@@ -3,13 +3,11 @@ module docn_datamode_iaf_mod
   use ESMF             , only : ESMF_SUCCESS, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_State
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
-  use pio
 
   implicit none
   private ! except

--- a/docn/docn_datamode_multilev_dom_mod.F90
+++ b/docn/docn_datamode_multilev_dom_mod.F90
@@ -4,7 +4,7 @@ module docn_datamode_multilev_dom_mod
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal, shr_const_spval
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type, shr_strdata_get_stream_count
@@ -168,7 +168,8 @@ contains
        if (nlev_stream > 1) exit
     end do
     if (nlev_stream == 0) then
-       call shr_sys_abort(trim(subname)//" could not find vertical levels greater than 0")
+       call shr_log_error(trim(subname)//" could not find vertical levels greater than 0", rc=rc)
+       return
     end if
     allocate(stream_vlevs(nlev_stream))
     stream_vlevs(:) = sdat%pstrm(stream_index)%stream_vlevs(:)
@@ -210,7 +211,8 @@ contains
           end if
        end do
        if (.not. level_found) then
-          call shr_sys_abort(trim(subname)//" could not find level bounds for vertical interpolation")
+          call shr_log_error(trim(subname)//" could not find level bounds for vertical interpolation", rc=rc)
+          return
        end if
     end do
 

--- a/docn/docn_datamode_multilev_mod.F90
+++ b/docn/docn_datamode_multilev_mod.F90
@@ -3,7 +3,7 @@ module docn_datamode_multilev_mod
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal, shr_const_spval
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use dshr_strdata_mod , only : shr_strdata_get_stream_pointer, shr_strdata_type
@@ -175,7 +175,8 @@ contains
           end if
        end do
        if (.not. level_found) then
-          call shr_sys_abort("ERROR: could not find level bounds for vertical interpolation")
+          call shr_log_error("ERROR: could not find level bounds for vertical interpolation", rc=rc)
+          return
        end if
     end do
 

--- a/docn/docn_datamode_som_mod.F90
+++ b/docn/docn_datamode_som_mod.F90
@@ -6,7 +6,6 @@ module docn_datamode_som_mod
   use ESMF             , only : ESMF_LogWrite
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_const_mod    , only : shr_const_cpsw, shr_const_rhosw, shr_const_TkFrz
   use shr_const_mod    , only : shr_const_TkFrzSw, shr_const_latice, shr_const_ocn_ref_sal
   use shr_const_mod    , only : shr_const_zsrflyr, shr_const_pi

--- a/docn/docn_import_data_mod.F90
+++ b/docn/docn_import_data_mod.F90
@@ -69,7 +69,7 @@ contains
 
    !===============================================================================
    subroutine docn_get_import_fields(str, flds, rc)
-      use shr_sys_mod          , only : shr_sys_abort
+      use shr_log_mod          , only : shr_log_error
       ! input/output variables
       character(len=*)               , intent(in)  :: str     ! colon deliminted string to search
       character(len=*) , allocatable , intent(out) :: flds(:) ! memory will be allocate for flds
@@ -98,7 +98,8 @@ contains
          valid = .false.
       end if
       if (.not. valid) then
-         call shr_sys_abort("ERROR: invalid list = "//trim(str))
+         call shr_log_error("ERROR: invalid list = "//trim(str), rc=rc)
+         return
       end if
       ! get number of fields in a colon delimited string list
       nflds = 0

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -24,9 +24,8 @@ module cdeps_docn_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_cal_mod      , only : shr_cal_ymd2date
-  use shr_log_mod      , only : shr_log_setLogUnit
+  use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_diagnose, chkerr, memcheck
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance, shr_strdata_init_from_config
   use dshr_mod         , only : dshr_model_initphase, dshr_init, dshr_mesh_init, dshr_restart_read
@@ -232,7 +231,8 @@ contains
        close(nu)
        if (ierr > 0) then
           write(logunit,F00) 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
 
        ! write namelist input to standard out
@@ -308,7 +308,8 @@ contains
          trim(datamode) == 'multilev_dom') then        ! multilevel ocean input and sst export
        ! success do nothing
     else
-       call shr_sys_abort(' ERROR illegal docn datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal docn datamode = '//trim(datamode), rc=rc)
+       return
     endif
 
     ! Advertise docn fields
@@ -653,7 +654,8 @@ contains
           case('sst_aquap_analytic', 'sst_aquap_constant')
              ! Do nothing
           case default
-             call shr_sys_abort(subName//'datamode '//trim(datamode)//' not recognized')
+             call shr_log_error(subName//'datamode '//trim(datamode)//' not recognized', rc=rc)
+             return
           end select
           
        endif

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -25,9 +25,8 @@ module cdeps_drof_comp
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_const_mod    , only : SHR_CONST_SPVAL
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_cal_mod      , only : shr_cal_ymd2date
-  use shr_log_mod      , only : shr_log_setLogUnit
+  use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance, shr_strdata_get_stream_domain
   use dshr_strdata_mod , only : shr_strdata_init_from_config
@@ -199,8 +198,9 @@ contains
        read (nu,nml=drof_nml,iostat=ierr)
        close(nu)
        if (ierr > 0) then
-          write(logunit,*) 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          rc = ierr
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
 
        ! write namelist input to standard out
@@ -242,7 +242,8 @@ contains
     if (trim(datamode) == 'copyall') then
        if (mainproc) write(logunit,*) 'drof datamode = ',trim(datamode)
     else
-       call shr_sys_abort(' ERROR illegal drof datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal drof datamode = '//trim(datamode), rc=rc)
+       return
     end if
 
     call dshr_fldList_add(fldsExport, trim(flds_scalar_name))

--- a/dshr/dshr_dfield_mod.F90
+++ b/dshr/dshr_dfield_mod.F90
@@ -3,7 +3,7 @@ module dshr_dfield_mod
   use ESMF             , only : ESMF_State, ESMF_FieldBundle, ESMF_MAXSTR, ESMF_SUCCESS
   use ESMF             , only : ESMF_FieldBundleGet, ESMF_ITEMORDER_ADDORDER, ESMF_Field, ESMF_FieldGet
   use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_count, shr_strdata_get_stream_fieldbundle
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfieldn, dshr_field_getfldptr, dshr_fldbun_getFldPtr
   use dshr_methods_mod , only : chkerr
@@ -77,7 +77,8 @@ contains
     allocate(dfield_new, stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
     dfield_new%next => dfields
     dfields => dfield_new
@@ -154,7 +155,8 @@ contains
     allocate(dfield_new, stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
     dfield_new%next => dfields
     dfields => dfield_new
@@ -253,7 +255,8 @@ contains
     endif
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
 
     ! determine stream fldnames array
@@ -261,12 +264,14 @@ contains
     allocate(dfield_new%stream_indices(nflds), stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
     allocate(dfield_new%fldbun_indices(nflds), stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
     dfield_new%stream_indices(:) = 0
     dfield_new%fldbun_indices(:) = 0
@@ -358,7 +363,8 @@ contains
     endif
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
 
     ! determine stream fldnames array
@@ -367,12 +373,14 @@ contains
     allocate(dfield_new%stream_indices(nflds), stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
     allocate(dfield_new%fldbun_indices(nflds), stat=status)
     if (status /= 0) then
        write(msgstr,*)'allocation error ',__LINE__,':',__FILE__
-       call shr_sys_abort(msgstr)
+       call shr_log_error(msgstr, rc=rc)
+       return
     endif
 
     ! loop through the field names in strm_flds

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -88,7 +88,7 @@ contains
 
   subroutine dshr_model_initphase(gcomp, importState, exportState, clock, rc)
     use ESMF, only : ESMF_ClockIsCreated, ESMF_StateIsCreated
-    use shr_sys_mod, only : shr_sys_abort
+
     ! input/output variables
     type(ESMF_GridComp)   :: gcomp
     type(ESMF_State)      :: importState, exportState
@@ -100,7 +100,8 @@ contains
     rc = ESMF_SUCCESS
     ! To prevent an unused variable warning
     if(.not. (ESMF_StateIsCreated(importState) .or. ESMF_StateIsCreated(exportState) .or. ESMF_ClockIsCreated(clock))) then
-       call shr_sys_abort(trim(subname)//' state or clock not created')
+       call shr_log_error(trim(subname)//' state or clock not created', rc=rc)
+       return
     endif
 
     ! Switch to IPDv01 by filtering all other phaseMap entries

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -23,9 +23,8 @@ module cdeps_dwav_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_sys_mod      , only : shr_sys_abort
   use shr_cal_mod      , only : shr_cal_ymd2date
-  use shr_log_mod      , only : shr_log_setLogUnit
+  use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr, memcheck, dshr_state_diagnose
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance
   use dshr_strdata_mod , only : shr_strdata_init_from_config
@@ -198,7 +197,8 @@ contains
        close(nu)
        if (ierr > 0) then
           write(logunit,*) 'ERROR: reading input namelist, '//trim(nlfilename)//' iostat=',ierr
-          call shr_sys_abort(subName//': namelist read error '//trim(nlfilename))
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
        end if
 
        ! write namelist input to standard out
@@ -240,7 +240,8 @@ contains
     if (trim(datamode) == 'copyall') then
        if (my_task == main_task) write(logunit,*) 'dwav datamode = ',trim(datamode)
     else
-       call shr_sys_abort(' ERROR illegal dwav datamode = '//trim(datamode))
+       call shr_log_error(' ERROR illegal dwav datamode = '//trim(datamode), rc=rc)
+       return
     end if
     call dwav_comp_advertise(importState, exportState, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/share/shr_abort_mod.F90
+++ b/share/shr_abort_mod.F90
@@ -7,10 +7,7 @@ module shr_abort_mod
   ! (shr_sys_abort, shr_sys_backtrace). (This is for consistency with older code, from
   ! when these routines were defined in shr_sys_mod.)
 
-  use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
-
   use shr_kind_mod, only : shr_kind_in, shr_kind_cx
-  use shr_log_mod , only : s_logunit => shr_log_Unit
 
 #ifdef CPRNAG
   ! NAG does not provide this as an intrinsic, but it does provide modules
@@ -36,11 +33,12 @@ contains
   !===============================================================================
   subroutine shr_abort_abort(string,rc, line, file)
     use esmf, only : ESMF_LOGWRITE, ESMF_LOGMSG_ERROR, ESMF_FINALIZE, ESMF_END_ABORT
+    use shr_log_mod, only : shr_log_error
     ! Consistent stopping mechanism
 
     !----- arguments -----
     character(len=*)    , intent(in), optional :: string  ! error message string
-    integer(shr_kind_in), intent(in), optional :: rc      ! error code
+    integer(shr_kind_in), intent(inout), optional :: rc      ! error code
     integer(shr_kind_in), intent(in), optional :: line
     character(len=*), intent(in), optional :: file
 
@@ -58,9 +56,7 @@ contains
        write(local_string, *) trim(local_string), ' rc=',rc
     endif
 
-    call print_error_to_logs("ERROR", local_string)
-
-    call ESMF_LogWrite(local_string, ESMF_LOGMSG_ERROR, line=line, file=file)
+    call shr_log_error(local_string, rc=rc, line=line, file=file)
     
     call shr_abort_backtrace()
 
@@ -120,41 +116,7 @@ contains
 
 #endif
 
-    flush(error_unit)
-
   end subroutine shr_abort_backtrace
-  !===============================================================================
-
-  !===============================================================================
-  subroutine print_error_to_logs(error_type, message)
-    ! This routine prints error messages to s_logunit (which is standard output
-    ! for most tasks in CESM) and also to standard error if s_logunit is a
-    ! file.
-    !
-    ! It also flushes these output units.
-
-    character(len=*), intent(in) :: error_type, message
-
-    integer, allocatable :: log_units(:)
-
-    integer :: i
-
-    if (s_logunit == output_unit .or. s_logunit == error_unit) then
-       ! If the log unit number is standard output or standard error, just
-       ! print to that.
-       allocate(log_units(1), source=[s_logunit])
-    else
-       ! Otherwise print the same message to both the log unit and standard
-       ! error.
-       allocate(log_units(2), source=[error_unit, s_logunit])
-    end if
-
-    do i = 1, size(log_units)
-       write(log_units(i),*) trim(error_type), ": ", trim(message)
-       flush(log_units(i))
-    end do
-
-  end subroutine print_error_to_logs
   !===============================================================================
 
 end module shr_abort_mod

--- a/share/shr_log_mod.F90
+++ b/share/shr_log_mod.F90
@@ -75,13 +75,13 @@ contains
     character(len=SHR_KIND_CX)   :: shr_log_errMsg
     character(len=*), intent(in) :: file
     integer         , intent(in) :: line
-    
+
     !EOP
-    
+
     shr_log_errMsg = 'ERROR in '//trim(file)//' at line '//toString(line)
-    
+
   end function shr_log_errMsg
-  
+
   ! Create a message for an out of bounds error.
   pure function shr_log_OOBMsg(operation, bounds, idx) result(OOBMsg)
 
@@ -89,19 +89,19 @@ contains
     ! occurred. A string containing the subroutine name is ideal, but more
     ! generic descriptions such as "read", "modify", or "insert" could be used.
     character(len=*), intent(in) :: operation
-    
+
     ! Upper and lower bounds allowed for the operation.
     integer, intent(in) :: bounds(2)
-    
+
     ! Index at which access was attempted.
     integer, intent(in) :: idx
-    
+
     ! Output message
     character(len=:), allocatable :: OOBMsg
-    
+
     allocate(OOBMsg, source=(operation//": "//toString(idx)//" not in range ["//&
          toString(bounds(1))//", "//toString(bounds(2))//"]."))
-    
+
   end function shr_log_OOBMsg
 
   subroutine shr_log_setLogUnit(unit)
@@ -160,7 +160,7 @@ contains
        write(log_units(i),*) trim(local_string)
        flush(log_units(i))
     end do
-    
+
   end subroutine shr_log_error
-  
+
 end module shr_log_mod

--- a/share/shr_log_mod.F90
+++ b/share/shr_log_mod.F90
@@ -120,7 +120,9 @@ contains
 
   subroutine shr_log_error(string, rc, line, file)
     use esmf, only : ESMF_LOGWRITE, ESMF_LOGMSG_ERROR, ESMF_FINALIZE, ESMF_END_ABORT, ESMF_FAILURE, ESMF_SUCCESS
-    ! Consistent stopping mechanism
+    ! This routine prints error messages to shr_log_unit (which is standard output
+    ! for most tasks in CESM), to the ESMF PET files and to standard error if shr_log_unit is a
+    ! file.  Sets rc to ESMF_FAILURE on return.
 
     !----- arguments -----
     character(len=*)    , intent(in) :: string  ! error message string

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -390,7 +390,6 @@ contains
     type(ESMF_CalKind_Flag)      :: esmf_caltype    ! esmf calendar type
     character(CS)                :: calendar        ! calendar name
     integer                      :: ns              ! stream index
-    integer                      :: m               ! generic index
     character(CX)                :: fileName        ! generic file name
     integer                      :: nfld            ! loop stream field index
     type(ESMF_Field)             :: lfield          ! temporary

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -44,7 +44,8 @@ module dshr_strdata_mod
   use dshr_tinterp_mod , only : shr_tInterp_getCosz, shr_tInterp_getAvgCosz, shr_tInterp_getFactors
   use dshr_methods_mod , only : dshr_fldbun_getfldptr, dshr_fldbun_getfieldN, dshr_fldbun_fldchk, chkerr
   use dshr_methods_mod , only : dshr_fldbun_diagnose, dshr_fldbun_regrid, dshr_field_getfldptr
-
+  use shr_sys_mod      , only : shr_sys_abort
+  
   use pio              , only : file_desc_t, iosystem_desc_t, io_desc_t, var_desc_t
   use pio              , only : pio_openfile, pio_closefile, pio_nowrite
   use pio              , only : pio_seterrorhandling, pio_initdecomp, pio_freedecomp
@@ -170,14 +171,11 @@ contains
     else if (trim(name) .eq. 'model_ub') then
        shr_strdata_get_stream_fieldbundle = sdat%pstrm(ns)%fldbun_data(sdat%pstrm(ns)%stream_ub)
     else if (trim(name) .eq. 'stream_lb') then
-       call shr_log_error("should not be here", rc=rc)
-       return
+       call shr_sys_abort("should not be here")
     else if (trim(name) .eq. 'stream_ub') then
-       call shr_log_error("should not be here", rc=rc)
-       return
+       call shr_sys_abort("should not be here")
     else
-       call shr_log_error(trim(name)//' is not a recognized stream bundle name', rc=rc)
-       return
+       call shr_sys_abort(trim(name)//' is not a recognized stream bundle name')
     endif
 
   end function shr_strdata_get_stream_fieldbundle
@@ -429,7 +427,7 @@ contains
        if (filename /= 'none' .and. mainproc) then
           inquire(file=trim(filename),exist=fileExists)
           if (.not. fileExists) then
-             call shr_log_error(subName//"ERROR: file does not exist: "//trim(fileName))
+             call shr_log_error(subName//"ERROR: file does not exist: "//trim(fileName), rc=rc)
              return
           end if
        endif

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1001,7 +1001,8 @@ contains
                    ! case (3), abort
                    write(logunit,*) trim(subname),' ERROR: mismatch calendar ', &
                         trim(sdat%model_calendar),':',trim(sdat%stream(ns)%calendar)
-                   call shr_log_error(trim(subname)//' ERROR: mismatch calendar ')
+                   call shr_log_error(trim(subname)//' ERROR: mismatch calendar ', rc=rc)
+                   return
                 endif
              else ! calendars are the same
                 if(trim(sdat%model_calendar) == trim(shr_cal_gregorian)) then

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -893,7 +893,7 @@ contains
           if (.not. strm%file(k)%haveData) then
              call shr_stream_readtCoord(strm, k, isroot_task, rCode)
              if ( rCode /= 0 )then
-                call shr_log_error(trim(subName)//" ERROR: readtCoord1")
+                call shr_sys_abort(trim(subName)//" ERROR: readtCoord1")
              end if
           end if
           do n=1,strm%file(k)%nt

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -34,7 +34,7 @@ module dshr_stream_mod
 #ifdef CESMCOUPLED
   use shr_pio_mod      , only : shr_pio_getiosys, shr_pio_getiotype, shr_pio_getioformat
 #endif
-
+  use shr_sys_mod      , only : shr_sys_abort
   implicit none
   private ! default private
 

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -16,7 +16,7 @@ module dshr_stream_mod
   ! -------------------------------------------------------------------------------
 
   use shr_kind_mod     , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, cxx=>shr_kind_cxx, cx=>shr_kind_cx
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use shr_const_mod    , only : shr_const_cday
   use shr_string_mod   , only : shr_string_leftalign_and_convert_tabs, shr_string_parseCFtunit
   use shr_cal_mod      , only : shr_cal_noleap
@@ -210,7 +210,8 @@ contains
 
        Sdoc => parseFile(streamfilename, iostat=status)
        if (status /= 0) then
-          call shr_sys_abort("Could not parse file "//trim(streamfilename))
+          call shr_log_error("Could not parse file "//trim(streamfilename), rc=rc)
+          return
        endif
        streamlist => getElementsByTagname(Sdoc, "stream_info")
        nstrms = getLength(streamlist)
@@ -228,7 +229,8 @@ contains
              if (streamdat(i)%taxmode /= shr_stream_taxis_cycle   .and. &
                  streamdat(i)%taxmode /= shr_stream_taxis_extend  .and. &
                  streamdat(i)%taxmode /= shr_stream_taxis_limit) then
-                call shr_sys_abort("tintalgo must have a value of either cycle, extend or limit")
+                call shr_log_error("tintalgo must have a value of either cycle, extend or limit", rc=rc)
+                return
              end if
           endif
 
@@ -241,7 +243,8 @@ contains
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_consf    .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_consd    .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_none) then
-                call shr_sys_abort("mapaglo must have a value of either bilinear, redist, nn, consf or consd")
+                call shr_log_error("mapaglo must have a value of either bilinear, redist, nn, consf or consd", rc=rc)
+                return
              end if
           endif
 
@@ -253,7 +256,8 @@ contains
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_nearest .and. &
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_linear  .and. &
                  streamdat(i)%tInterpAlgo /= shr_stream_tinterp_coszen) then
-                call shr_sys_abort("tintalgo must have a value of either lower, upper, nearest, linear or coszen")
+                call shr_log_error("tintalgo must have a value of either lower, upper, nearest, linear or coszen", rc=rc)
+                return
              end if
           endif
 
@@ -266,21 +270,24 @@ contains
           if(associated(p)) then
              call extractDataContent(p, streamdat(i)%yearFirst)
           else
-             call shr_sys_abort("yearFirst must be provided")
+             call shr_log_error("yearFirst must be provided", rc=rc)
+             return
           endif
 
           p=> item(getElementsByTagname(streamnode, "year_last"), 0)
           if(associated(p)) then
              call extractDataContent(p, streamdat(i)%yearLast)
           else
-             call shr_sys_abort("yearLast must be provided")
+             call shr_log_error("yearLast must be provided", rc=rc)
+             return
           endif
 
           p=> item(getElementsByTagname(streamnode, "year_align"), 0)
           if(associated(p)) then
              call extractDataContent(p, streamdat(i)%yearAlign)
           else
-             call shr_sys_abort("yearAlign must be provided")
+             call shr_log_error("yearAlign must be provided", rc=rc)
+             return
           endif
 
           p=> item(getElementsByTagname(streamnode, "dtlimit"), 0)
@@ -297,14 +304,16 @@ contains
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%meshfile)
           else
-             call shr_sys_abort("mesh file name must be provided")
+             call shr_log_error("mesh file name must be provided", rc=rc)
+             return
           endif
 
           p => item(getElementsByTagname(streamnode, "vectors"), 0)
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%stream_vectors)
           else
-             call shr_sys_abort("stream vectors must be provided")
+             call shr_log_error("stream vectors must be provided", rc=rc)
+             return
           endif
 
           ! Determine name of vertical dimension
@@ -312,13 +321,15 @@ contains
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%lev_dimname)
           else
-             call shr_sys_abort("stream vertical level dimension name must be provided")
+             call shr_log_error("stream vertical level dimension name must be provided", rc=rc)
+             return
           endif
 
           ! Determine input data files
           p => item(getElementsByTagname(streamnode, "datafiles"), 0)
           if (.not. associated(p)) then
-             call shr_sys_abort("stream data files must be provided")
+             call shr_log_error("stream data files must be provided", rc=rc)
+             return
           endif
           filelist => getElementsByTagname(p,"file")
           streamdat(i)%nfiles = getLength(filelist)
@@ -428,7 +439,8 @@ contains
 
        ! Error check
        if (trim(streamdat(i)%taxmode) == shr_stream_taxis_extend .and. streamdat(i)%dtlimit < 1.e10) then
-          call shr_sys_abort(trim(subName)//" ERROR: if taxmode value is extend set dtlimit to 1.e30")
+          call shr_log_error(trim(subName)//" ERROR: if taxmode value is extend set dtlimit to 1.e30", rc=rc)
+          return
        end if
        ! initialize flag that stream has been set
        streamdat(i)%init = .true.
@@ -625,7 +637,8 @@ contains
     if( nstrms > 0 ) then
       allocate(streamdat(nstrms))
     else
-      call shr_sys_abort("no stream_info in config file "//trim(streamfilename))
+       call shr_log_error("no stream_info in config file "//trim(streamfilename), rc=rc)
+       return
     endif
 
     ! fill in non-default values for the streamdat attributes
@@ -647,21 +660,24 @@ contains
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%yearFirst,label="yearFirst"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("yearFirst must be provided")
+         call shr_log_error("yearFirst must be provided", rc=rc)
+         return
       endif
 
       if( ESMF_ConfigGetLen(config=CF, label="yearLast"//mystrm//':', rc=rc) > 0 ) then
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%yearLast,label="yearLast"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("yearLast must be provided")
+         call shr_log_error("yearLast must be provided", rc=rc)
+         return
       endif
 
       if( ESMF_ConfigGetLen(config=CF, label="yearAlign"//mystrm//':', rc=rc) > 0 ) then
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%yearAlign,label="yearAlign"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("yearAlign must be provided")
+         call shr_log_error("yearAlign must be provided", rc=rc)
+         return
       endif
 
       call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%dtlimit,label="dtlimit"//mystrm//':', rc=rc)
@@ -674,21 +690,24 @@ contains
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%meshfile,label="stream_mesh_file"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("stream_mesh_file must be provided")
+         call shr_log_error("stream_mesh_file must be provided", rc=rc)
+         return
       endif
 
       if( ESMF_ConfigGetLen(config=CF, label="stream_vectors"//mystrm//':', rc=rc) > 0 ) then
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%stream_vectors,label="stream_vectors"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("stream_vectors must be provided")
+         call shr_log_error("stream_vectors must be provided", rc=rc)
+         return
       endif
 
       if( ESMF_ConfigGetLen(config=CF, label="stream_lev_dimname"//mystrm//':', rc=rc) > 0 ) then
         call ESMF_ConfigGetAttribute(CF,value=streamdat(i)%lev_dimname,label="stream_lev_dimname"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else
-        call shr_sys_abort("stream_lev_dimname must be provided")
+         call shr_log_error("stream_lev_dimname must be provided", rc=rc)
+         return
       endif
 
       ! Get a list of stream file names
@@ -703,7 +722,8 @@ contains
         enddo
         deallocate(strm_tmpstrings)
       else
-        call shr_sys_abort("stream data files must be provided")
+         call shr_log_error("stream data files must be provided", rc=rc)
+         return
       endif
 
       ! Get name of stream variables in file and model
@@ -718,7 +738,8 @@ contains
         enddo
         deallocate(strm_tmpstrings)
       else
-        call shr_sys_abort("stream data variables must be provided")
+         call shr_log_error("stream data variables must be provided", rc=rc)
+         return
       endif
 
       ! Initialize stream pio
@@ -739,7 +760,8 @@ contains
 
       ! Error check
       if (trim(streamdat(i)%taxmode) == shr_stream_taxis_extend .and.  streamdat(i)%dtlimit < 1.e10) then
-        call shr_sys_abort(trim(subName)//" ERROR: if taxmode value is extend set dtlimit to 1.e30")
+         call shr_log_error(trim(subName)//" ERROR: if taxmode value is extend set dtlimit to 1.e30", rc=rc)
+         return
       end if
 
     enddo ! end loop nstrm
@@ -826,7 +848,6 @@ contains
        cycle = .false.
        limit = .true.
     else
-       write(strm%logunit,*) trim(subName),' ERROR: illegal taxMode = ',trim(strm%taxMode)
        call shr_sys_abort(trim(subName)//' ERROR: illegal taxMode = '//trim(strm%taxMode))
     endif
 
@@ -872,7 +893,7 @@ contains
           if (.not. strm%file(k)%haveData) then
              call shr_stream_readtCoord(strm, k, isroot_task, rCode)
              if ( rCode /= 0 )then
-                call shr_sys_abort(trim(subName)//" ERROR: readtCoord1")
+                call shr_log_error(trim(subName)//" ERROR: readtCoord1")
              end if
           end if
           do n=1,strm%file(k)%nt
@@ -886,7 +907,6 @@ contains
           end do
        end do A
        if (.not. strm%found_lvd) then
-          write(strm%logunit,F00)  "ERROR: LVD not found, all data is before yearFirst"
           call shr_sys_abort(trim(subName)//" ERROR: LVD not found, all data is before yearFirst")
        else
           !--- LVD is in or beyond yearFirst, verify it is not beyond yearLast ---

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -1255,6 +1255,7 @@ contains
     integer                :: old_handle    ! previous setting of pio error handling
     real(R8)               :: nsec          ! elapsed secs on calendar date
     real(R8),allocatable   :: tvar(:)
+    character(CX)          :: msg
     character(*),parameter :: subname = '(shr_stream_readTCoord) '
     !-------------------------------------------------------------------------------
 
@@ -1334,9 +1335,9 @@ contains
     ! if offset is not zero, adjust strm%file(k)%date(n) and strm%file(k)%secs(n)
     if (strm%offset /= 0) then
        if (size(strm%file(k)%date) /= size(strm%file(k)%secs)) then
-          write(strm%logunit,'(a,2i7)') trim(subname)//" Incompatable date and secs sizes",&
+          write(msg ,'(a,2i7)') trim(subname)//" Incompatable date and secs sizes",&
                size(strm%file(k)%date), size(strm%file(k)%secs)
-          call shr_sys_abort()
+          call shr_sys_abort(trim(msg))
        endif
        num = size(strm%file(k)%date)
        offin = strm%offset

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -306,7 +306,7 @@ contains
     lsize = size(lon)
     if (lsize < 1 .or. size(lat) /= lsize .or. size(cosz) /= lsize) then
        write(6,*)'ERROR: lsize,size(lat),size(cosz) =  ',lsize,size(lat),size(cosz)
-       call shr_log_error(subname//' ERROR: lon lat cosz sizes disagree', rc=rc)
+       call shr_sys_abort(subname//' ERROR: lon lat cosz sizes disagree', file=__FILE__,line=__LINE__)
        return
     endif
 

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -307,7 +307,6 @@ contains
     if (lsize < 1 .or. size(lat) /= lsize .or. size(cosz) /= lsize) then
        write(6,*)'ERROR: lsize,size(lat),size(cosz) =  ',lsize,size(lat),size(cosz)
        call shr_sys_abort(subname//' ERROR: lon lat cosz sizes disagree', file=__FILE__,line=__LINE__)
-       return
     endif
 
     call shr_cal_date2julian(ymd, tod, calday, calendar)

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -12,7 +12,7 @@ module dshr_tInterp_mod
   use shr_orb_mod      , only : shr_orb_cosz, shr_orb_decl, SHR_ORB_UNDEF_REAL
   use shr_const_mod    , only : SHR_CONST_PI
   use dshr_methods_mod , only : chkerr
-
+  use shr_sys_mod      , only : shr_sys_abort
   implicit none
   private ! except
 

--- a/streams/dshr_tinterp_mod.F90
+++ b/streams/dshr_tinterp_mod.F90
@@ -7,7 +7,7 @@ module dshr_tInterp_mod
   use ESMF             , only : ESMF_Time, ESMF_TimeInterval, ESMF_TimeIntervalGet
   use ESMF             , only : ESMF_SUCCESS, operator(<), operator(-), operator(>), operator(==)
   use shr_kind_mod     , only : i8=>shr_kind_i8, r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl, shr_kind_in
-  use shr_sys_mod      , only : shr_sys_abort
+  use shr_log_mod      , only : shr_log_error
   use shr_cal_mod      , only : shr_cal_timeSet, shr_cal_advDateInt, shr_cal_date2julian
   use shr_orb_mod      , only : shr_orb_cosz, shr_orb_decl, SHR_ORB_UNDEF_REAL
   use shr_const_mod    , only : SHR_CONST_PI
@@ -88,7 +88,8 @@ contains
     ! --- always check that 1 <= 2, although we could relax this requirement ---
     if (itime2 < itime1) then
        write(logunit,F01) ' ERROR: itime2 < itime1 D=',D1,S1,D2,S2
-       call shr_sys_abort(subName//' itime2 < itime1 ')
+       call shr_log_error(subName//' itime2 < itime1 ', rc=rc)
+       return
     endif
 
     f1 = -1.0
@@ -121,7 +122,8 @@ contains
        !--- check that itimein is between itime1 and itime2 ---
        if (itime2 < itimein .or. itime1 > itimein) then
           write(logunit,F02) ' ERROR illegal linear times: ',D1,S1,Din,Sin,D2,S2
-          call shr_sys_abort(subName//' illegal itimes ')
+          call shr_log_error(subName//' illegal itimes ', rc=rc)
+          return
        endif
        if (itime2 == itime1) then
           f1 = 0.5_r8
@@ -135,8 +137,8 @@ contains
           f1 = real(snum,r8)/real(sden,r8)
        endif
     else
-       if (debug > 0) write(logunit,F00) 'ERROR: illegal lalgo option: ',trim(lalgo)
-       call shr_sys_abort(subName//' illegal algo option '//trim(lalgo))
+       call shr_log_error(subName//' illegal algo option '//trim(lalgo), rc=rc)
+       return
     endif
 
     f2 = c1 - f1
@@ -145,8 +147,8 @@ contains
     if (f1 < c0-eps .or. f1 > c1+eps .or. &
          f2 < c0-eps .or. f2 > c1+eps .or. &
          abs(f1+f2-c1) > eps) then
-       if (debug > 0) write(logunit,F01) 'ERROR: illegal tInterp values ',f1,f2
-       call shr_sys_abort(subName//' illegal tInterp values ')
+       call shr_log_error(subName//' illegal tInterp values ', rc=rc)
+       return
     endif
 
     if (debug > 0) then
@@ -204,9 +206,11 @@ contains
 
     ! error checks
     if (eccen == SHR_ORB_UNDEF_REAL) then
-       call shr_sys_abort(subname//' ERROR in orb params for coszen tinterp')
+       call shr_log_error(subname//' ERROR in orb params for coszen tinterp', rc=rc)
+       return
     else if (modeldt < 1) then
-       call shr_sys_abort(subname//' ERROR: model dt < 1 for coszen tinterp')
+       call shr_log_error(subname//' ERROR: model dt < 1 for coszen tinterp', rc=rc)
+       return
     endif
 
     !-------------------------------------------------------------------------------
@@ -216,7 +220,10 @@ contains
     !--- get LB & UB dates ---
     call shr_cal_timeSet(reday1,ymd1,tod1,calendar)
     call shr_cal_timeSet(reday2,ymd2,tod2,calendar)
-    if (reday1 > reday2) call shr_sys_abort(subname//'ERROR: lower-bound > upper-bound')
+    if (reday1 > reday2) then
+       call shr_log_error(subname//'ERROR: lower-bound > upper-bound', rc=rc)
+       return
+    endif
 
     timeint = reday2-reday1
     call ESMF_TimeIntervalGet(timeint, s_i8=dtsec, rc=rc)
@@ -299,7 +306,8 @@ contains
     lsize = size(lon)
     if (lsize < 1 .or. size(lat) /= lsize .or. size(cosz) /= lsize) then
        write(6,*)'ERROR: lsize,size(lat),size(cosz) =  ',lsize,size(lat),size(cosz)
-       call shr_sys_abort(subname//' ERROR: lon lat cosz sizes disagree')
+       call shr_log_error(subname//' ERROR: lon lat cosz sizes disagree', rc=rc)
+       return
     endif
 
     call shr_cal_date2julian(ymd, tod, calday, calendar)


### PR DESCRIPTION
### Description of changes
replace shr_sys_abort with shr_log_error and return up the call tree with an error code. 
### Specific notes

After [discussion](https://github.com/ESCOMP/CMEPS/discussions/534) we decided to implement the write to both logs, but also return up the call tree rather than abort with a stack.   However some routines do not have a return code variable and will need further work to comply. 
CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

