### PR TITLE
new datm optional streams 

### DIFF
--- a/datm/CMakeLists.txt
+++ b/datm/CMakeLists.txt
@@ -6,7 +6,11 @@ set(SRCFILES atm_comp_nuopc.F90
              datm_datamode_jra_mod.F90
              datm_datamode_gefs_mod.F90
              datm_datamode_era5_mod.F90
-             datm_datamode_simple_mod.F90)
+             datm_datamode_simple_mod.F90
+             datm_pres_aero_mod.F90
+             datm_pres_co2_mod.F90
+             datm_pres_ndep_mod.F90
+             datm_pres_o3_mod.F90)
 
 
 foreach(FILE ${SRCFILES})

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -68,6 +68,22 @@ module cdeps_datm_comp
   use datm_datamode_simple_mod  , only : datm_datamode_simple_init_pointers
   use datm_datamode_simple_mod  , only : datm_datamode_simple_advance
 
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_advertise
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_init_pointers
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_advance
+
+  use datm_pres_aero_mod        , only : datm_pres_aero_advertise
+  use datm_pres_aero_mod        , only : datm_pres_aero_init_pointers
+  use datm_pres_aero_mod        , only : datm_pres_aero_advance
+
+  use datm_pres_o3_mod          , only : datm_pres_o3_advertise
+  use datm_pres_o3_mod          , only : datm_pres_o3_init_pointers
+  use datm_pres_o3_mod          , only : datm_pres_o3_advance
+
+  use datm_pres_co2_mod         , only : datm_pres_co2_advertise
+  use datm_pres_co2_mod         , only : datm_pres_co2_init_pointers
+  use datm_pres_co2_mod         , only : datm_pres_co2_advance
+
   implicit none
   private ! except
 
@@ -139,9 +155,9 @@ module cdeps_datm_comp
   logical                      :: diagnose_data = .true.
   integer          , parameter :: main_task   = 0                   ! task number of main task
 #ifdef CESMCOUPLED
-  character(*)     , parameter :: modName       = "(atm_comp_nuopc)"
+  character(*)     , parameter :: modName = "(atm_comp_nuopc)"
 #else
-  character(*)     , parameter :: modName       = "(cdeps_datm_comp)"
+  character(*)     , parameter :: modName = "(cdeps_datm_comp)"
 #endif
 
   character(*), parameter :: u_FILE_u = &
@@ -156,7 +172,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
+    character(len=*),parameter  :: subname = modName//':(SetServices) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -212,10 +228,10 @@ contains
     integer           :: bcasttmp(10)
     character(CL)     :: nextsw_cday_calc
     type(ESMF_VM)     :: vm
-    character(len=*),parameter :: subname=trim(modName) // ':(InitializeAdvertise) '
-    character(*)    ,parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
-    character(*)    ,parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
-    character(*)    ,parameter :: F02 = "('(" // trim(modName) // ") ',a,l6)"
+    character(len=*),parameter :: subname = modName // ':(InitializeAdvertise) '
+    character(*)    ,parameter :: F00 = "('(" // modName // ") ',8a)"
+    character(*)    ,parameter :: F01 = "('(" // modName // ") ',a,2x,i8)"
+    character(*)    ,parameter :: F02 = "('(" // modName // ") ',a,l6)"
     !-------------------------------------------------------------------------------
 
     namelist / datm_nml / &
@@ -370,23 +386,33 @@ contains
        return
     endif
 
-    ! Advertise datm fields
+    ! Advertise fields that ARE NOT datamode specific
+    if (flds_co2) then
+       call datm_pres_co2_advertise(fldsExport, datamode)
+    end if
+    if (flds_preso3) then
+       call datm_pres_o3_advertise(fldsExport)
+    end if
+    if (flds_presndep) then
+       call datm_pres_ndep_advertise(fldsExport)
+    end if
+    if (flds_presaero) then
+       call datm_pres_aero_advertise(fldsExport)
+    end if
+
+    ! Advertise fields that ARE datamode specific
     select case (trim(datamode))
     case ('CORE2_NYF', 'CORE2_IAF')
-       call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
-       call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CLMNCEP')
-       call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, flds_preso3, rc)
+       call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CPLHIST')
-       call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('ERA5')
        call datm_datamode_era5_advertise(exportState, fldsExport, flds_scalar_name, rc)
@@ -429,7 +455,7 @@ contains
     real(R8)                :: orbObliqr     ! orb obliquity (radians)
     logical                 :: isPresent, isSet
     real(R8)                :: dayofYear
-    character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
+    character(len=*), parameter :: subname = modName//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -529,7 +555,7 @@ contains
     real(R8)                :: orbLambm0     ! orb mean long of perhelion (radians)
     real(R8)                :: orbObliqr     ! orb obliquity (radians)
     real(R8)                :: dayofYear
-    character(len=*),parameter  :: subname=trim(modName)//':(ModelAdvance) '
+    character(len=*),parameter  :: subname = modName//':(ModelAdvance) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -603,7 +629,7 @@ contains
 
     ! local variables
     logical :: first_time = .true.
-    character(len=CL) :: rpfile        
+    character(len=CL) :: rpfile
     character(*), parameter :: subName = '(datm_comp_run) '
     !-------------------------------------------------------------------------------
 
@@ -616,11 +642,35 @@ contains
     !--------------------
 
     if (first_time) then
+       ! Initialize data pointers for co2 (non datamode specific)
+       if (flds_co2) then
+          call datm_pres_co2_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for o3 (non datamode specific)
+       if (flds_preso3) then
+          call datm_pres_o3_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for nitrogen deposition (non datamode specific and use of ungridded dimensions)
+       if (flds_presndep) then
+          call datm_pres_ndep_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for prescribed aerosols (non datamode specific and use of ungridded dimensions)
+       if (flds_presaero) then
+          call datm_pres_aero_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
        ! Initialize dfields
        call datm_init_dfields(rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       ! Initialize datamode module ponters
+       ! Initialize datamode module pointers
        select case (trim(datamode))
        case('CORE2_NYF','CORE2_IAF')
           call datm_datamode_core2_init_pointers(exportState, sdat, datamode, factorfn_mesh, factorfn_data, rc)
@@ -650,7 +700,10 @@ contains
           call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'read', rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           select case (trim(datamode))
-          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
+               'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
+               'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+               'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
              call dshr_restart_read(restfilm, rpfile, logunit, my_task, mpicom, sdat, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           case default
@@ -675,6 +728,24 @@ contains
     call shr_strdata_advance(sdat, target_ymd, target_tod, logunit, 'datm', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_advance')
+
+    ! Update export state for non data-mode specific fields
+    if (flds_co2) then
+       call datm_pres_co2_advance()
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if (flds_preso3) then
+       call datm_pres_o3_advance()
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if (flds_presndep) then
+       call datm_pres_ndep_advance()
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+    if (flds_presaero) then
+       call datm_pres_aero_advance()
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
 
     ! copy all fields from streams to export state as default
     ! This automatically will update the fields in the export state
@@ -718,9 +789,12 @@ contains
        call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'write', rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        select case (trim(datamode))
-       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
-          call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, target_ymd, target_tod, logunit, &
-               my_task, sdat, rc)
+       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
+            'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
+            'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+            'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+          call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, &
+               target_ymd, target_tod, logunit, my_task, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case default
           call shr_log_error(subName//'datamode '//trim(datamode)//' not recognized', rc=rc)
@@ -754,13 +828,10 @@ contains
       integer, intent(out)   :: rc
 
       ! local variables
-      integer                         :: n
-      character(CS)                   :: strm_flds2(2)
-      character(CS)                   :: strm_flds3(3)
-      character(CS)                   :: strm_flds4(4)
-      integer                         :: rank
-      integer                         :: fieldcount
-      type(ESMF_Field)                :: lfield
+      integer          :: n
+      integer          :: rank
+      integer          :: fieldcount
+      type(ESMF_Field) :: lfield
       character(ESMF_MAXSTR) ,pointer :: lfieldnames(:)
       character(*), parameter   :: subName = "(datm_init_dfields) "
       !-------------------------------------------------------------------------------
@@ -773,63 +844,18 @@ contains
       call ESMF_StateGet(exportState, itemNameList=lfieldnames, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       do n = 1, fieldCount
-         call ESMF_LogWrite(trim(subname)//': field name = '//trim(lfieldnames(n)), ESMF_LOGMSG_INFO)
+         call ESMF_LogWrite(subname//': field name = '//trim(lfieldnames(n)), ESMF_LOGMSG_INFO)
          call ESMF_StateGet(exportState, itemName=trim(lfieldnames(n)), field=lfield, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
          call ESMF_FieldGet(lfield, rank=rank, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
-         if (rank == 1) then
+         ! Currently rank==2 fields are handled in datm_pres_aero_mod.F90, datm_pres_co2_mod.F90
+         ! and datm_pres_ndep_mod.F90
+         ! The rank one Sa_o3 field is handled in datm_pres_o3_mod.F90
+         if (rank == 1 .and. trim(lfieldnames(n)) /= 'Sa_o3') then
             call dshr_dfield_add( dfields, sdat, trim(lfieldnames(n)), trim(lfieldnames(n)), &
                  exportState, logunit, mainproc, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         else if (rank == 2) then
-            ! The following maps stream input fields to export fields that have an ungridded dimension
-            ! TODO: in the future it might be better to change the format of the streams file to have two more entries
-            ! that could denote how the stream variables are mapped to export fields that have an ungridded dimension
-
-            select case (trim(lfieldnames(n)))
-            case('Faxa_bcph')
-               strm_flds3 = (/'Faxa_bcphidry', 'Faxa_bcphodry', 'Faxa_bcphiwet'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_ocph')
-               strm_flds3 = (/'Faxa_ocphidry', 'Faxa_ocphodry', 'Faxa_ocphiwet'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_dstwet')
-               strm_flds4 = (/'Faxa_dstwet1', 'Faxa_dstwet2', 'Faxa_dstwet3', 'Faxa_dstwet4'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds4, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_dstdry')
-               strm_flds4 = (/'Faxa_dstdry1', 'Faxa_dstdry2', 'Faxa_dstdry3', 'Faxa_dstdry4'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds4, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_rainc_wiso')
-               strm_flds3 = (/'Faxa_rainc_16O', 'Faxa_rainc_18O', 'Faxa_rainc_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_rainl_wiso')
-               strm_flds3 = (/'Faxa_rainl_16O', 'Faxa_rainl_18O', 'Faxa_rainl_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_snowc_wiso')
-               strm_flds3 = (/'Faxa_snowc_16O', 'Faxa_snowc_18O', 'Faxa_snowc_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_snowl_wiso')
-               strm_flds3 = (/'Faxa_snowl_16O', 'Faxa_snowl_18O', 'Faxa_snowl_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_ndep')
-               strm_flds2 = (/'Faxa_ndep_nhx', 'Faxa_ndep_noy'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds2, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('cpl_scalars')
-               continue
-            case default
-               call shr_log_error(subName//'field '//trim(lfieldnames(n))//' not recognized', rc=rc)
-               return
-            end select
          end if
       end do
     end subroutine datm_init_dfields

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -102,18 +102,22 @@
 
   <entry id="DATM_PRESNDEP">
     <type>char</type>
-    <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
+    <valid_values>none,
+      clim_1850_cmip7,clim_2000_cmip7,clim_2010_cmip7,hist_cmip7,
+      clim_1850_cmip6,clim_2000_cmip6,clim_2010_cmip6,hist_cmip6,
+      SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist
+    </valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"   >clim_1850</value>
-      <value compset="^2000_"   >clim_2000</value>
-      <value compset="^2010_"   >clim_2010</value>
-      <value compset="^SSP126_" >SSP1-2.6</value>
-      <value compset="^SSP245_" >SSP2-4.5</value>
-      <value compset="^SSP370_" >SSP3-7.0</value>
-      <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST[CE]?_"   >hist</value>
-      <value compset="^20TR_"   >hist</value>
+      <value compset="^1850[CE]?_"  >clim_1850_cmip6</value>
+      <value compset="^2000_"       >clim_2000_cmip6</value>
+      <value compset="^2010_"       >clim_2010_cmip6</value>
+      <value compset="^HIST[CE]?_"  >hist_cmip6</value>
+      <value compset="^20TR_"       >hist_cmip6</value>
+      <value compset="^SSP126_"     >SSP1-2.6</value>
+      <value compset="^SSP245_"     >SSP2-4.5</value>
+      <value compset="^SSP370_"     >SSP3-7.0</value>
+      <value compset="^SSP585_"     >SSP5-8.5</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
     </values>

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Note that streamslist here does not handle the optional streams - -->

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <!-- TODO: when should the mapalgo be nn? -->
@@ -190,10 +188,14 @@
   optional stream nitrogen deposition
   - DATM_NDEP is set by the 4 character time prefix in config_component.xml
   ========================
-  presndep.clim_1850
-  presndep.clim_2000
-  presndep.clim_2010
-  presndep.hist
+  presndep.clim_1850_cmip7
+  presndep.clim_2000_cmip7
+  presndep.clim_2010_cmip7
+  presndep.hist_cmip7
+  presndep.clim_1850_cmip6
+  presndep.clim_2000_cmip6
+  presndep.clim_2010_cmip6
+  presndep.hist_cmip6
   presndep.SSP1-2.6
   presndep.SSP2-4.5
   presndep.SSP3-7.0
@@ -4861,7 +4863,147 @@
   <!--  presndep forcing streams -->
   <!-- ===================-->
 
-  <stream_entry name="presndep.clim_1850">
+  <stream_entry name="presndep.clim_1850_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-185012-clim_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>1850</stream_year_first>
+    <stream_year_last>1850</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.clim_2000_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>2000</stream_year_first>
+    <stream_year_last>2000</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.clim_2010_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>2010</stream_year_first>
+    <stream_year_last>2010</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.hist_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>1850</stream_year_first>
+    <stream_year_last>2022</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.clim_1850_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4869,6 +5011,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4893,7 +5036,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.clim_2000">
+  <stream_entry name="presndep.clim_2000_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4901,6 +5044,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4925,7 +5069,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.clim_2010">
+  <stream_entry name="presndep.clim_2010_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4957,7 +5101,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.hist">
+  <stream_entry name="presndep.hist_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4965,6 +5109,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4997,6 +5142,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5029,6 +5175,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP2-4.5-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5061,6 +5208,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.002_1849-2101_monthly_0.9x1.25_c211216.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5094,6 +5242,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>

--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -14,11 +14,12 @@ module datm_datamode_clmncep_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_clmncep_advertise
   public  :: datm_datamode_clmncep_init_pointers
   public  :: datm_datamode_clmncep_advance
+
   private :: datm_esat  ! determine saturation vapor pressure
 
   ! export state data
@@ -28,12 +29,9 @@ module datm_datamode_clmncep_mod
   real(r8), pointer :: Sa_tbot(:)           => null()
   real(r8), pointer :: Sa_ptem(:)           => null()
   real(r8), pointer :: Sa_shum(:)           => null()
-! TODO: water isotope support
-!  real(r8), pointer :: Sa_shum_wiso(:,:)    => null() ! water isotopes
   real(r8), pointer :: Sa_dens(:)           => null()
   real(r8), pointer :: Sa_pbot(:)           => null()
   real(r8), pointer :: Sa_pslv(:)           => null()
-  real(r8), pointer :: Sa_o3(:)             => null()
   real(r8), pointer :: Faxa_lwdn(:)         => null()
   real(r8), pointer :: Faxa_rainc(:)        => null()
   real(r8), pointer :: Faxa_rainl(:)        => null()
@@ -44,7 +42,6 @@ module datm_datamode_clmncep_mod
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
   real(r8), pointer :: Faxa_swnet(:)        => null()
-  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   ! stream data
   real(r8), pointer :: strm_z(:)         => null()
@@ -61,14 +58,6 @@ module datm_datamode_clmncep_mod
   real(r8), pointer :: strm_precc(:)     => null()
   real(r8), pointer :: strm_precl(:)     => null()
   real(r8), pointer :: strm_precn(:)     => null()
-
-  ! stream data - water isotopes
-  real(r8), pointer :: strm_rh_16O(:)    => null() ! water isoptopes
-  real(r8), pointer :: strm_rh_18O(:)    => null() ! water isoptopes
-  real(r8), pointer :: strm_rh_HDO(:)    => null() ! water isoptopes
-  real(r8), pointer :: strm_precn_16O(:) => null() ! water isoptopes
-  real(r8), pointer :: strm_precn_18O(:) => null() ! water isoptopes
-  real(r8), pointer :: strm_precn_HDO(:) => null() ! water isoptopes
 
   ! stream data bias correction
   real(r8), pointer :: strm_precsf(:)    => null()
@@ -100,26 +89,19 @@ module datm_datamode_clmncep_mod
   real(r8) , parameter :: stebol   = SHR_CONST_STEBOL   ! Stefan-Boltzmann constant ~ W/m^2/K^4
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR    ! dry air gas constant   ~ J/K/kg
 
-
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine datm_datamode_clmncep_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, flds_preso3, rc)
+  subroutine datm_datamode_clmncep_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
-    logical            , intent(in)    :: flds_preso3
     character(len=*)   , intent(in)    :: flds_scalar_name
     integer            , intent(out)   :: rc
 
@@ -151,29 +133,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_preso3) then
-       call dshr_fldList_add(fldsExport, 'Sa_o3')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -225,20 +184,6 @@ contains
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_swdn'      , strm_swdn  , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn'     , strm_precn , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_16O'    , strm_rh_16O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_18O'    , strm_rh_18O   , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_HDO'    , strm_rh_HDO   , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_16O' , strm_precn_16O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_18O' , strm_precn_18O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_HDO' , strm_precn_HDO, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_HDO' , strm_precn_HDO, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! initialize pointers for module level stream arrays for bias correction
@@ -303,23 +248,9 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportstate, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
-    call ESMF_StateGet(exportstate, 'Sa_o3', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Sa_o3', fldptr1=Sa_o3, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
     ! error check
     if (.not. associated(strm_wind) .or. .not. associated(strm_tbot)) then
-       call shr_log_error(trim(subname)//' ERROR: wind and tbot must be in streams for CLMNCEP', rc=rc)
+       call shr_log_error(subname//' ERROR: wind and tbot must be in streams for CLMNCEP', rc=rc)
        return
     endif
 
@@ -379,7 +310,7 @@ contains
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        tbotmax = rtmp(2)
-       if (mainproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
+       if (mainproc) write(logunit,*) subname,' tbotmax = ',tbotmax
        if(tbotmax <= 0) then
           call shr_log_error(subname//'ERROR: bad value in tbotmax', rc=rc)
           return
@@ -394,7 +325,7 @@ contains
        else
           anidrmax = SHR_CONST_SPVAL
        end if
-       if (mainproc) write(logunit,*) trim(subname),' anidrmax = ',anidrmax
+       if (mainproc) write(logunit,*) subname,' anidrmax = ',anidrmax
 
        ! determine tdewmax (see below for use)
        if (associated(strm_tdew)) then
@@ -402,7 +333,7 @@ contains
           call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           tdewmax = rtmp(2)
-          if (mainproc) write(logunit,*) trim(subname),' tdewmax = ',tdewmax
+          if (mainproc) write(logunit,*) subname,' tdewmax = ',tdewmax
        endif
 
        ! reset first_time
@@ -446,12 +377,6 @@ contains
           e = strm_rh(n) * 0.01_r8 * datm_esat(tbot,tbot)
           qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
           Sa_shum(n) = qsat
-          ! for isotopic tracer specific humidity, expect a delta, just keep the delta from the input file
-          ! if (associated(strm_rh_16O) .and. associated(strm_rh_18O) .and. associated(strm_rh_HDO)) then
-          !   Sa_shum_wiso(1,n) = strm_rh_16O(n)
-          !   Sa_shum_wiso(2,n) = strm_rh_18O(n)
-          !   Sa_shum_wiso(3,n) = strm_rh_HDO(n)
-          ! end if
        else if (associated(strm_tdew)) then
           if (tdewmax < 50.0_r8) strm_tdew(n) = strm_tdew(n) + tkFrz
           e = datm_esat(strm_tdew(n),tbot)
@@ -583,11 +508,6 @@ contains
        Faxa_swvdf(:) = Faxa_swvdf(:) * strm_swdn_af(:)
     endif
     ! bias correction / anomaly forcing ( end block )
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_clmncep_advance
 

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -11,7 +11,7 @@ module datm_datamode_cplhist_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_cplhist_advertise
   public  :: datm_datamode_cplhist_init_pointers
@@ -36,26 +36,20 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swndf(:)        => null()
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
-  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine datm_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+  subroutine datm_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
     character(len=*)   , intent(in)    :: flds_scalar_name
     integer            , intent(out)   :: rc
 
@@ -86,26 +80,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swvdf' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -127,7 +101,6 @@ contains
     integer                , intent(out)   :: rc
 
     ! local variables
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 
@@ -171,13 +144,6 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportState, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
  end subroutine datm_datamode_cplhist_init_pointers
 
   !===============================================================================
@@ -194,11 +160,6 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (assumes that input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_cplhist_advance
 

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -11,11 +11,12 @@ module datm_datamode_era5_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_era5_advertise
   public  :: datm_datamode_era5_init_pointers
   public  :: datm_datamode_era5_advance
+
   private :: datm_eSat  ! determine saturation vapor pressure
 
   ! export state data
@@ -44,8 +45,6 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Faxa_lat(:)          => null()
   real(r8), pointer :: Faxa_taux(:)         => null()
   real(r8), pointer :: Faxa_tauy(:)         => null()
-!
-!  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   ! stream data
   real(r8), pointer :: strm_tdew(:)         => null()
@@ -57,8 +56,8 @@ module datm_datamode_era5_mod
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
-  character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'undefined'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -189,7 +188,7 @@ contains
 
   end subroutine datm_datamode_era5_init_pointers
 
-  !===============================================================================  
+  !===============================================================================
   subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, mpicom, target_ymd, target_tod, model_calendar, rc)
     use ESMF, only: ESMF_VMGetCurrent, ESMF_VMAllReduce, ESMF_REDUCE_MAX, ESMF_VM
 
@@ -225,7 +224,7 @@ contains
 
          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
          t2max = rtmp(2)
-         if (mainproc) write(logunit,*) trim(subname),' t2max = ',t2max
+         if (mainproc) write(logunit,*) subname,' t2max = ',t2max
        end if
 
        ! determine tdewmax (see below for use)
@@ -233,7 +232,7 @@ contains
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        td2max = rtmp(2)
 
-       if (mainproc) write(logunit,*) trim(subname),' td2max = ',td2max
+       if (mainproc) write(logunit,*) subname,' td2max = ',td2max
 
        ! reset first_time
        first_time = .false.
@@ -312,7 +311,7 @@ contains
 
   end subroutine datm_datamode_era5_advance
 
-  !===============================================================================  
+  !===============================================================================
   real(r8) function datm_eSat(tK,tKbot)
 
     !----------------------------------------------------------------------------

--- a/datm/datm_datamode_gefs_mod.F90
+++ b/datm/datm_datamode_gefs_mod.F90
@@ -11,7 +11,7 @@ module datm_datamode_gefs_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_gefs_advertise
   public  :: datm_datamode_gefs_init_pointers
@@ -47,8 +47,8 @@ module datm_datamode_gefs_mod
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
-  character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'undefined'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -193,14 +193,14 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        tbotmax = rtmp(2)
 
-       if (mainproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
+       if (mainproc) write(logunit,*) subname,' tbotmax = ',tbotmax
 
        ! determine maskmax (see below for use)
        rtmp(1) = maxval(strm_mask(:))
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        maskmax = rtmp(2)
-       if (mainproc) write(logunit,*) trim(subname),' maskmax = ',maskmax
+       if (mainproc) write(logunit,*) subname,' maskmax = ',maskmax
 
        ! reset first_time
        first_time = .false.

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -14,7 +14,7 @@ module datm_datamode_jra_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_jra_advertise
   public  :: datm_datamode_jra_init_pointers
@@ -41,7 +41,6 @@ module datm_datamode_jra_mod
   real(r8), pointer :: Faxa_swvdr(:) => null()
   real(r8), pointer :: Faxa_swvdf(:) => null()
   real(r8), pointer :: Faxa_swnet(:) => null()
-  real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! stream data
   real(r8), pointer :: strm_prec(:)  => null()
@@ -57,25 +56,20 @@ module datm_datamode_jra_mod
   real(R8) , parameter :: phs_c0   =   0.298_R8
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine datm_datamode_jra_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+  subroutine datm_datamode_jra_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
     character(len=*)   , intent(in)    :: flds_scalar_name
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
     integer            , intent(out)   :: rc
 
     ! local variables
@@ -108,27 +102,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
 
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
-
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
        call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
@@ -153,7 +126,6 @@ contains
     integer           :: spatialDim         ! number of dimension in mesh
     integer           :: numOwnedElements   ! size of mesh
     real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 
@@ -217,16 +189,9 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_swnet' , fldptr1=Faxa_swnet , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportState, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
     ! erro check
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
-       call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
+       call shr_log_error(subname//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
        return
     endif
 
@@ -292,11 +257,6 @@ contains
        avg_alb = ( 0.069 - 0.011*cos(2.0_R8*yc(n)*degtorad ) )
        Faxa_swnet(n) = strm_swdn(n)*(1.0_R8 - avg_alb)
     enddo   ! lsize
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_jra_advance
 

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -25,9 +25,9 @@ module datm_datamode_simple_mod
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use shr_log_mod      , only : shr_log_error
-  
+
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_simple_advertise
   public  :: datm_datamode_simple_init_pointers
@@ -53,7 +53,6 @@ module datm_datamode_simple_mod
   real(r8), pointer :: Faxa_swvdr(:) => null()
   real(r8), pointer :: Faxa_swvdf(:) => null()
   real(r8), pointer :: Faxa_swnet(:) => null()
-  real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! othe module arrays
   real(R8), pointer :: yc(:)                 ! array of model latitudes
@@ -75,8 +74,8 @@ module datm_datamode_simple_mod
   real(R8) , parameter :: phs_c0   =   0.298_R8
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -191,7 +190,6 @@ contains
     integer           :: spatialDim         ! number of dimension in mesh
     integer           :: numOwnedElements   ! size of mesh
     real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 
@@ -250,13 +248,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_StateGet(exportstate, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
 
   end subroutine datm_datamode_simple_init_pointers
 
@@ -319,7 +310,7 @@ contains
       ! long wave
       solar_decl = (epsilon_deg * degtorad) * sin( 2.0_R8 * shr_const_pi * (int(rday) + 284.0_R8) / 365.0_R8)
       zenith_angle = acos(sin(yc(n) * degtorad ) * sin(solar_decl) + cos(yc(n) * degtorad) * cos(solar_decl) )
-      Faxa_lwdn(n) = max(0.0_R8, peak_lwdn * cos(zenith_angle)) 
+      Faxa_lwdn(n) = max(0.0_R8, peak_lwdn * cos(zenith_angle))
 
       ! short wave
       hour_angle = (15.0_R8 * (target_tod/3600.0_R8 - 12.0_R8) + xc(n) ) * degtorad
@@ -331,11 +322,6 @@ contains
       Faxa_swndf(n) = Faxa_swnet(n)*(0.17_R8)
 
     enddo   ! lsize
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_simple_advance
 

--- a/datm/datm_pres_aero_mod.F90
+++ b/datm/datm_pres_aero_mod.F90
@@ -1,0 +1,172 @@
+module datm_pres_aero_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private
+
+  public :: datm_pres_aero_advertise
+  public :: datm_pres_aero_init_pointers
+  public :: datm_pres_aero_advance
+
+  ! pointers to export state data
+  real(r8), pointer :: Faxa_bcph(:,:)   => null()
+  real(r8), pointer :: Faxa_ocph(:,:)   => null()
+  real(r8), pointer :: Faxa_dstwet(:,:) => null()
+  real(r8), pointer :: Faxa_dstdry(:,:) => null()
+
+  ! pointers to stream data
+  real(r8), pointer :: strm_Faxa_bcphidry(:) => null()
+  real(r8), pointer :: strm_Faxa_bcphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_bcphodry(:) => null()
+
+  real(r8), pointer :: strm_Faxa_ocphidry(:) => null()
+  real(r8), pointer :: strm_Faxa_ocphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_ocphodry(:) => null()
+
+  real(r8), pointer :: strm_Faxa_dstwet1(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet2(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet3(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet4(:)  => null()
+
+  real(r8), pointer :: strm_Faxa_dstdry1(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry2(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry3(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry4(:)  => null()
+
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_aero_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+    !----------------------------------------------------------
+
+    call dshr_fldList_add(fldsExport, 'Faxa_bcph'  , ungridded_lbound=1, ungridded_ubound=3)
+    call dshr_fldList_add(fldsExport, 'Faxa_ocph'  , ungridded_lbound=1, ungridded_ubound=3)
+    call dshr_fldList_add(fldsExport, 'Faxa_dstwet', ungridded_lbound=1, ungridded_ubound=4)
+    call dshr_fldList_add(fldsExport, 'Faxa_dstdry', ungridded_lbound=1, ungridded_ubound=4)
+
+  end subroutine datm_pres_aero_advertise
+
+  !===============================================================================
+  subroutine datm_pres_aero_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_pres_aero_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Set module pointers into export state
+
+    call dshr_state_getfldptr(exportState, 'Faxa_bcph', fldptr2=Faxa_bcph, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_ocph', fldptr2=Faxa_ocph, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_dstwet', fldptr2=Faxa_dstwet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_dstdry', fldptr2=Faxa_dstdry, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Set module pointers into streams and check that they are associated
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_Faxa_bcphidry, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_bcphidry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_Faxa_bcphodry, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_bcphodry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_Faxa_bcphiwet, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_bcphiwet must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_Faxa_ocphidry, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_ocphidry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_Faxa_ocphodry, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_ocphodry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_Faxa_ocphiwet, requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_ocphiwet must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_Faxa_dstdry1 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstdry1 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_Faxa_dstdry2 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstdry2 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_Faxa_dstdry3 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstdry3 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_Faxa_dstdry4 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstdry4 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_Faxa_dstwet1 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstwet1 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_Faxa_dstwet2 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstwet2 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_Faxa_dstwet3 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstwet3 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_Faxa_dstwet4 , requirePointer=.true., &
+         errmsg=subname//'strm_Faxa_dstwet4 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine datm_pres_aero_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_aero_advance()
+
+    ! The following maps stream input fields to export fields that
+    ! have an ungridded dimension
+
+    Faxa_bcph(1,:) = strm_Faxa_bcphidry(:)
+    Faxa_bcph(2,:) = strm_Faxa_bcphodry(:)
+    Faxa_bcph(3,:) = strm_Faxa_bcphiwet(:)
+
+    Faxa_ocph(1,:) = strm_Faxa_ocphidry(:)
+    Faxa_ocph(2,:) = strm_Faxa_ocphodry(:)
+    Faxa_ocph(3,:) = strm_Faxa_ocphiwet(:)
+
+    Faxa_dstdry(1,:) = strm_Faxa_dstdry1(:)
+    Faxa_dstdry(2,:) = strm_Faxa_dstdry2(:)
+    Faxa_dstdry(3,:) = strm_Faxa_dstdry3(:)
+    Faxa_dstdry(4,:) = strm_Faxa_dstdry4(:)
+
+    Faxa_dstwet(1,:) = strm_Faxa_dstwet1(:)
+    Faxa_dstwet(2,:) = strm_Faxa_dstwet2(:)
+    Faxa_dstwet(3,:) = strm_Faxa_dstwet3(:)
+    Faxa_dstwet(4,:) = strm_Faxa_dstwet4(:)
+
+  end subroutine datm_pres_aero_advance
+
+end module datm_pres_aero_mod

--- a/datm/datm_pres_co2_mod.F90
+++ b/datm/datm_pres_co2_mod.F90
@@ -1,0 +1,98 @@
+module datm_pres_co2_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
+  use shr_kind_mod     , only : r8=>shr_kind_r8, cl=>shr_kind_cl
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private
+
+  public :: datm_pres_co2_advertise
+  public :: datm_pres_co2_init_pointers
+  public :: datm_pres_co2_advance
+
+  ! export state data
+  real(r8), pointer :: Sa_co2diag(:) => null()
+  real(r8), pointer :: Sa_co2prog(:) => null()
+
+  ! stream pointer
+  real(r8), pointer :: strm_Sa_co2diag(:) => null()
+  real(r8), pointer :: strm_Sa_co2prog(:) => null()
+
+  character(len=CL) :: datamode
+
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_co2_advertise(fldsExport, datamode_in)
+
+    ! input/output variables
+    type(fldlist_type) , pointer    :: fldsexport
+    character(len=*)   , intent(in) :: datamode_in
+    !----------------------------------------------------------
+
+    ! Set module variable
+    datamode = datamode_in
+
+    call dshr_fldList_add(fldsExport, 'Sa_co2diag')
+    call dshr_fldList_add(fldsExport, 'Sa_co2prog')
+
+  end subroutine datm_pres_co2_advertise
+
+  !===============================================================================
+  subroutine datm_pres_co2_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_pres_co2_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Sa_co2diag', fldptr1=Sa_co2diag, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call dshr_state_getfldptr(exportState, 'Sa_co2prog', fldptr1=Sa_co2prog, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get pointer to stream data that will be used below
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_co2diag', strm_Sa_co2diag, requirePointer=.true., &
+         errmsg=subname//'strm_Sa_co2diag must be associated if flds_co2 is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if (datamode == 'CPLHIST') then
+       call shr_strdata_get_stream_pointer(sdat, 'Sa_co2prog', strm_Sa_co2prog, requirePointer=.true., &
+            errmsg=subname//'strm_Sa_co2prog must be associated if flds_co2 is .true. '// &
+            ' and datamode is CPLHIST', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+  end subroutine datm_pres_co2_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_co2_advance()
+
+    if (datamode == 'CPLHIST') then
+       Sa_co2diag(:) = strm_Sa_co2diag(:)
+       Sa_co2prog(:) = strm_Sa_co2prog(:)
+    else
+       ! Because we do not currently have any Sa_co2prog in this case,
+       ! for now set Sa_co2prog equal to Sa_co2diag
+       Sa_co2diag(:) = strm_Sa_co2diag(:)
+       Sa_co2prog(:) = strm_Sa_co2diag(:)
+    end if
+
+  end subroutine datm_pres_co2_advance
+
+end module datm_pres_co2_mod

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -1,0 +1,113 @@
+module datm_pres_ndep_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use shr_log_mod      , only : shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private
+
+  public :: datm_pres_ndep_advertise
+  public :: datm_pres_ndep_init_pointers
+  public :: datm_pres_ndep_advance
+
+  ! export state data
+  real(r8), pointer :: Faxa_ndep(:,:) => null()
+
+  ! stream data
+  real(r8), pointer :: strm_Faxa_ndep_nhx_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_nhx_wet(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy_wet(:) => null() ! stream cmip7 ndep data
+
+  real(r8), pointer :: strm_Faxa_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy(:)     => null() ! pre-cmip7 ndep data
+
+  logical :: use_cmip7_ndep
+
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_ndep_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+    !----------------------------------------------------------
+
+    call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
+
+  end subroutine datm_pres_ndep_advertise
+
+  !===============================================================================
+  subroutine datm_pres_ndep_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_ndep_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get pointer to stream data that will be used below - if the
+    ! following stream fields are not in any sdat streams, then a null value is returned
+
+    ! cmip7 ndep forcing
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_dry', strm_Faxa_ndep_nhx_dry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_wet', strm_Faxa_ndep_nhx_wet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_dry', strm_Faxa_ndep_noy_dry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_wet', strm_Faxa_ndep_noy_wet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! cmip6 ndep forcing
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_nhx', strm_Faxa_ndep_nhx, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_Faxa_ndep_noy, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! determine use_cmip_ndep module variable
+    if (associated(strm_Faxa_ndep_nhx_dry) .and. associated(strm_Faxa_ndep_nhx_wet) .and. &
+        associated(strm_Faxa_ndep_noy_dry) .and. associated(strm_Faxa_ndep_noy_wet)) then
+       use_cmip7_ndep = .true.
+    else if (associated(strm_Faxa_ndep_nhx) .and. associated(strm_Faxa_ndep_noy)) then
+       use_cmip7_ndep = .false.
+    else
+       call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing', rc=rc)
+       return
+    end if
+
+  end subroutine datm_pres_ndep_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_ndep_advance()
+
+    if (use_cmip7_ndep) then
+       ! assume data is in kgN/m2/s
+       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx_dry(:) + strm_Faxa_ndep_nhx_wet(:)
+       Faxa_ndep(2,:) = strm_Faxa_ndep_noy_dry(:) + strm_Faxa_ndep_noy_wet(:)
+    else
+       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
+       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx(:) / 1000._r8
+       Faxa_ndep(2,:) = strm_Faxa_ndep_noy(:) / 1000._r8
+    end if
+
+  end subroutine datm_pres_ndep_advance
+
+end module datm_pres_ndep_mod

--- a/datm/datm_pres_o3_mod.F90
+++ b/datm/datm_pres_o3_mod.F90
@@ -1,0 +1,70 @@
+module datm_pres_o3_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private
+
+  public :: datm_pres_o3_advertise
+  public :: datm_pres_o3_init_pointers
+  public :: datm_pres_o3_advance
+
+  ! export state data
+  real(r8), pointer :: Sa_o3(:) => null()
+
+  ! stream pointer
+  real(r8), pointer :: strm_Sa_o3(:) => null()
+
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_o3_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+
+    call dshr_fldList_add(fldsExport, 'Sa_o3')
+
+  end subroutine datm_pres_o3_advertise
+
+  !===============================================================================
+  subroutine datm_pres_o3_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_o3_init_pointers): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Sa_o3', fldptr1=Sa_o3, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get pointer to stream data that will be used below
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_o3', strm_Sa_o3, requirePointer=.true., &
+         errmsg=subname//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine datm_pres_o3_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_o3_advance()
+
+    Sa_o3(:) = strm_Sa_o3(:)
+
+  end subroutine datm_pres_o3_advance
+
+end module datm_pres_o3_mod

--- a/dglc/cime_config/namelist_definition_dglc.xml
+++ b/dglc/cime_config/namelist_definition_dglc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!--

--- a/dglc/cime_config/stream_definition_dglc.xml
+++ b/dglc/cime_config/stream_definition_dglc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
   <!--
       %y   => year from the range yearfirst to yearlast
               obtained from values of <strm_year_start> -> <strm_year_end> below

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -27,23 +27,15 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-
-  <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3">
-    <machines>
-      <machine name="derecho" compiler="gnu" category="aux_cdeps_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-    <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_tn14_gris4" name="SMS_D_Ly3">
-    <machines>
-      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30:00 </option>
-    </options>
-  </test>
+  <!-- NOTE: currently there is no compset DATAMODELTEST -->
+  <!-- <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3"> -->
+  <!--   <machines> -->
+  <!--     <machine name="derecho" compiler="gnu" category="aux_cdeps"/> -->
+  <!--     <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:10:00 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
 
 </testlist>

--- a/dice/cime_config/namelist_definition_dice.xml
+++ b/dice/cime_config/namelist_definition_dice.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DICE model namelists.
@@ -54,7 +52,7 @@
     <desc>file specifying model mesh</desc>
     <values>
       <value>$ICE_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -68,7 +66,7 @@
     </desc>
     <values>
       <value>$MASK_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -81,7 +79,7 @@
     </desc>
     <values>
       <value>$ICE_NX</value>
-      <value single_column='true'>1</value> 
+      <value single_column='true'>1</value>
     </values>
   </entry>
 
@@ -94,7 +92,7 @@
     </desc>
     <values>
       <value>$ICE_NY</value>
-      <value single_column='true'>1</value> 
+      <value single_column='true'>1</value>
     </values>
   </entry>
 

--- a/dice/cime_config/stream_definition_dice.xml
+++ b/dice/cime_config/stream_definition_dice.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="ssmi_nyf">

--- a/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!--

--- a/dlnd/cime_config/stream_definition_dlnd.xml
+++ b/dlnd/cime_config/stream_definition_dlnd.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
   <!--
       %glc => GLC elevation class from the range 0 to GLC_NEC, obtained from the GLC_NEC xml variable
       %y   => year from the range yearfirst to yearlast

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DOCN model docn namelists. -->

--- a/docn/cime_config/stream_definition_docn.xml
+++ b/docn/cime_config/stream_definition_docn.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="prescribed">

--- a/drof/cime_config/namelist_definition_drof.xml
+++ b/drof/cime_config/namelist_definition_drof.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <entry id="streamslist">
@@ -46,7 +44,7 @@
     </values>
   </entry>
 
-  <entry id="model_meshfile"> 
+  <entry id="model_meshfile">
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>

--- a/drof/cime_config/stream_definition_drof.xml
+++ b/drof/cime_config/stream_definition_drof.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="rof.diatren_ann_rx1">

--- a/dwav/cime_config/namelist_definition_dwav.xml
+++ b/dwav/cime_config/namelist_definition_dwav.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DWAV model dwav namelists. -->

--- a/dwav/cime_config/stream_definition_dwav.xml
+++ b/dwav/cime_config/stream_definition_dwav.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="climo">


### PR DESCRIPTION
### Description of changes

This introduces the following new stream modules that are optional and can be added to the datamode streams already in place:

### Specific notes
The following new modules have been added
 - datm_pres_aero_mod.F90,  datm_pres_co2_mod.F90,  datm_pres_ndep_mod.F90,  datm_pres_o3_mod.F90

For datm_pres_ndep_mod.F90:
- added new streams clim_1850_cmip7, clim_2000_cmip7, clim_2010_cmip7, and hist_cmip7 (currently these are only used by NorESM)
- renamed the following streams
   - clim_1850 -> clim_1850_cmip6
   - clim_2000 -> clim_2000_cmip6
   - ciim_2010 -> clim_2010_cmip6
   - hist -> hist_cmip6
  by default for CESM, the following cmip6 streams will be used (whereas for NorESM, the cmip7 streams are used)
Note that for the cmip7 data, no unit conversion is done whereas for the default cmip6 data the input data is converted from` g/m2/sec` to `kg/m2/sec`.

For datm_pres_co2_mod.F90:   
- added the following logic which will change answers for non-CPLHIST mode
```F90
  if (datamode == 'CPLHIST') then
       Sa_co2diag(:) = strm_Sa_co2diag(:)
       Sa_co2prog(:) = strm_Sa_co2prog(:)
  else
       ! This is intentional since we don't have any Sa_co2prog - but for now
       ! will set Sa_co2prog equal to Sa_co2diag
       Sa_co2diag(:) = strm_Sa_co2diag(:)
       Sa_co2prog(:) = strm_Sa_co2diag(:)
  end if
```

Also 
- removed references to water isotopes in DATM modules since this will be refactored in upcoming work.
- removed style sheet references in all component namelist_definition_dXXX.xml and stream_definition_dXXX.xml since they are not used.

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #370 
The following tests now have correct values of o3 sent to 
```
ERI_D_Ld11.ne30pg3_ne30pg3_mtn14.I1850Clm60FatesNocompSpinup.betzy_gnu.clm-FatesColdSpinupAD
ERS_D_Ld11.ne30pg3_ne30pg3_mtn14.I1850Clm60FatesNocompSpinup.betzy_intel.clm-FatesColdSpinup
SMS_D_Ld1000_P1536.ne30pg3_ne30pg3_mtn14.I1850Clm60FatesNocompSpinup.betzy_gnu.clm-FatesColdSpinup
```
Are there dependencies on other component PRs: This PR contains all the changes from CDEPS PR #368.

Are changes expected to change answers (bfb): bfb except for Sa_o3 bug fix and when DATM_PRES_CO2 is used.

Any User Interface Changes: add new options for DATM_PRESNDEP

Testing performed: Successfully carried out aux_cdeps_noresm, aux_blom_noresm and aux_clm_noresm with a corresonding PR in NorESMhub (see testing description in https://github.com/NorESMhub/CDEPS/pull/27).

Hashes used for testing:
