### PR TITLE
Use 512-length filenames

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -26,6 +26,7 @@ module cdeps_datm_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, setVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod     , only : cx=>shr_kind_cx
   use shr_const_mod    , only : shr_const_cday
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
@@ -103,8 +104,8 @@ module cdeps_datm_comp
   character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
-  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
   integer                      :: iradsw = 0                          ! radiation interval (input namelist)
   logical                      :: nextsw_cday_calc_cam7               ! true => use logic appropriate to cam7 (and later) for calculating nextsw_cday
   character(CL)                :: factorFn_mesh = 'null'              ! file containing correction factors mesh
@@ -294,15 +295,15 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, anomaly_forcing, CL*8, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, factorFn_data, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, factorFn_mesh, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, nextsw_cday_calc, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -119,7 +119,7 @@ module cdeps_datm_comp
   character(CL)                :: bias_correct = nullstr              ! send bias correction fields to coupler
   character(CL)                :: anomaly_forcing(8) = nullstr        ! send anomaly forcing fields to coupler
 
-  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global                           ! global nx
   integer                      :: ny_global                           ! global ny
   logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -101,8 +101,8 @@ module cdeps_datm_comp
   character(len=*) , parameter :: nullstr = 'null'
 
   ! datm_in namelist input
-  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
-  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CX)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
   character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
   character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -29,14 +29,4 @@
     </options>
   </test>
 
-  <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3">
-    <machines>
-      <machine name="derecho" compiler="gnu" category="aux_cdeps"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-    
-  
 </testlist>

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -28,6 +28,7 @@ module cdeps_dglc_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod     , only : cx=>shr_kind_cx
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use shr_string_mod   , only : shr_string_listGetNum, shr_string_listGetName
@@ -95,10 +96,10 @@ module cdeps_dglc_comp
   character(CL)     :: case_name
 
   ! dglc_in namelist input
-  character(CL) :: streamfilename = nullstr    ! filename to obtain stream info from
-  character(CL) :: nlfilename = nullstr        ! filename to obtain namelist info from
+  character(CX) :: streamfilename = nullstr    ! filename to obtain stream info from
+  character(CX) :: nlfilename = nullstr        ! filename to obtain namelist info from
   character(CL) :: datamode = nullstr          ! flags physics options wrt input data
-  character(CL) :: restfilm = nullstr          ! model restart file namelist
+  character(CX) :: restfilm = nullstr          ! model restart file namelist
   logical       :: skip_restart_read = .false. ! true => skip restart read in continuation run
   logical       :: export_all = .false.        ! true => export all fields, do not check connected or not
 
@@ -262,7 +263,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, model_meshfiles, CL*max_icesheets, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -25,6 +25,7 @@ module cdeps_dice_comp
   use NUOPC_Model          , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model          , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod         , only : r8=>shr_kind_r8, cxx=>shr_kind_cxx, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod         , only : cx=>shr_kind_cx
   use shr_const_mod        , only : shr_const_pi
   use shr_log_mod          , only : shr_log_setLogUnit, shr_log_error
   use shr_cal_mod          , only : shr_cal_ymd2date, shr_cal_ymd2julian
@@ -81,13 +82,13 @@ module cdeps_dice_comp
   character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode                            ! flags physics options wrt input data
-  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
   real(R8)                     :: flux_swpf                           ! short-wave penatration factor
   real(R8)                     :: flux_Qmin                           ! bound on melt rate
   logical                      :: flux_Qacc                           ! activates water accumulation/melt wrt Q
   real(R8)                     :: flux_Qacc0                          ! initial water accumulation value
-  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
   logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
@@ -250,11 +251,11 @@ contains
 
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, bcasttmp, 3, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -79,8 +79,8 @@ module cdeps_dice_comp
   character(*) , parameter     :: nullstr = 'null'
 
   ! dice_in namelist input
-  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
-  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CX)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode                            ! flags physics options wrt input data
   character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
   character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -23,6 +23,7 @@ module cdeps_dlnd_comp
   use NUOPC_Model       , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod      , only : cx=>shr_kind_cx
   use shr_cal_mod       , only : shr_cal_ymd2date
   use shr_log_mod       , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod  , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
@@ -71,13 +72,13 @@ module cdeps_dlnd_comp
 
   ! dlnd_in namelist input
   character(CL)            :: dataMode = nullstr                  ! flags physics options wrt input data
-  character(CL)            :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)            :: model_maskfile = nullstr            ! full pathname to obtain mask from
-  character(CL)            :: streamfilename                      ! filename to obtain stream info from
-  character(CL)            :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)            :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)            :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)            :: streamfilename                      ! filename to obtain stream info from
+  character(CX)            :: nlfilename = nullstr                ! filename to obtain namelist info from
 !  not currently used
 !  logical                  :: force_prognostic_true = .false.     ! if true set prognostic true
-  character(CL)            :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)            :: restfilm = nullstr                  ! model restart file namelist
   integer                  :: nx_global                           ! global nx dimension of model mesh
   integer                  :: ny_global                           ! global ny dimension of model mesh
   logical                  :: skip_restart_read = .false.         ! true => skip restart read in continuation
@@ -219,11 +220,11 @@ contains
 
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, bcasttmp, 3, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -24,6 +24,7 @@ module cdeps_docn_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod     , only : cx=>shr_kind_cx
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_diagnose, chkerr, memcheck
@@ -96,11 +97,11 @@ module cdeps_docn_comp
   character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: datamode = nullstr                  ! flags physics options wrt input data
-  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
   real(R8)                     :: sst_constant_value                  ! sst constant value
   integer                      :: aquap_option                        ! if aqua-planet mode, option to use
-  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
   logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
@@ -262,11 +263,11 @@ contains
 
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, import_data_fields, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -94,8 +94,8 @@ module cdeps_docn_comp
   character(*) , parameter     :: nullstr = 'null'
 
   ! docn_in namelist input
-  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
-  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CX)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: datamode = nullstr                  ! flags physics options wrt input data
   character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
   character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -68,8 +68,8 @@ module cdeps_drof_comp
   character(CL)                :: case_name                           ! case name
   character(*) , parameter     :: nullstr = 'null'
                                                                       ! drof_in namelist input
-  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
-  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CX)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
   character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
   character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -24,6 +24,7 @@ module cdeps_drof_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod     , only : cx=>shr_kind_cx
   use shr_const_mod    , only : SHR_CONST_SPVAL
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
@@ -70,9 +71,9 @@ module cdeps_drof_comp
   character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
-  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
-  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
   logical                      :: skip_restart_read = .false.         ! true => skip restart read
@@ -225,11 +226,11 @@ contains
 
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, bcasttmp, 3, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -23,6 +23,7 @@ module cdeps_dwav_comp
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_kind_mod     , only : cx=>shr_kind_cx
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr, memcheck, dshr_state_diagnose
@@ -71,9 +72,9 @@ module cdeps_dwav_comp
   character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
   character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
-  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
-  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
-  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CX)                :: restfilm = nullstr                  ! model restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
   logical                      :: skip_restart_read = .false.         ! true => skip restart read
@@ -223,11 +224,11 @@ contains
 
     call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_meshfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, model_maskfile, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, restfilm, CX, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, bcasttmp, 3, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -69,8 +69,8 @@ module cdeps_dwav_comp
   character(*) , parameter     :: nullstr = 'null'
 
   ! dwav_in namelist input
-  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
-  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CX)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CX)                :: nlfilename = nullstr                ! filename to obtain namelist info from
   character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
   character(CX)                :: model_meshfile = nullstr            ! full pathname to model meshfile
   character(CX)                :: model_maskfile = nullstr            ! full pathname to obtain mask from


### PR DESCRIPTION
### Description of changes
Increases filename length in many places from 256 (`CL`) to 512 (`CX`). This was necessary to support a new test that ended up generating very long file paths (see ESCOMP/CTSM#3292).

I'm planning to merge in the latest CDEPS tag once I get an initial review.

### Specific notes

**Contributors other than yourself, if any:** None

**CDEPS Issues Fixed:**
- Resolves #344

**Are there dependencies on other component PRs (if so list):** No

**Are changes expected to change answers (bfb, different to roundoff, more substantial):** bfb

**Any User Interface Changes (namelist or namelist defaults changes):** No

**Testing performed (e.g. aux_cdeps, CESM prealpha, etc):** 

One CTSM test that was previously failing due to long file paths now passes.

`aux_cdeps` tests all pass except two that aren't the result of this work:
- `SMS_D_Ld3.f10_f10_ais8gris4_mg37.DATAMODELTEST.derecho_gnu`: fails because `DATAMODELTEST` isn't a valid compset name (This is issue #344)
- `SMS_Ld3.f19_g17_rx1.2000_SATM_SLND_SICE_SOCN_DROF%NYF_SGLC_SWAV.derecho_intel`: fails with "ERROR: no alias f19_g17_rx1 defined" (This is issue #345)

**Hashes used for testing:** 0595593

- [x] Remove the DATAMODEL test from: dglc/cime_config/testdefs/testlist_dglc.xml
- [x] Test after merging latest CDEPS tag