### PR TITLE
Change ICE NCAT for DICE

### DIFF
--- a/dice/cime_config/buildnml
+++ b/dice/cime_config/buildnml
@@ -52,6 +52,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     atm_nx = case.get_value("ATM_NX")
     atm_ny = case.get_value("ATM_NY")
 
+    # DICE always uses a single ice thickness category
+    case.set_value("ICE_NCAT", 1)
+
     # Check for incompatible options.
     expect(ice_grid != "null",
            "ICE_GRID cannot be null")


### PR DESCRIPTION
### Description of changes
ICE_NCAT is used by both CICE and MARBL (the ocean BGC model). We need the ICE_NCAT set to 1 so that data is passed to MARBL through the coupler (CICE buildnml always sets ICE_NCAT but DICE doesn't). It affects shortwave penetration. @mnlevy1981 can answer questions about this PR. 

### Specific notes

Contributors other than yourself, if any: @mnlevy1981 

CDEPS Issues Fixed (include github issue #): N/A

Are there dependencies on other component PRs (if so list): N/A

Are changes expected to change answers (bfb, different to roundoff, more substantial): 

Any User Interface Changes (namelist or namelist defaults changes): 
ICE_NCAT changes from a default of zero to one.
Testing performed (e.g. aux_cdeps, CESM prealpha, etc): None

Hashes used for testing:

