### PR TITLE
Fixes for ifx compiler

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1849,10 +1849,12 @@ contains
                 endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
-                      if (.not. shr_infnan_isnan(data_real2d(n,lev)) .and. data_real2d(n,lev) .ne. fillvalue_r4) then
-                         dataptr2d(lev,n) = real(data_real2d(n,lev), kind=r8) ! Note the order of indices
-                      else
+                      if (shr_infnan_isnan(data_real2d(n,lev))) then
                          dataptr2d(lev,n) = r8fill
+                      else if (data_real2d(n,lev) == fillvalue_r4) then
+                         dataptr2d(lev,n) = r8fill
+                      else
+                         dataptr2d(lev,n) = real(data_real2d(n,lev), kind=r8) ! Note the order of indices
                       endif
                    enddo
                 end do
@@ -1888,10 +1890,12 @@ contains
                 endif
 
                 do n=1,size(dataptr1d)
-                   if(.not. shr_infnan_isnan(data_real1d(n)) .and. data_real1d(n) .ne. fillvalue_r4) then
-                      dataptr1d(n) = real(data_real1d(n), kind=r8)
-                   else
+                   if (shr_infnan_isnan(data_real1d(n))) then
                       dataptr1d(n) = r8fill
+                   else if (data_real1d(n) == fillvalue_r4) then
+                      dataptr1d(n) = r8fill
+                   else
+                      dataptr1d(n) = real(data_real1d(n), kind=r8)
                    endif
                 enddo
              else
@@ -1925,10 +1929,12 @@ contains
                 endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
-                      if (.not. shr_infnan_isnan(data_dbl2d(n,lev)) .and. data_dbl2d(n,lev) .ne. fillvalue_r8) then
-                         dataptr2d(lev,n) = data_dbl2d(n,lev)
-                      else
+                      if (shr_infnan_isnan(data_dbl2d(n,lev))) then
                          dataptr2d(lev,n) = r8fill
+                      else if (data_dbl2d(n,lev) == fillvalue_r8) then
+                         dataptr2d(lev,n) = r8fill
+                      else
+                         dataptr2d(lev,n) = data_dbl2d(n,lev)
                       endif
                    enddo
                 end do
@@ -1960,10 +1966,12 @@ contains
                    end if
                 endif
                 do n = 1,size(dataptr1d)
-                   if (.not. shr_infnan_isnan(data_dbl1d(n)) .and. data_dbl1d(n) .ne. fillvalue_r8) then
-                      dataptr1d(n) = data_dbl1d(n)
-                   else
+                   if (shr_infnan_isnan(data_dbl1d(n))) then
                       dataptr1d(n) = r8fill
+                   else if (data_dbl1d(n) == fillvalue_r8) then
+                      dataptr1d(n) = r8fill
+                   else
+                      dataptr1d(n) = data_dbl1d(n)
                    end if
                 enddo
              else

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1836,14 +1836,16 @@ contains
              end if
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
-                if (stream%mapalgo == 'none' .and. any(data_real2d == fillvalue_r4)) then
-                   write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',&
-                        trim(per_stream%fldlist_stream(nf))
-                   if (sdat%mainproc) then
-                      write(sdat%logunit,'(2a)') subname,trim(errmsg)
+                if (stream%mapalgo == 'none') then
+                   if (any(data_real2d == fillvalue_r4)) then
+                      write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',&
+                           trim(per_stream%fldlist_stream(nf))
+                      if (sdat%mainproc) then
+                         write(sdat%logunit,'(2a)') subname,trim(errmsg)
+                      end if
+                      call shr_log_error(errmsg, rc=rc)
+                      return
                    end if
-                   call shr_log_error(errmsg, rc=rc)
-                   return
                 endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
@@ -1874,13 +1876,15 @@ contains
              end if
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
-                if (stream%mapalgo == 'none' .and. any(data_real1d == fillvalue_r4)) then
-                   write (errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',trim(per_stream%fldlist_stream(nf))
-                   if (sdat%mainproc) then
-                      write(sdat%logunit,'(2a)') subname,trim(errmsg)
+                if (stream%mapalgo == 'none') then
+                   if (any(data_real1d == fillvalue_r4)) then
+                      write (errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',trim(per_stream%fldlist_stream(nf))
+                      if (sdat%mainproc) then
+                         write(sdat%logunit,'(2a)') subname,trim(errmsg)
+                      end if
+                      call shr_log_error(errmsg, rc=rc)
+                      return
                    end if
-                   call shr_log_error(errmsg, rc=rc)
-                   return
                 endif
 
                 do n=1,size(dataptr1d)
@@ -1912,10 +1916,12 @@ contains
              end if
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
-                if (stream%mapalgo == 'none' .and. any(data_dbl2d == fillvalue_r8)) then
-                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
-                   call shr_log_error(errmsg, rc=rc)
-                   return
+                if (stream%mapalgo == 'none') then
+                   if (any(data_dbl2d == fillvalue_r8)) then
+                      write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                      call shr_log_error(errmsg, rc=rc)
+                      return
+                   end if
                 endif
                 do lev = 1,stream_nlev
                    do n = 1,size(dataptr2d, dim=2)
@@ -1946,10 +1952,12 @@ contains
              end if
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
-                if (stream%mapalgo == 'none' .and. any(data_dbl1d == fillvalue_r8)) then
-                   write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
-                   call shr_log_error(subname//trim(errmsg), rc=rc)
-                   return
+                if (stream%mapalgo == 'none') then
+                   if (any(data_dbl1d == fillvalue_r8)) then
+                      write(errmsg,*) ' ERROR: _Fillvalue found in stream input variable: '// trim(per_stream%fldlist_stream(nf))
+                      call shr_log_error(subname//trim(errmsg), rc=rc)
+                      return
+                   end if
                 endif
                 do n = 1,size(dataptr1d)
                    if (.not. shr_infnan_isnan(data_dbl1d(n)) .and. data_dbl1d(n) .ne. fillvalue_r8) then


### PR DESCRIPTION
### Description of changes

The ifx compiler seems not to do short-circuit evaluation of conditionals. This was leading to failures in some debug tests when there were NaN values on an input file: checks like `if (.not. isnan(x) .and. x /= fillval)` were okay if short-circuit evaluation was being done, but are failing now.

This PR refactors some conditionals to effectively do this short-circuit evaluation via splitting the conditionals.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Ran aux_cdeps plus the following tests in the context of cesm3_0_alpha08e:
```
SMS_D_Ld1.ne30pg3_t232.I1850Clm50BgcSpinup.derecho_intel.clm-cplhist
SMS_D.TL319_t232.G_JRA_RYF.derecho_intel
SMS_D_Ld3.f10_f10_mg37.I1850Clm50BgcCrop.derecho_intel.clm-default
ERP_D_Ln9.f19_f19_mg17.QPC6.derecho_intel.cam-outfrq9s
SMS_D_Ld1_PS.f09_g17.I2000Clm50BgcCru.derecho_intel.clm-datm_bias_correct_cruv7
SMS_D_Ld5.f10_f10_mg37.ISSP245Clm60BgcCropCrujra.derecho_intel.clm-datm_rcp45_anom_forc
```

All tests passed and were bfb except for one expected failure from the aux_cdeps suite (which also failed in alpha08e: `FAIL SMS_Ld3.f19_g17_rx1.2000_SATM_SLND_SICE_SOCN_DROF%NYF_SGLC_SWAV.derecho_intel CREATE_NEWCASE`)

Also ran `SMS_D_Ld3_PS.f09_t232.I1850Clm60SpCrujraNoAnthro.derecho_intel.clm-decStart1851_noinitial--clm-nofireemis` with updated ccs_config that switches to ifx; that test failed before these changes and passes with these changes.

Hashes used for testing:
cesm3_0_alpha08e
