### PR TITLE
make 1st timestep same as cam7

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -877,6 +877,8 @@ contains
           ! or later.
           if (mod(tod,delta_radsw) == 0 .and. stepno > 0) then
              nextsw_cday = julday + 1*dtime/shr_const_cday
+          elseif (stepno == 0) then
+             nextsw_cday = julday + (1+liradsw)*dtime/shr_const_cday
           else
              nextsw_cday = -1._r8
           end if


### PR DESCRIPTION
(cherry picked from commit feb289049efc4f23eb0f995bc2d86b04874022d3)

### Description of changes

Make `nextsw_cday_calc_cam7` compute `nextsw_cday` same way cam7 does on the first timestep.

### Specific notes
https://github.com/ESCOMP/CAM/blob/514ab5b9cdeed512bac884014e6c830e87bb0749/src/physics/rrtmgp/radiation.F90#L346C1-L378C1
In cam7 radiation.F90:

```
   case ('sw') ! do a shortwave heating calc this timestep?
      radiation_do = nstep == 0  .or.  iradsw == 1                     &
                    .or. (mod(nstep-1,iradsw) == 0  .and.  nstep /= 1) &
                    .or. nstep <= irad_always
```

However, in `atm_comp_nuopc.F90`

https://github.com/ESCOMP/CDEPS/blob/9e57b278de18cf69351bc693fe1988143e859fa7/datm/atm_comp_nuopc.F90#L878C1-L880C15

```
          if (mod(tod,delta_radsw) == 0 .and. stepno > 0) then
             nextsw_cday = julday + 1*dtime/shr_const_cday
          else
             nextsw_cday = -1._r8
          end if
```

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Resolves #333

Are there dependencies on other component PRs (if so list):

No

Are changes expected to change answers (bfb, different to roundoff, more substantial):

No. (components handle the 0th timestep themselves), plus f.e. for CTSM, without `fates_radiation_model='twostream'`

Any User Interface Changes (namelist or namelist defaults changes):

No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

`aux_clm_noresm`,`prealpha_noresm`,`aux_noresm_blom`. 
Testslits can be viewed at the [NorESM repos](https://github.com/NorESMhub)


Hashes used for testing:

