### PR TITLE
DGLC grid updates for new gris4 mesh

### DIFF
--- a/dglc/cime_config/namelist_definition_dglc.xml
+++ b/dglc/cime_config/namelist_definition_dglc.xml
@@ -41,8 +41,8 @@
     <input_pathname>abs</input_pathname>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">$DIN_LOC_ROOT/glc/cism/Antarctica/ISMIP6_Antarctica_8km.init.c210908.nc:$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c171126.nc</value>
-      <value glc_grid="gris4" >$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c171126.nc</value>
+      <value glc_grid="ais8:gris4">$DIN_LOC_ROOT/glc/cism/Antarctica/ISMIP6_Antarctica_8km.init.c210908.nc:$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c251001.nc</value>
+      <value glc_grid="gris4" >$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c251001.nc</value>
       <value glc_grid="ais8"  >$DIN_LOC_ROOT/glc/cism/Antarctica/ISMIP6_Antarctica_8km.init.c210908.nc</value>
     </values>
     <desc>
@@ -85,9 +85,9 @@
     <category>streams</category>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">704,416</value>
+      <value glc_grid="ais8:gris4">704,421</value>
       <value glc_grid="ais8">704</value>
-      <value glc_grid="gris4">416</value>
+      <value glc_grid="gris4">421</value>
       <value glc_grid="gris20">76</value>
     </values>
     <desc>
@@ -101,9 +101,9 @@
     <category>streams</category>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">576,704</value>
+      <value glc_grid="ais8:gris4">576,721</value>
       <value glc_grid="ais8">576</value>
-      <value glc_grid="gris4">704</value>
+      <value glc_grid="gris4">721</value>
       <value glc_grid="gris20">141</value>
     </values>
     <desc>


### PR DESCRIPTION
### Description of changes

Updates to the DGLC namelist to point to the new grid files for the gris4 grid.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list): This fulfills a dependency from ccs_config_cesm1.0.63

Are changes expected to change answers (bfb, different to roundoff, more substantial): They will change answers in any compset using the gris4 grid and DGLC

Any User Interface Changes (namelist or namelist defaults changes): These are namelist defaults changes for gris4 grids

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Ran the test Chris was having trouble with. 
Before: SMS_Ld2.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio (Overall: FAIL)
After: SMS_Ld2.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio (Overall: PASS)

Hashes used for testing:

