### PR TITLE
Allow anomaly forcings with any DATM

### DIFF
--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -89,18 +89,6 @@ def _get_neon_data_availability(case, neonsite):
     expect(newestdate, "No tower data found on server for NEON site {}".format(neonsite))
     return None
 
-####################################################################################
-def _check_datm_af_mismatch(anomaly_forcing, datm_mode):
-####################################################################################
-
-    # CMIP5 and CMIP6 anomalies were only generated relative to GSWP3v1
-    is_cmip5_or_6 = any(x in anomaly_forcing for x in ["cmip5", "cmip6"])
-    if is_cmip5_or_6 and datm_mode != "CLMGSWP3v1":
-        raise SystemExit(
-            "CMIP5 and CMIP6 anomalies were only generated relative for DATM_MODE CLMGSWP3v1."
-            " To fix this error, do: ./xmlchange DATM_MODE=CLMGSWP3v1"
-        )
-
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -236,7 +224,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     # Set anomaly forcing in datm.streams.xml
     anomaly_forcing = nmlgen.get_value("anomaly_forcing")
     if anomaly_forcing[0] is not None and anomaly_forcing[0] != "none":
-        _check_datm_af_mismatch(anomaly_forcing[0], datm_mode)
         streamlist += anomaly_forcing
 
     # Generate datm.streams.xml

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -62,6 +62,16 @@
       <option name="comment">Check that SSP126 compset works right</option>
     </options>
   </test>
+  <test compset="SSP126_DATM%CRUJRA2024_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
+      <machine name="betzy" compiler="intel" category="aux_cdeps_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+      <option name="comment">Check that SSP126 compset works right with CRU-JRA</option>
+    </options>
+  </test>
   <test compset="SSP245_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>


### PR DESCRIPTION
### Description of changes

Removes check that `datm_mode` be GSWP3v1.

### Specific notes

**Contributors other than yourself, if any:** None

**CDEPS Issues Fixed:**
- Resolves #339

**Are there dependencies on other component PRs (if so list):** No

**Are changes expected to change answers (bfb, different to roundoff, more substantial):** No

**Any User Interface Changes (namelist or namelist defaults changes):** No

**Testing performed (e.g. aux_cdeps, CESM prealpha, etc):**
- `aux_cdeps` tests all pass compared to cdeps1.0.74

**Hashes used for testing:** 0a59658

