### PR TITLE
Fix rDateIn >= rDategvd error messages in dshr_stream_mod.F90

### DIFF
--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -1035,8 +1035,8 @@ contains
 
     else if (strm%found_gvd .and. rDateIn >= rDategvd) then
        if (limit) then
-          write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn gt rDategvd",rDateIn,rDategvd
-          call shr_sys_abort(trim(subName)//" ERROR: rDateIn gt rDategvd limit true")
+          write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn ge rDategvd",rDateIn,rDategvd
+          call shr_sys_abort(trim(subName)//" ERROR: rDateIn ge rDategvd limit true")
        endif
 
        if (.not.cycle) then
@@ -1135,8 +1135,8 @@ contains
 
           if (strm%found_gvd .and. rDateIn >= rDategvd) then
              if (limit) then
-                write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn gt rDategvd",rDateIn,rDategvd
-                call shr_sys_abort(trim(subName)//" ERROR: rDateIn gt rDategvd limit true")
+                write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn ge rDategvd",rDateIn,rDategvd
+                call shr_sys_abort(trim(subName)//" ERROR: rDateIn ge rDategvd limit true")
              endif
 
              if (.not.cycle) then

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -1035,8 +1035,8 @@ contains
 
     else if (strm%found_gvd .and. rDateIn >= rDategvd) then
        if (limit) then
-          write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn ge rDategvd",rDateIn,rDategvd
-          call shr_sys_abort(trim(subName)//" ERROR: rDateIn ge rDategvd limit true")
+          write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn >= rDategvd",rDateIn,rDategvd
+          call shr_sys_abort(trim(subName)//" ERROR: rDateIn >= rDategvd limit true")
        endif
 
        if (.not.cycle) then
@@ -1135,8 +1135,8 @@ contains
 
           if (strm%found_gvd .and. rDateIn >= rDategvd) then
              if (limit) then
-                write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn ge rDategvd",rDateIn,rDategvd
-                call shr_sys_abort(trim(subName)//" ERROR: rDateIn ge rDategvd limit true")
+                write(strm%logunit,*) trim(subName)," ERROR: limit on and rDateIn >= rDategvd",rDateIn,rDategvd
+                call shr_sys_abort(trim(subName)//" ERROR: rDateIn >= rDategvd limit true")
              endif
 
              if (.not.cycle) then


### PR DESCRIPTION
Fix typos in error messages to match rDateIn >= rDategvd in if test clause

### Description of changes

Fix typos in error messages to match rDateIn >= rDategvd in if test clause

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):
no

Any User Interface Changes (namelist or namelist defaults changes):
only error log messages

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
none

Hashes used for testing:

