### PR TITLE
Additional minor revisions to #322

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -503,10 +503,10 @@
 
   <stream_entry name="CLMCRUJRA2024.Solar">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/mesh_cdf5.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/mesh_0.5x0.5_CRUJRAv2.5mask_cdf5_c20240916.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.Solr.%y.nc</file>
+      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.Solr.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>FSDS     Faxa_swdn</var>
@@ -534,10 +534,10 @@
 
   <stream_entry name="CLMCRUJRA2024.Precip">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/mesh_cdf5.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/mesh_0.5x0.5_CRUJRAv2.5mask_cdf5_c20240916.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.Prec.%y.nc</file>
+      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.Prec.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>PRECTmms Faxa_precn</var>
@@ -565,10 +565,10 @@
 
   <stream_entry name="CLMCRUJRA2024.TPQW">
     <stream_meshfile>
-      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/mesh_cdf5.nc</meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/mesh_0.5x0.5_CRUJRAv2.5mask_cdf5_c20240916.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/inputs/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.%y.nc</file>
+      <file first_year="1901" last_year="2023">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.%y.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>TBOT     Sa_tbot</var>


### PR DESCRIPTION
### Description of changes
- [x] mesh file needs time stamp; change the name to:
mesh_0.5x0.5_CRUJRAv2.5mask_cdf5_c20240916.nc
- [x] remove /inputs directory from path to the CRUJRA data in datm/cime_config/stream_definition_datm.xml
 
### Specific notes

Are changes expected to change answers (bfb, different to roundoff, more substantial):
No.

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
I will run aux_cdeps before this gets merged.
