### PR TITLE
update 1850 and HIST compset names

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -74,7 +74,7 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850_"   >clim_1850</value>
+      <value compset="^1850[CE]?_"   >clim_1850</value>
       <value compset="^2000_"   >clim_2000</value>
       <value compset="^2010_"   >clim_2010</value>
       <value compset="^SSP119_" >SSP1-1.9</value>
@@ -85,7 +85,7 @@
       <value compset="^SSP460_" >SSP4-6.0</value>
       <value compset="^SSP534_" >SSP5-3.4</value>
       <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST_"   >hist</value>
+      <value compset="^HIST[CE]?_"   >hist</value>
       <value compset="^20TR_"   >hist</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
@@ -100,14 +100,14 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850_"   >clim_1850</value>
+      <value compset="^1850[CE]?_"   >clim_1850</value>
       <value compset="^2000_"   >clim_2000</value>
       <value compset="^2010_"   >clim_2010</value>
       <value compset="^SSP126_" >SSP1-2.6</value>
       <value compset="^SSP245_" >SSP2-4.5</value>
       <value compset="^SSP370_" >SSP3-7.0</value>
       <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST_"   >hist</value>
+      <value compset="^HIST[CE]?_"   >hist</value>
       <value compset="^20TR_"   >hist</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
@@ -122,13 +122,13 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP2-4.5,SSP3-7.0,SSP5-8.5</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850_"   >clim_1850</value>
+      <value compset="^1850[CE]?_"   >clim_1850</value>
       <value compset="^2000_"   >clim_2000</value>
       <value compset="^2010_"   >clim_2010</value>
       <value compset="^SSP245_" >SSP2-4.5</value>
       <value compset="^SSP370_" >SSP3-7.0</value>
       <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST_"   >hist</value>
+      <value compset="^HIST[CE]?_"   >hist</value>
       <value compset="^20TR_"   >hist</value>
       <!-- Only needed for compsets with active land; only in DATM CLMNCEP mode -->
       <value compset="_SLND">none</value>
@@ -167,7 +167,7 @@
       <value compset="^SSP460_">SSP4-6.0</value>
       <value compset="^SSP534_">SSP5-3.4</value>
       <value compset="^SSP585_">SSP5-8.5</value>
-      <value compset="^HIST"   >20tr</value>
+      <value compset="^HIST[CE]?_"   >20tr</value>
       <value compset="^20TR"   >20tr</value>
       <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">omip.iaf</value>
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">omip.jra</value>

--- a/docn/cime_config/config_component.xml
+++ b/docn/cime_config/config_component.xml
@@ -159,19 +159,19 @@
       <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_c061106.nc</value>
       <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_c110526.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2021_c120422.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"		>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_1850_2021_c120422.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_1850_2021_c120422.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_1850_2021_c120422.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2021_c120422.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2021_c120422.nc</value>
-      <value compset="1850_"  grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2021_c120422.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"		>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_1850_2021_c120422.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_1850_2021_c120422.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_1850_2021_c120422.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2021_c120422.nc</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2021_c120422.nc</value>
+      <value compset="1850[CE]?_"  grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
       <value compset="1850S_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1850_clim_c20190125.nc</value>
-      <value compset="1850_"  grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
-      <value compset="1850_"  grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
-      <value compset="1850_"  grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
-      <value compset="1850_"  grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
-      <value compset="1850_"  grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
+      <value compset="1850[CE]?_"  grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
+      <value compset="1850[CE]?_"  grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
+      <value compset="1850[CE]?_"  grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
+      <value compset="1850[CE]?_"  grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
+      <value compset="1850[CE]?_"  grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
       <value compset="1950_"  grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
       <value compset="2010S_" grid="a%ne30np4.*_oi%oEC60to30v3"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
     </values>
@@ -206,7 +206,7 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values match="last">
-      <value compset="(AMIP_|20TR_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="(AMIP_|20TR_|HIST[CE]?_|5505_|PIPD_|%TSCH)">1850</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -228,7 +228,7 @@
     <valid_values></valid_values>
     <default_value>0</default_value>
     <values match="last">
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)">1850</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -244,7 +244,7 @@
     <valid_values></valid_values>
     <default_value>0</default_value>
     <values match="last">
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">2021</value>
+      <value compset="(AMIP_|HIST[CE]?_|20TR_|5505_|PIPD_|%TSCH)">2021</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
### Description of changes
Allow for C or E modifiers in date field of compset names for 1850 and HIST compsets. 
 
### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

