### PR TITLE
Move co2diag from 3hourly to daily for CPLHIST mode

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -163,7 +163,7 @@
 
   <entry id="DATM_CO2_TSERIES">
     <type>char</type>
-    <valid_values>none,cmip6_20tr,cmip7_20tr,omip.iaf,omip.jra,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5</valid_values>
+    <valid_values>none,cplhist,cmip6_20tr,cmip7_20tr,omip.iaf,omip.jra,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5</valid_values>
     <default_value>none</default_value>
     <values match="last">
       <value compset="^SSP119_">SSP1-1.9</value>
@@ -178,6 +178,7 @@
       <value compset="^20TR"   >cmip6_20tr</value>
       <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">omip.iaf</value>
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">omip.jra</value>
+      <value compset="_DATM%CPLHIST">cplhist</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -155,6 +155,7 @@
   - The historical series are labeled as either CMIP6 or CMIP7 era
   - The SSP future scenarios are all CMIP6 era data
   ========================
+  co2tseries.cplhist
   co2tseries.cmip6_20tr
   co2tseries.cmip7_20tr
   co2tseries.omip.iaf
@@ -3812,6 +3813,37 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
+  <stream_entry name="co2tseries.cplhist">
+    <stream_meshfile>
+      <meshfile>$ATM_DOMAIN_MESH</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END" filename_advance_days='1'>$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.24h.avrg.%ymd-00000.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>atmImp_Sa_co2diag   Sa_co2diag</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>3.0</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
   <stream_entry name="co2tseries.omip.iaf">
     <stream_meshfile>
       <meshfile>none</meshfile>
@@ -5348,7 +5380,6 @@
       <var>atmImp_Sa_pbot    Sa_pbot</var>
       <var>atmImp_Sa_dens    Sa_dens</var>
       <var>atmImp_Sa_pslv    Sa_pslv</var>
-      <var>atmImp_Sa_co2diag Sa_co2diag</var>
       <var>atmImp_Sa_co2prog Sa_co2prog</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -63,11 +63,11 @@
   </test>
   <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="ERS_Ld5" testmods="datm/cplhist_create">
     <machines>
-      <machine name="derecho" compiler="gnu" category="aux_cdeps"/>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
-      <option name="comment">Make sure can run creating CPLHIST data to run DATM from with DEBUG off for gnu compiler</option>
+      <option name="comment">Make sure can run creating CPLHIST data to run DATM from with DEBUG off</option>
     </options>
   </test>
   <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -43,7 +43,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="1850_DATM%CPLHIST_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5" testmods="datm/cplhist">
+  <test compset="1850_DATM%CPLHIST_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="SMS_Ld5" testmods="datm/cplhist">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -52,13 +52,22 @@
       <option name="comment">Make sure CPLHIST mode will run</option>
     </options>
   </test>
-  <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5" testmods="datm/cplhist_create">
+  <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="SMS_D_Ld5" testmods="datm/cplhist_create">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
-      <option name="comment">Make sure can run creating CPLHIST data</option>
+      <option name="comment">Make sure can run creating CPLHIST data to run DATM from with DEBUG on</option>
+    </options>
+  </test>
+  <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="ERS_Ld5" testmods="datm/cplhist_create">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="aux_cdeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+      <option name="comment">Make sure can run creating CPLHIST data to run DATM from with DEBUG off for gnu compiler</option>
     </options>
   </test>
   <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -43,6 +43,24 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+  <test compset="1850_DATM%CPLHIST_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5" testmods="datm/cplhist">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+      <option name="comment">Make sure CPLHIST mode will run</option>
+    </options>
+  </test>
+  <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5" testmods="datm/cplhist_create">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+      <option name="comment">Make sure can run creating CPLHIST data</option>
+    </options>
+  </test>
   <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
@@ -114,7 +132,6 @@
   <test compset="1850_DATM%CRUJRA2024_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Ld5">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
-      <machine name="betzy" compiler="intel" category="aux_cdeps_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/datm/cime_config/testdefs/testmods_dirs/datm/cplhist/shell_commands
+++ b/datm/cime_config/testdefs/testmods_dirs/datm/cplhist/shell_commands
@@ -1,0 +1,6 @@
+./xmlchange DATM_CPLHIST_DIR="/glade/derecho/scratch/hannay/archive/b.e30_alpha08o.B1850C_MTso.ne30_t232_wgx3.330/cpl/hist/"
+./xmlchange DATM_CPLHIST_CASE="b.e30_alpha08o.B1850C_MTso.ne30_t232_wgx3.330"
+./xmlchange DATM_YR_START="101"
+./xmlchange DATM_YR_END="101"
+./xmlchange RUN_STARTDATE="0101-01-01"
+./xmlchange DATM_PRESNDEP="clim_1850_cmip6"

--- a/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/shell_commands
+++ b/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/shell_commands
@@ -1,0 +1,5 @@
+./xmlchange DATM_CO2_TSERIES=cmip6_20tr
+./xmlchange DATM_PRESO3=clim_1850
+./xmlchange DATM_TOPO=observed
+./xmlchange CCSM_BGC=CO2A
+

--- a/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
+++ b/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
@@ -1,0 +1,9 @@
+histaux_l2x1yrg = .true.
+histaux_atm2med_file1_enabled = .true.
+histaux_atm2med_file2_enabled = .true.
+histaux_atm2med_file3_enabled = .true.
+histaux_atm2med_file4_enabled = .true.
+histaux_atm2med_file5_enabled = .true.
+histaux_atm2med_file5_history_n = 1
+histaux_atm2med_file5_history_option = 'ndays'
+histaux_atm2med_file5_ntperfile = 1

--- a/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
+++ b/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
@@ -1,4 +1,3 @@
-histaux_l2x1yrg = .true.
 histaux_atm2med_file1_enabled = .true.
 histaux_atm2med_file2_enabled = .true.
 histaux_atm2med_file3_enabled = .true.
@@ -7,5 +6,3 @@ histaux_atm2med_file5_enabled = .true.
 histaux_atm2med_file5_history_n = 1
 histaux_atm2med_file5_history_option = 'ndays'
 histaux_atm2med_file5_ntperfile = 1
-
-histaux_lnd2med_file1_enabled = .true.

--- a/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
+++ b/datm/cime_config/testdefs/testmods_dirs/datm/cplhist_create/user_nl_cpl
@@ -7,3 +7,5 @@ histaux_atm2med_file5_enabled = .true.
 histaux_atm2med_file5_history_n = 1
 histaux_atm2med_file5_history_option = 'ndays'
 histaux_atm2med_file5_ntperfile = 1
+
+histaux_lnd2med_file1_enabled = .true.


### PR DESCRIPTION
### Description of changes

In order to synchronize with how the CPLHIST output files are handled in the latest CMEPS, this move the reading of co2diag from the 3-hourly file to the daily file. It also 

### Specific notes

Contributors other than yourself, if any: @billsacks

CDEPS Issues Fixed (include github issue #):
  Fixes #400

Are there dependencies on other component PRs (if so list):
  Needed for CDEPS to work with output using cmeps1.1.35

Are changes expected to change answers (bfb, different to roundoff, more substantial):
   Answers for CPLHIST will be different and greater than roundoff, but it also didn't work previously

Any User Interface Changes (namelist or namelist defaults changes):
   Add cplhist mode as an option to DATM_CO2_TSERIES
   Remove co2diag from CPLHIST for the 3hourly stream file
   When cplhist mode is used in DATM_CO2_TSERIES use the daily file

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): So far running a case on Derecho_intel
   Will run aux_cdeps

Hashes used for testing:

Definition of Done:
 - [x] Add some tests for this to aux_cdeps testlist
 - [x] Run aux_cdeps compared to the cesm3_0_beta08 baselines