### PR TITLE
refactoring ERA5 data mode

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -140,6 +140,7 @@ module cdeps_datm_comp
   integer                      :: ny_global                           ! global ny
   logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
   logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
+  logical                      :: skip_field_check = .false.          ! true => no not check all fields are provided or not 
   logical                      :: first_call = .true.
 
   ! linked lists
@@ -249,7 +250,8 @@ contains
          skip_restart_read, &
          flds_presndep, &
          flds_preso3, &
-         export_all
+         export_all, &
+         skip_field_check
 
     rc = ESMF_SUCCESS
 
@@ -305,6 +307,7 @@ contains
        write(logunit,'(2a,l6)') subname,' flds_co2          = ',flds_co2
        write(logunit,'(2a,l6)') subname,' skip_restart_read = ',skip_restart_read
        write(logunit,'(2a,l6)') subname,' export_all        = ',export_all
+       write(logunit,'(2a,l6)') subname,' skip_field_check  = ',skip_field_check
 
        bcasttmp = 0
        bcasttmp(1) = nx_global
@@ -316,6 +319,7 @@ contains
        if(flds_co2)          bcasttmp(7) = 1
        if(skip_restart_read) bcasttmp(8) = 1
        if(export_all)        bcasttmp(9) = 1
+       if(skip_field_check)  bcasttmp(10) = 1
     end if
 
     ! Broadcast namelist input
@@ -351,6 +355,7 @@ contains
     flds_co2          = (bcasttmp(7) == 1)
     skip_restart_read = (bcasttmp(8) == 1)
     export_all        = (bcasttmp(9) == 1)
+    skip_field_check  = (bcasttmp(10) == 1)
 
     if (nextsw_cday_calc == 'cam7') then
        nextsw_cday_calc_cam7 = .true.
@@ -669,7 +674,7 @@ contains
           call datm_datamode_cplhist_init_pointers(importState, exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('ERA5')
-          call datm_datamode_era5_init_pointers(exportState, sdat, rc)
+          call datm_datamode_era5_init_pointers(exportState, sdat, skip_field_check, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('GEFS')
           call datm_datamode_gefs_init_pointers(exportState, sdat, logunit, mainproc, rc)
@@ -747,7 +752,7 @@ contains
        call datm_datamode_cplhist_advance(rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('ERA5')
-       call datm_datamode_era5_advance(exportstate, mainproc, logunit, rc)
+       call datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, sdat%model_calendar, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('GEFS')
        call datm_datamode_gefs_advance(exportstate, sdat, mainproc, logunit, rc)

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -141,7 +141,7 @@ module cdeps_datm_comp
   logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
   logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
   logical                      :: skip_field_check = .false.          ! true => no not check all fields are provided or not 
-  integer                      :: qsat_algorithm = 0                  ! qsat algoritm 0: previous impl., 1: Gill, 82
+  integer                      :: qsat_algorithm = 0                  ! qsat algorithm 0: previous impl., 1: Gill, 82
   logical                      :: first_call = .true.
 
   ! linked lists
@@ -361,8 +361,6 @@ contains
     export_all        = (bcasttmp(9) == 1)
     skip_field_check  = (bcasttmp(10) == 1)
     qsat_algorithm    = bcasttmp(11)
-
-    print*, "datm - qsat_algorithm = ", qsat_algorithm
 
     if (nextsw_cday_calc == 'cam7') then
        nextsw_cday_calc_cam7 = .true.

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -141,6 +141,7 @@ module cdeps_datm_comp
   logical                      :: skip_restart_read = .false.         ! true => skip restart read in continuation run
   logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
   logical                      :: skip_field_check = .false.          ! true => no not check all fields are provided or not 
+  integer                      :: qsat_algorithm = 0                  ! qsat algoritm 0: previous impl., 1: Gill, 82
   logical                      :: first_call = .true.
 
   ! linked lists
@@ -226,7 +227,7 @@ contains
     ! local variables
     integer           :: nu         ! unit number
     integer           :: ierr       ! error code
-    integer           :: bcasttmp(10)
+    integer           :: bcasttmp(11)
     character(CL)     :: nextsw_cday_calc
     type(ESMF_VM)     :: vm
     character(len=*),parameter :: subname=trim(modName) // ':(InitializeAdvertise) '
@@ -251,7 +252,8 @@ contains
          flds_presndep, &
          flds_preso3, &
          export_all, &
-         skip_field_check
+         skip_field_check, &
+         qsat_algorithm
 
     rc = ESMF_SUCCESS
 
@@ -308,6 +310,7 @@ contains
        write(logunit,'(2a,l6)') subname,' skip_restart_read = ',skip_restart_read
        write(logunit,'(2a,l6)') subname,' export_all        = ',export_all
        write(logunit,'(2a,l6)') subname,' skip_field_check  = ',skip_field_check
+       write(logunit,'(2a,i0)') subname,' qsat_algorithm    = ',qsat_algorithm
 
        bcasttmp = 0
        bcasttmp(1) = nx_global
@@ -320,6 +323,7 @@ contains
        if(skip_restart_read) bcasttmp(8) = 1
        if(export_all)        bcasttmp(9) = 1
        if(skip_field_check)  bcasttmp(10) = 1
+       bcasttmp(11) = qsat_algorithm
     end if
 
     ! Broadcast namelist input
@@ -343,7 +347,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, nextsw_cday_calc, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, bcasttmp, 10, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, bcasttmp, 11, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     nx_global         = bcasttmp(1)
@@ -356,6 +360,9 @@ contains
     skip_restart_read = (bcasttmp(8) == 1)
     export_all        = (bcasttmp(9) == 1)
     skip_field_check  = (bcasttmp(10) == 1)
+    qsat_algorithm    = bcasttmp(11)
+
+    print*, "datm - qsat_algorithm = ", qsat_algorithm
 
     if (nextsw_cday_calc == 'cam7') then
        nextsw_cday_calc_cam7 = .true.
@@ -752,7 +759,8 @@ contains
        call datm_datamode_cplhist_advance(rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('ERA5')
-       call datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, sdat%model_calendar, rc)
+       call datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, &
+            sdat%model_calendar, qsat_algorithm, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('GEFS')
        call datm_datamode_gefs_advance(exportstate, sdat, mainproc, logunit, rc)

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -1,9 +1,10 @@
 module datm_datamode_era5_mod
 
-  use ESMF             , only : ESMF_State, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_State, ESMF_MeshGet, ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use NUOPC            , only : NUOPC_Advertise
+  use shr_cal_mod      , only : shr_cal_date2julian
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_const_mod    , only : shr_const_tkfrz, shr_const_rhofw, shr_const_rdair
+  use shr_const_mod    , only : shr_const_tkfrz, shr_const_rhofw, shr_const_rdair, shr_const_pi
   use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
@@ -23,13 +24,20 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Sa_u10m(:)           => null()
   real(r8), pointer :: Sa_v10m(:)           => null()
   real(r8), pointer :: Sa_wspd10m(:)        => null()
+  real(r8), pointer :: Sa_u(:)              => null()
+  real(r8), pointer :: Sa_v(:)              => null()
+  real(r8), pointer :: Sa_wspd(:)           => null()
   real(r8), pointer :: Sa_t2m(:)            => null()
   real(r8), pointer :: Sa_tskn(:)           => null()
   real(r8), pointer :: Sa_q2m(:)            => null()
   real(r8), pointer :: Sa_pslv(:)           => null()
+  real(r8), pointer :: Sa_tbot(:)           => null()
+  real(r8), pointer :: Sa_shum(:)           => null()
+  real(r8), pointer :: Sa_pbot(:)           => null()
   real(r8), pointer :: Faxa_rain(:)         => null()
   real(r8), pointer :: Faxa_rainc(:)        => null()
   real(r8), pointer :: Faxa_rainl(:)        => null()
+  real(r8), pointer :: Faxa_snow(:)         => null()
   real(r8), pointer :: Faxa_snowc(:)        => null()
   real(r8), pointer :: Faxa_snowl(:)        => null()
   real(r8), pointer :: Faxa_swndr(:)        => null()
@@ -48,9 +56,13 @@ module datm_datamode_era5_mod
   ! stream data
   real(r8), pointer :: strm_Sa_tdew(:)    => null()
   real(r8), pointer :: strm_Sa_t2m(:)     => null()
+  real(r8), pointer :: strm_Sa_tbot(:)    => null()
   real(r8), pointer :: strm_Sa_u10m(:)    => null()
   real(r8), pointer :: strm_Sa_v10m(:)    => null()
+  real(r8), pointer :: strm_Sa_u(:)       => null()
+  real(r8), pointer :: strm_Sa_v(:)       => null()
   real(r8), pointer :: strm_Sa_pslv(:)    => null()
+  real(r8), pointer :: strm_Sa_pbot(:)    => null()
   real(r8), pointer :: strm_Faxa_swdn(:)  => null()
   real(r8), pointer :: strm_Faxa_swvdr(:) => null()
   real(r8), pointer :: strm_Faxa_swndr(:) => null()
@@ -69,12 +81,20 @@ module datm_datamode_era5_mod
   real(r8), pointer :: strm_Faxa_taux(:)  => null()
   real(r8), pointer :: strm_Faxa_tauy(:)  => null()
 
-  real(r8) :: t2max  ! units detector
-  real(r8) :: td2max ! units detector
+  ! other module arrays
+  real(r8), pointer :: yc(:) ! array of model latitudes
+
+  real(r8) :: t2max   ! units detector
+  real(r8) :: td2max  ! units detector
+  real(r8) :: lwmax   ! units detector
+  real(r8) :: precmax ! units detector
 
   real(r8) , parameter :: tKFrz    = SHR_CONST_TKFRZ
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
+  real(R8) , parameter :: degtorad = SHR_CONST_PI/180.0_R8
+  real(R8) , parameter :: phs_c0   =   0.298_R8
+  real(R8) , parameter :: dLWarc   =  -5.000_R8
 
   character(len=*), parameter :: nullstr = 'undefined'
   character(len=*), parameter :: u_FILE_u = &
@@ -103,13 +123,20 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_u10m'    )
     call dshr_fldList_add(fldsExport, 'Sa_v10m'    )
     call dshr_fldList_add(fldsExport, 'Sa_wspd10m' )
+    call dshr_fldList_add(fldsExport, 'Sa_u'       )
+    call dshr_fldList_add(fldsExport, 'Sa_v'       )
+    call dshr_fldList_add(fldsExport, 'Sa_wspd'    )
     call dshr_fldList_add(fldsExport, 'Sa_t2m'     )
     call dshr_fldList_add(fldsExport, 'Sa_tskn'    )
     call dshr_fldList_add(fldsExport, 'Sa_q2m'     )
     call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
+    call dshr_fldList_add(fldsExport, 'Sa_tbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_shum'    )
+    call dshr_fldList_add(fldsExport, 'Sa_pbot'    )
     call dshr_fldList_add(fldsExport, 'Faxa_rain'  )
     call dshr_fldList_add(fldsExport, 'Faxa_rainc' )
     call dshr_fldList_add(fldsExport, 'Faxa_rainl' )
+    call dshr_fldList_add(fldsExport, 'Faxa_snow'  )
     call dshr_fldList_add(fldsExport, 'Faxa_snowc' )
     call dshr_fldList_add(fldsExport, 'Faxa_snowl' )
     call dshr_fldList_add(fldsExport, 'Faxa_swndr' )
@@ -136,29 +163,53 @@ contains
   end subroutine datm_datamode_era5_advertise
 
   !===============================================================================
-  subroutine datm_datamode_era5_init_pointers(exportState, sdat, rc)
+  subroutine datm_datamode_era5_init_pointers(exportState, sdat, skip_field_check, rc)
 
     ! input/output variables
     type(ESMF_State)       , intent(inout) :: exportState
     type(shr_strdata_type) , intent(in)    :: sdat
+    logical                , intent(in)    :: skip_field_check
     integer                , intent(out)   :: rc
 
     ! local variables
+    integer           :: n
+    integer           :: spatialDim         ! number of dimension in mesh
+    integer           :: numOwnedElements   ! size of mesh
+    real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+
+    ! determine yc
+    call ESMF_MeshGet(sdat%model_mesh, spatialDim=spatialDim, numOwnedElements=numOwnedElements, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    allocate(ownedElemCoords(spatialDim*numOwnedElements))
+    allocate(yc(numOwnedElements))
+    call ESMF_MeshGet(sdat%model_mesh, ownedElemCoords=ownedElemCoords)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    do n = 1,numOwnedElements
+       yc(n) = ownedElemCoords(2*n)
+    end do
 
     ! initialize pointers for module level stream arrays
     call shr_strdata_get_stream_pointer( sdat,'Sa_tdew', strm_Sa_tdew , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_t2m' , strm_Sa_t2m , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_tbot' , strm_Sa_tbot , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_u10m', strm_Sa_u10m, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_v10m', strm_Sa_v10m, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_u', strm_Sa_u, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_v', strm_Sa_v, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_pslv', strm_Sa_pslv, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_pbot', strm_Sa_pbot, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_swdn', strm_Faxa_swdn, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -194,6 +245,12 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_wspd10m' , fldptr1=Sa_wspd10m , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u'       , fldptr1=Sa_u       , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_wspd'    , fldptr1=Sa_wspd    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_t2m'     , fldptr1=Sa_t2m     , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tskn'    , fldptr1=Sa_tskn    , allowNullReturn=.true., rc=rc)
@@ -202,11 +259,19 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_pslv'    , fldptr1=Sa_pslv    , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_pbot    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_shum'    , fldptr1=Sa_shum    , allowNullReturn=.true., rc=rc) 
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_pbot'    , fldptr1=Sa_pbot    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_rain'  , fldptr1=Faxa_rain  , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_rainc' , fldptr1=Faxa_rainc , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_rainl' , fldptr1=Faxa_rainl , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_snow'  , fldptr1=Faxa_snow  , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_snowc' , fldptr1=Faxa_snowc , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -238,108 +303,117 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Error checks
-    if (.not. associated(strm_Sa_tdew)) then
-       call shr_log_error(subname//'ERROR: strm_Sa_tdew must be associated for era5 datamode')
-       return
-    end if
-
-    if (associated(Sa_wspd10m) .and. .not. associated(strm_Sa_u10m)) then
-       call shr_log_error(subname//'ERROR: strm_Sa_u10m must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Sa_wspd10m) .and. .not. associated(strm_Sa_v10m)) then
-       call shr_log_error(subname//'ERROR: strm_Sa_v10m must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Sa_t2m) .and. .not. associated(strm_Sa_t2m)) then
-       call shr_log_error(subname//'ERROR: strm_Sa_t2m must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Sa_t2m) .and. associated(Sa_pslv) .and. associated(Sa_q2m) .and. .not. associated(strm_Sa_pslv)) then
-       call shr_log_error(subname//'ERROR: strm_Sa_pslv must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_swdn)) then
-       if (.not. associated(strm_Faxa_swdn)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swdn must be associated for era5 datamode', rc=rc)
+    if (.not. skip_field_check) then
+       if (.not. associated(strm_Sa_tdew)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_tdew must be associated for era5 datamode')
           return
        end if
-    end if
-    if ( associated(Faxa_swvdr) .or. associated(Faxa_swndr) .or. associated(Faxa_swvdf) .or. associated(Faxa_swndf)) then
-       if (.not. associated(strm_Faxa_swdn)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swdn must be associated for era5 datamode', rc=rc)
+       if (associated(Sa_wspd10m) .and. .not. associated(strm_Sa_u10m)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_u10m must be associated for era5 datamode', rc=rc)
           return
        end if
-    end if
-    if (associated(Faxa_swvdr) .and. .not. associated(strm_Faxa_swvdr)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_swvdr must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_swndr) .and. .not. associated(strm_Faxa_swndr)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_swndr must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_swvdf) .and. .not. associated(strm_Faxa_swvdf)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_swvdf must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_swndf) .and. .not. associated(strm_Faxa_swndf)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_swndf must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_lwdn) .and. .not. associated(strm_Faxa_lwdn)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_lwdn must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_lwnet) .and. .not. associated(strm_Faxa_lwnet)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_lwnet must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_swnet) .and. .not. associated(strm_Faxa_swnet)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_swnet must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_sen) .and. .not. associated(strm_Faxa_sen)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_sen must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_lat) .and. .not. associated(strm_Faxa_lat)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_lat must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_rain) .and. .not. associated(strm_Faxa_rain)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_rain must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_rainc) .and. .not. associated(strm_Faxa_rainc)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_rainc must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_rainl) .and. .not. associated(strm_Faxa_rainl)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_rainl must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_snowc) .and. .not. associated(strm_Faxa_snowc)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_snowc must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_snowl) .and. .not. associated(strm_Faxa_snowl)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_snowl must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_taux) .and. .not. associated(strm_Faxa_taux)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_taux must be associated for era5 datamode', rc=rc)
-       return
-    end if
-    if (associated(Faxa_tauy) .and. .not. associated(strm_Faxa_tauy)) then
-       call shr_log_error(subname//'ERROR: strm_Faxa_tauy must be associated for era5 datamode', rc=rc)
-       return
+       if (associated(Sa_wspd10m) .and. .not. associated(strm_Sa_v10m)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_v10m must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Sa_wspd) .and. .not. associated(strm_Sa_u)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_u must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Sa_wspd) .and. .not. associated(strm_Sa_v)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_v must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Sa_t2m) .and. .not. associated(strm_Sa_t2m)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_t2m must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Sa_t2m) .and. associated(Sa_pslv) .and. associated(Sa_q2m) .and. .not. associated(strm_Sa_pslv)) then
+          call shr_log_error(subname//'ERROR: strm_Sa_pslv must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_swdn)) then
+          if (.not. associated(strm_Faxa_swdn)) then
+             call shr_log_error(subname//'ERROR: strm_Faxa_swdn must be associated for era5 datamode', rc=rc)
+             return
+          end if
+       end if
+       if ( associated(Faxa_swvdr) .or. associated(Faxa_swndr) .or. associated(Faxa_swvdf) .or. associated(Faxa_swndf)) then
+          if (.not. associated(strm_Faxa_swdn)) then
+             call shr_log_error(subname//'ERROR: strm_Faxa_swdn must be associated for era5 datamode', rc=rc)
+             return
+          end if
+       end if
+       if (associated(Faxa_swvdr) .and. .not. associated(strm_Faxa_swvdr)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_swvdr must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_swndr) .and. .not. associated(strm_Faxa_swndr)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_swndr must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_swvdf) .and. .not. associated(strm_Faxa_swvdf)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_swvdf must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_swndf) .and. .not. associated(strm_Faxa_swndf)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_swndf must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_lwdn) .and. .not. associated(strm_Faxa_lwdn)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_lwdn must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_lwnet) .and. .not. associated(strm_Faxa_lwnet)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_lwnet must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_swnet) .and. .not. associated(strm_Faxa_swnet)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_swnet must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_sen) .and. .not. associated(strm_Faxa_sen)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_sen must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_lat) .and. .not. associated(strm_Faxa_lat)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_lat must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_rain) .and. .not. associated(strm_Faxa_rain)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_rain must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_rainc) .and. .not. associated(strm_Faxa_rainc)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_rainc must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_rainl) .and. .not. associated(strm_Faxa_rainl)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_rainl must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_snowc) .and. .not. associated(strm_Faxa_snowc)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_snowc must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_snowl) .and. .not. associated(strm_Faxa_snowl)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_snowl must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_taux) .and. .not. associated(strm_Faxa_taux)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_taux must be associated for era5 datamode', rc=rc)
+          return
+       end if
+       if (associated(Faxa_tauy) .and. .not. associated(strm_Faxa_tauy)) then
+          call shr_log_error(subname//'ERROR: strm_Faxa_tauy must be associated for era5 datamode', rc=rc)
+          return
+       end if
     end if
 
   end subroutine datm_datamode_era5_init_pointers
 
   !===============================================================================
-  subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, rc)
+  subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, model_calendar, rc)
 
     use ESMF, only: ESMF_VMGetCurrent, ESMF_VMAllReduce, ESMF_REDUCE_MAX, ESMF_VM
 
@@ -347,12 +421,18 @@ contains
     type(ESMF_State)       , intent(inout) :: exportState
     logical                , intent(in)    :: mainproc
     integer                , intent(in)    :: logunit
+    integer                , intent(in)    :: target_ymd
+    integer                , intent(in)    :: target_tod
+    character(len=*)       , intent(in)    :: model_calendar
     integer                , intent(out)   :: rc
 
     ! local variables
     logical  :: first_time = .true.
     integer  :: n                   ! indices
     integer  :: lsize               ! size of attr vect
+    real(r8) :: avg_alb             ! average albedo
+    real(r8) :: rday                ! elapsed day
+    real(r8) :: cosFactor           ! cosine factor
     real(r8) :: rtmp(2)
     real(r8) :: t2, pslv
     real(r8) :: e, qsat
@@ -362,25 +442,83 @@ contains
 
     rc = ESMF_SUCCESS
 
-    lsize = size(strm_Sa_tdew)
+    if (associated(Sa_z)) then
+       lsize = size(Sa_z)
+    else
+       if (mainproc) write(logunit,*) subname,' Sa_z is not given. Try with Sa_pslv to get stream size'
+    end if
+    if (associated(Sa_pslv)) then
+       lsize = size(Sa_pslv)
+    else
+       if (mainproc) write(logunit,*) subname,' Sa_pslv is also not given. Exiting!'
+       call shr_log_error(subname//'ERROR: Sa_z and/or Sa_pslv must be associated for era5 datamode', rc=rc)
+       return
+    end if
+
+    call shr_cal_date2julian(target_ymd, target_tod, rday, model_calendar)
+    rday = mod((rday - 1.0_R8),365.0_R8)
+    cosfactor = cos((2.0_R8*SHR_CONST_PI*rday)/365 - phs_c0)
+
     if (first_time) then
        call ESMF_VMGetCurrent(vm, rc=rc)
        ! determine t2max (see below for use)
-       if (associated(Sa_t2m)) then
-         Sa_t2m(:) = strm_Sa_t2m(:)
-         rtmp(1) = maxval(Sa_t2m(:))
+       if (associated(Sa_t2m) .and. associated(strm_Sa_t2m)) then
+          Sa_t2m(:) = strm_Sa_t2m(:)
+          rtmp(1) = maxval(Sa_t2m(:))
 
-         call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
-         t2max = rtmp(2)
-         if (mainproc) write(logunit,*) subname,' t2max = ',t2max
+          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+          t2max = rtmp(2)
+          if (mainproc) write(logunit,*) subname,' t2max = ',t2max
        end if
 
        ! determine tdewmax (see below for use)
-       rtmp(1) = maxval(strm_Sa_tdew(:))
-       call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
-       td2max = rtmp(2)
+       if (associated(strm_Sa_tdew)) then
+          rtmp(1) = maxval(strm_Sa_tdew(:))
 
-       if (mainproc) write(logunit,*) subname,' td2max = ',td2max
+          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+          td2max = rtmp(2)
+          if (mainproc) write(logunit,*) subname,' td2max = ',td2max
+       end if
+
+       ! determine lwmax
+       if (associated(Faxa_lwdn)) then
+          rtmp(1) = maxval(Faxa_lwdn(:))
+
+          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+          lwmax = rtmp(2)
+          if (mainproc) write(logunit,*) trim(subname),' lwmax = ',lwmax
+       else
+          ! try with other variable since Faxa_lwdn is not available
+          if (associated(Faxa_lwnet)) then
+             rtmp(1) = maxval(Faxa_lwnet(:))
+
+             call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+             lwmax = rtmp(2)
+             if (mainproc) write(logunit,*) trim(subname),' lwmax = ',lwmax
+          else
+             lwmax = 0.0_r8
+          end if
+       end if
+
+       ! determine precmax
+       if (associated(Faxa_rain)) then
+          rtmp(1) = maxval(Faxa_rain(:))
+
+          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+          precmax = rtmp(2)
+          if (mainproc) write(logunit,*) trim(subname),' precmax = ', precmax
+       else
+          ! try with other variable since Faxa_rain is not available
+          if (associated(Faxa_rainl)) then
+            rtmp(1) = maxval(Faxa_rainl(:))
+
+            call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
+            precmax = rtmp(2)
+            if (mainproc) write(logunit,*) trim(subname),' precmax = ', precmax
+          else
+            precmax = 0.0_r8
+          end if
+       end if
 
        ! reset first_time
        first_time = .false.
@@ -389,16 +527,23 @@ contains
     do n = 1, lsize
        !--- bottom layer height ---
        if (associated(Sa_z)) then
-         Sa_z(n) = 10.0_r8
+          Sa_z(n) = 10.0_r8
        end if
 
        !--- calculate wind speed ---
        if (associated(Sa_wspd10m)) then
-         Sa_wspd10m(n) = sqrt(strm_Sa_u10m(n)*strm_Sa_u10m(n) + strm_Sa_v10m(n)*strm_Sa_v10m(n))
+          if (associated(strm_Sa_u10m) .and. associated(strm_Sa_v10m)) then
+             Sa_wspd10m(n) = sqrt(strm_Sa_u10m(n)*strm_Sa_u10m(n) + strm_Sa_v10m(n)*strm_Sa_v10m(n))
+          end if
+       end if
+       if (associated(Sa_wspd)) then
+          if (associated(strm_Sa_u) .and. associated(strm_Sa_v)) then
+             Sa_wspd(n) = sqrt(strm_Sa_u(n)*strm_Sa_u(n) + strm_Sa_v(n)*strm_Sa_v(n))
+          end if
        end if
 
        !--- specific humidity at 2m ---
-       if (associated(Sa_t2m) .and. associated(Sa_pslv) .and. associated(Sa_q2m)) then
+       if (associated(strm_Sa_t2m) .and. associated(Sa_pslv) .and. associated(Sa_q2m)) then
          t2 = Sa_t2m(n)
          pslv = strm_Sa_pslv(n)
          if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
@@ -406,56 +551,66 @@ contains
          qsat = (0.622_r8 * e)/(pslv - 0.378_r8 * e)
          Sa_q2m(n) = qsat
        end if
+       if (associated(strm_Sa_tbot) .and. associated(Sa_pbot) .and. associated(Sa_shum)) then
+         t2 = Sa_tbot(n)
+         pslv = strm_Sa_pbot(n)
+         if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
+         e = datm_eSat(strm_Sa_tdew(n), t2)
+         qsat = (0.622_r8 * e)/(pslv - 0.378_r8 * e)
+         Sa_shum(n) = qsat
+       end if
+
+       !--- radiation data ---
+       ! fabricate required swdn components from net swdn
+       if (associated(Faxa_swdn) .and. associated(strm_Faxa_swdn)) then
+          Faxa_swvdr(n) = strm_Faxa_swdn(n)*(0.28_R8)
+          Faxa_swndr(n) = strm_Faxa_swdn(n)*(0.31_R8)
+          Faxa_swvdf(n) = strm_Faxa_swdn(n)*(0.24_R8)
+          Faxa_swndf(n) = strm_Faxa_swdn(n)*(0.17_R8)
+       end if
+
+       ! compute net short-wave based on LY08 latitudinally-varying albedo
+       if (associated(Faxa_swnet) .and. associated(strm_Faxa_swdn)) then
+          avg_alb = ( 0.069 - 0.011*cos(2.0_R8*yc(n)*degtorad ) )
+          Faxa_swnet(n) = strm_Faxa_swdn(n)*(1.0_R8 - avg_alb)
+       end if
     end do
-
-    !----------------------------------------------------------
-    ! shortwave bands
-    !----------------------------------------------------------
-
-    !--- shortwave radiation (Faxa_* basically holds albedo) ---
-    !--- see comments for Faxa_swnet
-    if (associated(Faxa_swvdr)) Faxa_swvdr(:) = strm_Faxa_swdn(:)*strm_Faxa_swvdr(:)
-    if (associated(Faxa_swndr)) Faxa_swndr(:) = strm_Faxa_swdn(:)*strm_Faxa_swndr(:)
-    if (associated(Faxa_swvdf)) Faxa_swvdf(:) = strm_Faxa_swdn(:)*strm_Faxa_swvdf(:)
-    if (associated(Faxa_swndf)) Faxa_swndf(:) = strm_Faxa_swdn(:)*strm_Faxa_swndf(:)
-
-    !--- TODO: need to understand relationship between shortwave bands and
-    !--- net shortwave rad. currently it is provided directly from ERA5
-    !--- and the total of the bands are not consistent with the swnet
-    !--- swnet: a diagnostic quantity ---
-    !if (associated(Faxa_swnet)) then
-    !  if (associated(Faxa_swndr) .and. associated(Faxa_swvdr) .and. &
-    !      associated(Faxa_swndf) .and. associated(Faxa_swvdf)) then
-    !    Faxa_swnet(:) = Faxa_swndr(:) + Faxa_swvdr(:) + Faxa_swndf(:) + Faxa_swvdf(:)
-    !  end if
-    !end if
 
     !----------------------------------------------------------
     ! unit conversions (temporal resolution is hourly)
     !----------------------------------------------------------
 
     ! convert J/m^2 to W/m^2
-    if (associated(Faxa_lwdn))  Faxa_lwdn(:)  = strm_Faxa_lwdn(:)/3600.0_r8
-    if (associated(Faxa_lwnet)) Faxa_lwnet(:) = strm_Faxa_lwnet(:)/3600.0_r8
-    if (associated(Faxa_swvdr)) Faxa_swvdr(:) = strm_Faxa_swvdr(:)/3600.0_r8
-    if (associated(Faxa_swndr)) Faxa_swndr(:) = strm_Faxa_swndr(:)/3600.0_r8
-    if (associated(Faxa_swvdf)) Faxa_swvdf(:) = strm_Faxa_swvdf(:)/3600.0_r8
-    if (associated(Faxa_swndf)) Faxa_swndf(:) = strm_Faxa_swndf(:)/3600.0_r8
-    if (associated(Faxa_swdn))  Faxa_swdn(:)  = strm_Faxa_swdn(:)/3600.0_r8
-    if (associated(Faxa_swnet)) Faxa_swnet(:) = strm_Faxa_swnet(:)/3600.0_r8
-    if (associated(Faxa_sen))   Faxa_sen(:)   = strm_Faxa_sen(:)/3600.0_r8
-    if (associated(Faxa_lat))   Faxa_lat(:)   = strm_Faxa_lat(:)/3600.0_r8
+    if (lwmax < 1.0e4_r8) then
+       if (mainproc) write(logunit,*) trim(subname),' flux related variables are already in W/m^2 unit!'
+    else
+       if (associated(Faxa_lwdn) .and. associated(strm_Faxa_lwdn)) Faxa_lwdn(:) = strm_Faxa_lwdn(:)/3600.0_r8
+       if (associated(Faxa_lwnet) .and. associated(strm_Faxa_lwnet)) Faxa_lwnet(:) = strm_Faxa_lwnet(:)/3600.0_r8
+       if (associated(Faxa_swvdr) .and. associated(strm_Faxa_swvdr)) Faxa_swvdr(:) = strm_Faxa_swvdr(:)/3600.0_r8
+       if (associated(Faxa_swndr) .and. associated(strm_Faxa_swndr)) Faxa_swndr(:) = strm_Faxa_swndr(:)/3600.0_r8
+       if (associated(Faxa_swvdf) .and. associated(strm_Faxa_swvdf)) Faxa_swvdf(:) = strm_Faxa_swvdf(:)/3600.0_r8
+       if (associated(Faxa_swndf) .and. associated(strm_Faxa_swndf)) Faxa_swndf(:) = strm_Faxa_swndf(:)/3600.0_r8
+       if (associated(Faxa_swdn) .and. associated(strm_Faxa_swdn)) Faxa_swdn(:) = strm_Faxa_swdn(:)/3600.0_r8
+       if (associated(Faxa_swnet) .and. associated(strm_Faxa_swnet)) Faxa_swnet(:) = strm_Faxa_swnet(:)/3600.0_r8
+       if (associated(Faxa_sen) .and. associated(strm_Faxa_sen)) Faxa_sen(:) = strm_Faxa_sen(:)/3600.0_r8
+       if (associated(Faxa_lat) .and. associated(strm_Faxa_lat)) Faxa_lat(:) = strm_Faxa_lat(:)/3600.0_r8
+    end if
 
     ! convert m to kg/m^2/s
-    if (associated(Faxa_rain))  Faxa_rain(:)  = strm_Faxa_rain(:)/3600.0_r8*rhofw
-    if (associated(Faxa_rainc)) Faxa_rainc(:) = strm_Faxa_rainc(:)/3600.0_r8*rhofw
-    if (associated(Faxa_rainl)) Faxa_rainl(:) = strm_Faxa_rainl(:)/3600.0_r8*rhofw
-    if (associated(Faxa_snowc)) Faxa_snowc(:) = strm_Faxa_snowc(:)/3600.0_r8*rhofw
-    if (associated(Faxa_snowl)) Faxa_snowl(:) = strm_Faxa_snowl(:)/3600.0_r8*rhofw
+    if (precmax < 0.01_r8) then
+       if (mainproc) write(logunit,*) trim(subname),' precipitation related variables are already in kg/m^2/s unit!'
+    else
+       if (associated(Faxa_rain) .and. associated(strm_Faxa_rain)) Faxa_rain(:)  = strm_Faxa_rain(:)/3600.0_r8*rhofw
+       if (associated(Faxa_rainc) .and. associated(strm_Faxa_rainc)) Faxa_rainc(:) = strm_Faxa_rainc(:)/3600.0_r8*rhofw
+       if (associated(Faxa_rainl) .and. associated(strm_Faxa_rainl)) Faxa_rainl(:) = strm_Faxa_rainl(:)/3600.0_r8*rhofw
+       if (associated(Faxa_snowc) .and. associated(strm_Faxa_snowc)) Faxa_snowc(:) = strm_Faxa_snowc(:)/3600.0_r8*rhofw
+       if (associated(Faxa_snowl) .and. associated(strm_Faxa_snowl)) Faxa_snowl(:) = strm_Faxa_snowl(:)/3600.0_r8*rhofw
+    end if
 
     ! convert N/m^2 s to N/m^2
-    if (associated(Faxa_taux))  Faxa_taux(:)  = strm_Faxa_taux(:)/3600.0_r8
-    if (associated(Faxa_tauy))  Faxa_tauy(:)  = strm_Faxa_tauy(:)/3600.0_r8
+    ! TODO: put control like radiation and precipitation components
+    if (associated(Faxa_taux) .and. associated(strm_Faxa_taux)) Faxa_taux(:)  = strm_Faxa_taux(:)/3600.0_r8
+    if (associated(Faxa_tauy) .and. associated(strm_Faxa_tauy)) Faxa_tauy(:)  = strm_Faxa_tauy(:)/3600.0_r8
 
   end subroutine datm_datamode_era5_advance
 

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -29,11 +29,13 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Sa_wspd(:)           => null()
   real(r8), pointer :: Sa_t2m(:)            => null()
   real(r8), pointer :: Sa_tskn(:)           => null()
-  real(r8), pointer :: Sa_q2m(:)            => null()
-  real(r8), pointer :: Sa_pslv(:)           => null()
   real(r8), pointer :: Sa_tbot(:)           => null()
+  real(r8), pointer :: Sa_ptem(:)           => null()
+  real(r8), pointer :: Sa_q2m(:)            => null()
   real(r8), pointer :: Sa_shum(:)           => null()
+  real(r8), pointer :: Sa_pslv(:)           => null()
   real(r8), pointer :: Sa_pbot(:)           => null()
+  real(r8), pointer :: Sa_dens(:)           => null()
   real(r8), pointer :: Faxa_rain(:)         => null()
   real(r8), pointer :: Faxa_rainc(:)        => null()
   real(r8), pointer :: Faxa_rainl(:)        => null()
@@ -59,21 +61,22 @@ module datm_datamode_era5_mod
   real(r8), pointer :: strm_Sa_tbot(:)    => null()
   real(r8), pointer :: strm_Sa_u10m(:)    => null()
   real(r8), pointer :: strm_Sa_v10m(:)    => null()
+  real(r8), pointer :: strm_Sa_wspd10m(:) => null()
   real(r8), pointer :: strm_Sa_u(:)       => null()
   real(r8), pointer :: strm_Sa_v(:)       => null()
+  real(r8), pointer :: strm_Sa_wspd(:)    => null()
   real(r8), pointer :: strm_Sa_pslv(:)    => null()
   real(r8), pointer :: strm_Sa_pbot(:)    => null()
+  real(r8), pointer :: strm_Sa_q2m(:)     => null()
+  real(r8), pointer :: strm_Sa_shum(:)    => null()
   real(r8), pointer :: strm_Faxa_swdn(:)  => null()
-  real(r8), pointer :: strm_Faxa_swvdr(:) => null()
-  real(r8), pointer :: strm_Faxa_swndr(:) => null()
-  real(r8), pointer :: strm_Faxa_swvdf(:) => null()
-  real(r8), pointer :: strm_Faxa_swndf(:) => null()
   real(r8), pointer :: strm_Faxa_swnet(:) => null()
   real(r8), pointer :: strm_Faxa_lwdn(:)  => null()
   real(r8), pointer :: strm_Faxa_lwnet(:) => null()
   real(r8), pointer :: strm_Faxa_rain(:)  => null()
   real(r8), pointer :: strm_Faxa_rainc(:) => null()
   real(r8), pointer :: strm_Faxa_rainl(:) => null()
+  real(r8), pointer :: strm_Faxa_snow(:)  => null()
   real(r8), pointer :: strm_Faxa_snowc(:) => null()
   real(r8), pointer :: strm_Faxa_snowl(:) => null()
   real(r8), pointer :: strm_Faxa_sen(:)   => null()
@@ -128,11 +131,13 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_wspd'    )
     call dshr_fldList_add(fldsExport, 'Sa_t2m'     )
     call dshr_fldList_add(fldsExport, 'Sa_tskn'    )
-    call dshr_fldList_add(fldsExport, 'Sa_q2m'     )
-    call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
     call dshr_fldList_add(fldsExport, 'Sa_tbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_ptem'    )
+    call dshr_fldList_add(fldsExport, 'Sa_q2m'     )
     call dshr_fldList_add(fldsExport, 'Sa_shum'    )
+    call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
     call dshr_fldList_add(fldsExport, 'Sa_pbot'    )
+    call dshr_fldList_add(fldsExport, 'Sa_dens'    )
     call dshr_fldList_add(fldsExport, 'Faxa_rain'  )
     call dshr_fldList_add(fldsExport, 'Faxa_rainc' )
     call dshr_fldList_add(fldsExport, 'Faxa_rainl' )
@@ -203,23 +208,35 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_v10m', strm_Sa_v10m, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_wspd10m', strm_Sa_wspd10m, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_u', strm_Sa_u, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_v', strm_Sa_v, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_wspd', strm_Sa_wspd, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_pslv', strm_Sa_pslv, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Sa_pbot', strm_Sa_pbot, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_shum', strm_Sa_shum, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_q2m', strm_Sa_q2m, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_rain', strm_Faxa_rain, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_rainc', strm_Faxa_rainc, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_rainl', strm_Faxa_rainl, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_snow', strm_Faxa_snow, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_snowc', strm_Faxa_snowc, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_snowl', strm_Faxa_snowl, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_swdn', strm_Faxa_swdn, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_swvdr', strm_Faxa_swvdr, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_swndr', strm_Faxa_swndr, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_swvdf', strm_Faxa_swvdf, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_swndf', strm_Faxa_swndf, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_swnet', strm_Faxa_swnet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -255,15 +272,19 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tskn'    , fldptr1=Sa_tskn    , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_ptem'    , fldptr1=Sa_ptem    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_q2m'     , fldptr1=Sa_q2m     , allowNullReturn=.true., rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Sa_pslv'    , fldptr1=Sa_pslv    , allowNullReturn=.true., rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_pbot    , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_shum'    , fldptr1=Sa_shum    , allowNullReturn=.true., rc=rc) 
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_pslv'    , fldptr1=Sa_pslv    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_pbot'    , fldptr1=Sa_pbot    , allowNullReturn=.true., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_dens'    , fldptr1=Sa_dens    , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_rain'  , fldptr1=Faxa_rain  , allowNullReturn=.true., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -344,22 +365,6 @@ contains
              return
           end if
        end if
-       if (associated(Faxa_swvdr) .and. .not. associated(strm_Faxa_swvdr)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swvdr must be associated for era5 datamode', rc=rc)
-          return
-       end if
-       if (associated(Faxa_swndr) .and. .not. associated(strm_Faxa_swndr)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swndr must be associated for era5 datamode', rc=rc)
-          return
-       end if
-       if (associated(Faxa_swvdf) .and. .not. associated(strm_Faxa_swvdf)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swvdf must be associated for era5 datamode', rc=rc)
-          return
-       end if
-       if (associated(Faxa_swndf) .and. .not. associated(strm_Faxa_swndf)) then
-          call shr_log_error(subname//'ERROR: strm_Faxa_swndf must be associated for era5 datamode', rc=rc)
-          return
-       end if
        if (associated(Faxa_lwdn) .and. .not. associated(strm_Faxa_lwdn)) then
           call shr_log_error(subname//'ERROR: strm_Faxa_lwdn must be associated for era5 datamode', rc=rc)
           return
@@ -410,6 +415,14 @@ contains
        end if
     end if
 
+    ! Initialize value of export state
+    if (associated(Faxa_rain)) Faxa_rain(:) = 0.0_r8
+    if (associated(Faxa_rainc)) Faxa_rainc(:) = 0.0_r8
+    if (associated(Faxa_rainl)) Faxa_rainl(:) = 0.0_r8
+    if (associated(Faxa_snow)) Faxa_snow(:) = 0.0_r8
+    if (associated(Faxa_snowc)) Faxa_snowc(:) = 0.0_r8
+    if (associated(Faxa_snowl)) Faxa_snowl(:) = 0.0_r8
+
   end subroutine datm_datamode_era5_init_pointers
 
   !===============================================================================
@@ -436,6 +449,7 @@ contains
     real(r8) :: rtmp(2)
     real(r8) :: t2, pslv
     real(r8) :: e, qsat
+    real(r8) :: tbot, pbot
     type(ESMF_VM) :: vm
     character(len=*), parameter :: subname='(datm_datamode_era5_advance): '
     !-------------------------------------------------------------------------------
@@ -462,9 +476,8 @@ contains
     if (first_time) then
        call ESMF_VMGetCurrent(vm, rc=rc)
        ! determine t2max (see below for use)
-       if (associated(Sa_t2m) .and. associated(strm_Sa_t2m)) then
-          Sa_t2m(:) = strm_Sa_t2m(:)
-          rtmp(1) = maxval(Sa_t2m(:))
+       if (associated(strm_Sa_t2m)) then
+          rtmp(1) = maxval(strm_Sa_t2m(:))
 
           call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
           t2max = rtmp(2)
@@ -481,16 +494,16 @@ contains
        end if
 
        ! determine lwmax
-       if (associated(Faxa_lwdn)) then
-          rtmp(1) = maxval(Faxa_lwdn(:))
+       if (associated(strm_Faxa_lwdn)) then
+          rtmp(1) = maxval(strm_Faxa_lwdn(:))
 
           call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
           lwmax = rtmp(2)
           if (mainproc) write(logunit,*) trim(subname),' lwmax = ',lwmax
        else
           ! try with other variable since Faxa_lwdn is not available
-          if (associated(Faxa_lwnet)) then
-             rtmp(1) = maxval(Faxa_lwnet(:))
+          if (associated(strm_Faxa_lwnet)) then
+             rtmp(1) = maxval(strm_Faxa_lwnet(:))
 
              call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
              lwmax = rtmp(2)
@@ -501,16 +514,16 @@ contains
        end if
 
        ! determine precmax
-       if (associated(Faxa_rain)) then
-          rtmp(1) = maxval(Faxa_rain(:))
+       if (associated(strm_Faxa_rain)) then
+          rtmp(1) = maxval(strm_Faxa_rain(:))
 
           call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
           precmax = rtmp(2)
           if (mainproc) write(logunit,*) trim(subname),' precmax = ', precmax
        else
           ! try with other variable since Faxa_rain is not available
-          if (associated(Faxa_rainl)) then
-            rtmp(1) = maxval(Faxa_rainl(:))
+          if (associated(strm_Faxa_rainl)) then
+            rtmp(1) = maxval(strm_Faxa_rainl(:))
 
             call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
             precmax = rtmp(2)
@@ -524,55 +537,103 @@ contains
        first_time = .false.
     end if
 
+    ! direct copy from stream
+    if (associated(strm_Sa_tbot)) then
+       if (associated(Sa_tbot)) Sa_tbot(:) = strm_Sa_tbot(:)
+       if (associated(Sa_ptem)) Sa_ptem(:) = strm_Sa_tbot(:)
+    end if
+    if (associated(strm_Sa_t2m) .and. associated(Sa_t2m)) Sa_t2m(:) = strm_Sa_t2m(:)
+    if (associated(strm_Sa_q2m) .and. associated(Sa_q2m)) Sa_q2m(:) = strm_Sa_q2m(:)
+    if (associated(strm_Sa_shum) .and. associated(Sa_shum)) Sa_shum(:) = strm_Sa_shum(:)
+    if (associated(strm_Sa_pbot) .and. associated(Sa_pbot)) Sa_pbot(:) = strm_Sa_pbot(:)
+    if (associated(strm_Sa_pslv) .and. associated(Sa_pslv)) Sa_pslv(:) = strm_Sa_pslv(:)
+    if (associated(strm_Sa_u) .and. associated(Sa_u)) Sa_u(:) = strm_Sa_u(:)
+    if (associated(strm_Sa_v) .and. associated(Sa_v)) Sa_v(:) = strm_Sa_v(:)
+    if (associated(strm_Sa_u10m) .and. associated(Sa_u10m)) Sa_u10m(:) = strm_Sa_u10m(:)
+    if (associated(strm_Sa_v10m) .and. associated(Sa_v10m)) Sa_v10m(:) = strm_Sa_v10m(:)
+    if (associated(strm_Faxa_rain) .and. associated(Faxa_rain)) Faxa_rain(:) = strm_Faxa_rain(:)
+    if (associated(strm_Faxa_rainc) .and. associated(Faxa_rainc)) Faxa_rainc(:) = strm_Faxa_rainc(:)
+    if (associated(strm_Faxa_rainl) .and. associated(Faxa_rainl)) Faxa_rainl(:) = strm_Faxa_rainl(:)
+    if (associated(strm_Faxa_snow) .and. associated(Faxa_snow)) Faxa_snow(:) = strm_Faxa_snow(:)
+    if (associated(strm_Faxa_snowc) .and. associated(Faxa_snowc)) Faxa_snowc(:) = strm_Faxa_snowc(:)
+    if (associated(strm_Faxa_snowl) .and. associated(Faxa_snowl)) Faxa_snowl(:) = strm_Faxa_snowl(:)
+    if (associated(strm_Faxa_swdn) .and. associated(Faxa_swdn)) Faxa_swdn(:) = strm_Faxa_swdn(:)
+    if (associated(strm_Faxa_lwdn) .and. associated(Faxa_lwdn)) Faxa_lwdn(:) = strm_Faxa_lwdn(:)
+    if (associated(strm_Faxa_swnet) .and. associated(Faxa_swnet)) Faxa_swnet(:) = strm_Faxa_swnet(:)
+    if (associated(strm_Faxa_lwnet) .and. associated(Faxa_lwnet)) Faxa_lwnet(:) = strm_Faxa_lwnet(:)
+    if (associated(strm_Faxa_sen) .and. associated(Faxa_sen)) Faxa_sen(:) = strm_Faxa_sen(:)
+    if (associated(strm_Faxa_lat) .and. associated(Faxa_lat)) Faxa_lat(:) = strm_Faxa_lat(:)
+    if (associated(strm_Faxa_taux) .and. associated(Faxa_taux)) Faxa_taux(:) = strm_Faxa_taux(:)
+    if (associated(strm_Faxa_tauy) .and. associated(Faxa_tauy)) Faxa_tauy(:) = strm_Faxa_tauy(:)
+
     do n = 1, lsize
        !--- bottom layer height ---
        if (associated(Sa_z)) then
           Sa_z(n) = 10.0_r8
        end if
 
-       !--- calculate wind speed ---
-       if (associated(Sa_wspd10m)) then
-          if (associated(strm_Sa_u10m) .and. associated(strm_Sa_v10m)) then
-             Sa_wspd10m(n) = sqrt(strm_Sa_u10m(n)*strm_Sa_u10m(n) + strm_Sa_v10m(n)*strm_Sa_v10m(n))
-          end if
+       !--- calculate wind components if wind speed is provided ---
+       if (associated(strm_Sa_wspd)) then
+          Sa_u(n) = strm_Sa_wspd(n)/sqrt(2.0_r8)
+          Sa_v(n) = Sa_u(n)
        end if
-       if (associated(Sa_wspd)) then
-          if (associated(strm_Sa_u) .and. associated(strm_Sa_v)) then
-             Sa_wspd(n) = sqrt(strm_Sa_u(n)*strm_Sa_u(n) + strm_Sa_v(n)*strm_Sa_v(n))
-          end if
+       if (associated(strm_Sa_wspd10m)) then
+          Sa_u10m(n) = strm_Sa_wspd10m(n)/sqrt(2.0_r8)
+          Sa_v10m(n) = Sa_u10m(n)
        end if
 
-       !--- specific humidity at 2m ---
-       if (associated(strm_Sa_t2m) .and. associated(Sa_pslv) .and. associated(Sa_q2m)) then
-         t2 = Sa_t2m(n)
-         pslv = strm_Sa_pslv(n)
-         if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
-         e = datm_eSat(strm_Sa_tdew(n), t2)
-         qsat = (0.622_r8 * e)/(pslv - 0.378_r8 * e)
-         Sa_q2m(n) = qsat
+       !--- calculate wind speed if wind components are provided ---
+       if (associated(Sa_wspd10m) .and. associated(strm_Sa_u10m) .and. associated(strm_Sa_v10m)) then
+          Sa_wspd10m(n) = sqrt(strm_Sa_u10m(n)*strm_Sa_u10m(n) + strm_Sa_v10m(n)*strm_Sa_v10m(n))
        end if
-       if (associated(strm_Sa_tbot) .and. associated(Sa_pbot) .and. associated(Sa_shum)) then
-         t2 = Sa_tbot(n)
-         pslv = strm_Sa_pbot(n)
-         if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
-         e = datm_eSat(strm_Sa_tdew(n), t2)
-         qsat = (0.622_r8 * e)/(pslv - 0.378_r8 * e)
-         Sa_shum(n) = qsat
+       if (associated(Sa_wspd) .and. associated(strm_Sa_u) .and. associated(strm_Sa_v)) then
+          Sa_wspd(n) = sqrt(strm_Sa_u(n)*strm_Sa_u(n) + strm_Sa_v(n)*strm_Sa_v(n))
+       end if
+
+       !--- calculate specific humidity from dew point temperature ---
+       if (associated(strm_Sa_tdew)) then
+          if (associated(strm_Sa_t2m)) then
+             tbot = strm_Sa_t2m(n)
+          else if (associated(strm_Sa_tbot)) then
+             tbot = strm_Sa_tbot(n)
+          end if
+
+          if (associated(strm_Sa_pslv)) then
+             pbot = strm_Sa_pslv(n)
+          else if (associated(strm_Sa_pbot)) then
+             pbot = strm_Sa_pbot(n)
+          end if
+
+          if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
+          e = datm_eSat(strm_Sa_tdew(n), tbot)
+          qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
+          if (associated(Sa_q2m)) Sa_q2m(n) = qsat
+          if (associated(Sa_shum)) Sa_shum(n) = qsat
+       end if
+
+       !--- calculate density --
+       if (associated(strm_Sa_pbot) .and. associated(strm_Sa_tbot) .and. associated(strm_Sa_shum)) then
+          if (associated(Sa_dens)) then
+             Sa_dens(n) = strm_Sa_pbot(n)/(rdair*strm_Sa_tbot(n)*(1 + 0.608*strm_Sa_shum(n)))
+          end if
        end if
 
        !--- radiation data ---
        ! fabricate required swdn components from net swdn
-       if (associated(Faxa_swdn) .and. associated(strm_Faxa_swdn)) then
-          Faxa_swvdr(n) = strm_Faxa_swdn(n)*(0.28_R8)
-          Faxa_swndr(n) = strm_Faxa_swdn(n)*(0.31_R8)
-          Faxa_swvdf(n) = strm_Faxa_swdn(n)*(0.24_R8)
-          Faxa_swndf(n) = strm_Faxa_swdn(n)*(0.17_R8)
+       if (associated(strm_Faxa_swdn)) then
+          if (associated(Faxa_swvdr)) Faxa_swvdr(n) = strm_Faxa_swdn(n)*(0.28_R8)
+          if (associated(Faxa_swndr)) Faxa_swndr(n) = strm_Faxa_swdn(n)*(0.31_R8)
+          if (associated(Faxa_swvdf)) Faxa_swvdf(n) = strm_Faxa_swdn(n)*(0.24_R8)
+          if (associated(Faxa_swndf)) Faxa_swndf(n) = strm_Faxa_swdn(n)*(0.17_R8)
        end if
 
        ! compute net short-wave based on LY08 latitudinally-varying albedo
-       if (associated(Faxa_swnet) .and. associated(strm_Faxa_swdn)) then
-          avg_alb = ( 0.069 - 0.011*cos(2.0_R8*yc(n)*degtorad ) )
-          Faxa_swnet(n) = strm_Faxa_swdn(n)*(1.0_R8 - avg_alb)
+       if (associated(strm_Faxa_swdn)) then
+          if (.not. associated(strm_Faxa_swnet) .and. associated(Faxa_swnet)) then
+             avg_alb = ( 0.069 - 0.011*cos(2.0_R8*yc(n)*degtorad ) )
+             Faxa_swnet(n) = strm_Faxa_swdn(n)*(1.0_R8 - avg_alb)
+             Faxa_swnet(n) = Faxa_swnet(n)*3600.0_r8 ! to J/m^2
+          end if
        end if
     end do
 
@@ -584,33 +645,36 @@ contains
     if (lwmax < 1.0e4_r8) then
        if (mainproc) write(logunit,*) trim(subname),' flux related variables are already in W/m^2 unit!'
     else
-       if (associated(Faxa_lwdn) .and. associated(strm_Faxa_lwdn)) Faxa_lwdn(:) = strm_Faxa_lwdn(:)/3600.0_r8
-       if (associated(Faxa_lwnet) .and. associated(strm_Faxa_lwnet)) Faxa_lwnet(:) = strm_Faxa_lwnet(:)/3600.0_r8
-       if (associated(Faxa_swvdr) .and. associated(strm_Faxa_swvdr)) Faxa_swvdr(:) = strm_Faxa_swvdr(:)/3600.0_r8
-       if (associated(Faxa_swndr) .and. associated(strm_Faxa_swndr)) Faxa_swndr(:) = strm_Faxa_swndr(:)/3600.0_r8
-       if (associated(Faxa_swvdf) .and. associated(strm_Faxa_swvdf)) Faxa_swvdf(:) = strm_Faxa_swvdf(:)/3600.0_r8
-       if (associated(Faxa_swndf) .and. associated(strm_Faxa_swndf)) Faxa_swndf(:) = strm_Faxa_swndf(:)/3600.0_r8
-       if (associated(Faxa_swdn) .and. associated(strm_Faxa_swdn)) Faxa_swdn(:) = strm_Faxa_swdn(:)/3600.0_r8
-       if (associated(Faxa_swnet) .and. associated(strm_Faxa_swnet)) Faxa_swnet(:) = strm_Faxa_swnet(:)/3600.0_r8
-       if (associated(Faxa_sen) .and. associated(strm_Faxa_sen)) Faxa_sen(:) = strm_Faxa_sen(:)/3600.0_r8
-       if (associated(Faxa_lat) .and. associated(strm_Faxa_lat)) Faxa_lat(:) = strm_Faxa_lat(:)/3600.0_r8
+       if (associated(Faxa_lwdn))  Faxa_lwdn(:)  = Faxa_lwdn(:) /3600.0_r8
+       if (associated(Faxa_lwnet)) Faxa_lwnet(:) = Faxa_lwnet(:)/3600.0_r8
+       if (associated(Faxa_swvdr)) Faxa_swvdr(:) = Faxa_swvdr(:)/3600.0_r8
+       if (associated(Faxa_swndr)) Faxa_swndr(:) = Faxa_swndr(:)/3600.0_r8
+       if (associated(Faxa_swvdf)) Faxa_swvdf(:) = Faxa_swvdf(:)/3600.0_r8
+       if (associated(Faxa_swndf)) Faxa_swndf(:) = Faxa_swndf(:)/3600.0_r8
+       if (associated(Faxa_swdn))  Faxa_swdn(:)  = Faxa_swdn(:) /3600.0_r8
+       if (associated(Faxa_swnet)) Faxa_swnet(:) = Faxa_swnet(:)/3600.0_r8
+       if (associated(Faxa_sen))   Faxa_sen(:)   = Faxa_sen(:)  /3600.0_r8
+       if (associated(Faxa_lat))   Faxa_lat(:)   = Faxa_lat(:)  /3600.0_r8
     end if
 
     ! convert m to kg/m^2/s
     if (precmax < 0.01_r8) then
        if (mainproc) write(logunit,*) trim(subname),' precipitation related variables are already in kg/m^2/s unit!'
     else
-       if (associated(Faxa_rain) .and. associated(strm_Faxa_rain)) Faxa_rain(:)  = strm_Faxa_rain(:)/3600.0_r8*rhofw
-       if (associated(Faxa_rainc) .and. associated(strm_Faxa_rainc)) Faxa_rainc(:) = strm_Faxa_rainc(:)/3600.0_r8*rhofw
-       if (associated(Faxa_rainl) .and. associated(strm_Faxa_rainl)) Faxa_rainl(:) = strm_Faxa_rainl(:)/3600.0_r8*rhofw
-       if (associated(Faxa_snowc) .and. associated(strm_Faxa_snowc)) Faxa_snowc(:) = strm_Faxa_snowc(:)/3600.0_r8*rhofw
-       if (associated(Faxa_snowl) .and. associated(strm_Faxa_snowl)) Faxa_snowl(:) = strm_Faxa_snowl(:)/3600.0_r8*rhofw
+       if (associated(Faxa_rain))  Faxa_rain(:)  = Faxa_rain(:)/3600.0_r8*rhofw
+       if (associated(Faxa_rainc)) Faxa_rainc(:) = Faxa_rainc(:)/3600.0_r8*rhofw
+       if (associated(Faxa_rainl)) Faxa_rainl(:) = Faxa_rainl(:)/3600.0_r8*rhofw
+       if (associated(Faxa_snowc)) Faxa_snowc(:) = Faxa_snowc(:)/3600.0_r8*rhofw
+       if (associated(Faxa_snowl)) Faxa_snowl(:) = Faxa_snowl(:)/3600.0_r8*rhofw
     end if
 
     ! convert N/m^2 s to N/m^2
-    ! TODO: put control like radiation and precipitation components
-    if (associated(Faxa_taux) .and. associated(strm_Faxa_taux)) Faxa_taux(:)  = strm_Faxa_taux(:)/3600.0_r8
-    if (associated(Faxa_tauy) .and. associated(strm_Faxa_tauy)) Faxa_tauy(:)  = strm_Faxa_tauy(:)/3600.0_r8
+    if (lwmax < 1.0e4_r8) then
+       if (mainproc) write(logunit,*) trim(subname),' momentum flux related variables are already in N/m^2 unit!'
+    else
+       if (associated(Faxa_taux)) Faxa_taux(:) = Faxa_taux(:)/3600.0_r8
+       if (associated(Faxa_tauy)) Faxa_tauy(:) = Faxa_tauy(:)/3600.0_r8
+    end if
 
   end subroutine datm_datamode_era5_advance
 

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -607,26 +607,29 @@ contains
              pbot = strm_Sa_pbot(n)
           end if
 
-          if (qsat_algorithm == 0) then ! from dew point temperature
-             if (associated(strm_Sa_tdew)) then     
-                if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
-                e = datm_eSat(strm_Sa_tdew(n), tbot)
-                qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
+          !--- Sa_shum not provided, calculate indirectly ---
+          if (.not. associated(strm_Sa_shum)) then
+             if (qsat_algorithm == 0) then ! from dew point temperature
+                if (associated(strm_Sa_tdew)) then
+                   if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
+                   e = datm_eSat(strm_Sa_tdew(n), tbot)
+                   qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
+                else
+                   if (mainproc) write(logunit,*) subname,' Sa_tdew needs to be provided. Exiting!'
+                   call shr_log_error(subname//'ERROR: Sa_tdew must be to calculate specific humidity with qsat_algorithm = 0', rc=rc)
+                   return
+                end if
+             elseif (qsat_algorithm == 1) then ! from temperature and pressure
+                qsat = datm_qSat_Gill82(tbot, pbot)
              else
-                if (mainproc) write(logunit,*) subname,' Sa_tdew needs to be provided. Exiting!'
-                call shr_log_error(subname//'ERROR: Sa_tdew must be to calculate specific humidity with qsat_algorithm = 1', rc=rc)
+                if (mainproc) write(logunit,*) subname,' qsat_algorithm can be only 0 and 1. Exiting!'
+                call shr_log_error(subname//'ERROR: qsat_algorithm can be only 0 and 1. Please correct datm_in.', rc=rc)
                 return
              end if
-          elseif (qsat_algorithm == 1) then ! from temperature and pressure
-             qsat = datm_qSat_Gill82(tbot, pbot)
-          else
-             if (mainproc) write(logunit,*) subname,' qsat_algorithm can be only 0 and 1. Exiting!'
-             call shr_log_error(subname//'ERROR: qsat_algorithm can be only 0 and 1. Please correct datm_in.', rc=rc)
-             return
-          end if
 
-          if (associated(Sa_q2m)) Sa_q2m(n) = qsat
-          if (associated(Sa_shum)) Sa_shum(n) = qsat
+             if (associated(Sa_q2m)) Sa_q2m(n) = qsat
+             if (associated(Sa_shum)) Sa_shum(n) = qsat
+          end if
        end if
 
        !--- calculate density --

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -17,7 +17,8 @@ module datm_datamode_era5_mod
   public  :: datm_datamode_era5_init_pointers
   public  :: datm_datamode_era5_advance
 
-  private :: datm_eSat  ! determine saturation vapor pressure
+  private :: datm_eSat        ! determine saturation vapor pressure
+  private :: datm_qSat_Gill82 ! 
 
   ! export state data
   real(r8), pointer :: Sa_z(:)              => null()
@@ -426,7 +427,8 @@ contains
   end subroutine datm_datamode_era5_init_pointers
 
   !===============================================================================
-  subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, model_calendar, rc)
+  subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, target_ymd, target_tod, &
+                model_calendar, qsat_algorithm, rc)
 
     use ESMF, only: ESMF_VMGetCurrent, ESMF_VMAllReduce, ESMF_REDUCE_MAX, ESMF_VM
 
@@ -437,6 +439,7 @@ contains
     integer                , intent(in)    :: target_ymd
     integer                , intent(in)    :: target_tod
     character(len=*)       , intent(in)    :: model_calendar
+    integer                , intent(in)    :: qsat_algorithm
     integer                , intent(out)   :: rc
 
     ! local variables
@@ -590,8 +593,8 @@ contains
           Sa_wspd(n) = sqrt(strm_Sa_u(n)*strm_Sa_u(n) + strm_Sa_v(n)*strm_Sa_v(n))
        end if
 
-       !--- calculate specific humidity from dew point temperature ---
-       if (associated(strm_Sa_tdew)) then
+       !--- calculate specific humidity ---
+       if (associated(Sa_q2m) .or. associated(Sa_shum)) then
           if (associated(strm_Sa_t2m)) then
              tbot = strm_Sa_t2m(n)
           else if (associated(strm_Sa_tbot)) then
@@ -604,9 +607,24 @@ contains
              pbot = strm_Sa_pbot(n)
           end if
 
-          if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
-          e = datm_eSat(strm_Sa_tdew(n), tbot)
-          qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
+          if (qsat_algorithm == 0) then ! from dew point temperature
+             if (associated(strm_Sa_tdew)) then     
+                if (td2max < 50.0_r8) strm_Sa_tdew(n) = strm_Sa_tdew(n) + tkFrz
+                e = datm_eSat(strm_Sa_tdew(n), tbot)
+                qsat = (0.622_r8 * e)/(pbot - 0.378_r8 * e)
+             else
+                if (mainproc) write(logunit,*) subname,' Sa_tdew needs to be provided. Exiting!'
+                call shr_log_error(subname//'ERROR: Sa_tdew must be to calculate specific humidity with qsat_algorithm = 1', rc=rc)
+                return
+             end if
+          elseif (qsat_algorithm == 1) then ! from temperature and pressure
+             qsat = datm_qSat_Gill82(tbot, pbot)
+          else
+             if (mainproc) write(logunit,*) subname,' qsat_algorithm can be only 0 and 1. Exiting!'
+             call shr_log_error(subname//'ERROR: qsat_algorithm can be only 0 and 1. Please correct datm_in.', rc=rc)
+             return
+          end if
+
           if (associated(Sa_q2m)) Sa_q2m(n) = qsat
           if (associated(Sa_shum)) Sa_shum(n) = qsat
        end if
@@ -721,5 +739,33 @@ contains
     end if
 
   end function datm_eSat
+
+  !===============================================================================
+  real(r8) function datm_qSat_Gill82(t,p)
+
+    !----------------------------------------------------------------------------
+    ! use Gill (1981) to calculate saturation specific humidity
+    !----------------------------------------------------------------------------
+
+    ! input/output variables
+    real(r8),intent(in) :: t  ! temperature, K
+    real(r8),intent(in) :: p  ! pressure, Pa
+
+    ! local variables
+    real(r8) :: e_sw, f_w, e_sw_prime, tc, pmb
+
+    !--- coefficients ---
+    ! not used in Gill but used in Tsujino et al (2018)
+    real(r8),parameter :: correction_factor_salt_water = 0.98_r8
+    real(r8),parameter :: omega = 0.62197_r8
+
+    tc = t-273.15d0
+    pmb = p/100.0d0
+    e_sw = 10.0_r8 ** ((0.7859_r8 + 0.03477_r8 * tc) / (1.0_r8 + 0.00412_r8 * tc))
+    f_w = 1.0_r8 + 1.0d-6 * pmb * (4.5_r8 + 0.0006_r8 * tc**2)
+    e_sw_prime = f_w * e_sw * correction_factor_salt_water
+    datm_qSat_Gill82 = (omega * e_sw_prime) / (pmb - (1.0_r8 - omega) * e_sw_prime)
+
+  end function datm_qSat_Gill82
 
 end module datm_datamode_era5_mod


### PR DESCRIPTION
### Description of changes
This PR aims to restructure ERA5 data mode to support:
**(1)** Using ERA5 as a replacement of JRA55 under CESM framework. This work does not include any necessary change needs to be done in CIME interface. 
**(2)** Adding new data component configuration option for data atmosphere (DATM) as `skip_field_check`. The default value is `.false.` and does not change the exiting behavior. By setting it `.true.` the field check part is skipped and user is able to provide just set of fields supported by the data mode.
**(3)** The changes related to support UFS WM RTs with help of **(2)** and also some other changes. 

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list): 
No

Are changes expected to change answers (bfb, different to roundoff, more substantial): 
No

Any User Interface Changes (namelist or namelist defaults changes): 
New optional `skip_field_check` option for datm

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
**UFS WM RTs:**
```
datm_cdeps_lnd_era5
datm_cdeps_lnd_era5_rst
hafs_regional_datm_cdeps
```
**UFS Coastal:**
```
DATM-DOCN-CICE6 and DATM-SCHSIM-CICE6 regional sea-ice configuration
```

Hashes used for testing:

