### PR TITLE
Support JRA55do in datm

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -364,7 +364,7 @@ contains
     ! Validate sdat datamode
     if (mainproc) write(logunit,*) ' datm datamode = ',trim(datamode)
     select case (trim(datamode))
-       case ('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA', &
+       case ('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA', 'JRA55do', &
              'CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA', &
              'CLMNCEP','CPLHIST','GEFS','ERA5','SIMPLE')
        if (mainproc) write(logunit,'(3a)') subname,'datm datamode = ',trim(datamode)
@@ -392,7 +392,7 @@ contains
     case ('CORE2_NYF', 'CORE2_IAF')
        call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
+    case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA', 'JRA55do')
        call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CLMNCEP')
@@ -659,7 +659,7 @@ contains
        case('CORE2_NYF','CORE2_IAF')
           call datm_datamode_core2_init_pointers(exportState, sdat, datamode, factorfn_mesh, factorfn_data, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
+       case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA', 'JRA55do')
           call datm_datamode_jra_init_pointers(exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('CLMNCEP')
@@ -686,7 +686,7 @@ contains
           select case (trim(datamode))
           case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
                'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
-               'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+               'CORE_RYF9091_JRA','CORE_RYF0304_JRA' , 'JRA55do', &
                'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
              call dshr_restart_read(restfilm, rpfile, logunit, my_task, mpicom, sdat, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -737,7 +737,7 @@ contains
        call datm_datamode_core2_advance(datamode, target_ymd, target_tod, target_mon, &
             sdat%model_calendar, factorfn_mesh, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    case('CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA')
+    case('CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA', 'JRA55do')
        call datm_datamode_jra_advance(exportstate, target_ymd, target_tod, sdat%model_calendar, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('CLMNCEP')
@@ -764,7 +764,7 @@ contains
        select case (trim(datamode))
        case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
             'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
-            'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+            'CORE_RYF9091_JRA','CORE_RYF0304_JRA','JRA55do' ,&
             'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
           call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, &
                target_ymd, target_tod, logunit, my_task, sdat, rc)

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -47,7 +47,9 @@ module datm_datamode_jra_mod
   real(r8), pointer :: strm_Sa_u(:)      => null()
   real(r8), pointer :: strm_Sa_v(:)      => null()
   real(r8), pointer :: strm_Sa_shum(:)   => null()
-  real(r8), pointer :: strm_Faxa_prec(:) => null()
+  real(r8), pointer :: strm_Faxa_prec(:) => null()   ! Jra provides one precip flux
+  real(r8), pointer :: strm_Faxa_prrn(:) => null()   ! Jra55do provides rainfall flux
+  real(r8), pointer :: strm_Faxa_prsn(:) => null()   ! and Snowfall flux seperately
   real(r8), pointer :: strm_Faxa_lwdn(:) => null()
   real(r8), pointer :: strm_Faxa_swdn(:) => null()
 
@@ -119,6 +121,8 @@ contains
 
   !===============================================================================
   subroutine datm_datamode_jra_init_pointers(exportState, sdat, rc)
+
+    use shr_log_mod      , only : shr_log_error
 
     ! input/output variables
     type(ESMF_State)       , intent(inout) :: exportState
@@ -193,9 +197,19 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! initialize stream pointers
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_prec' , strm_Faxa_prec  , requirePointer=.true., &
-         errmsg=subname//'ERROR: strm_Faxa_prec must be associated for jra datamode', rc=rc)
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_prec' , strm_Faxa_prec  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_prrn' , strm_Faxa_prrn  , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_prsn' , strm_Faxa_prsn  , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if ( .not. ((associated(strm_Faxa_prec) & !jra 55
+          .or. (associated(strm_Faxa_prrn) .and. associated(strm_Faxa_prsn))))) & !jra55do
+          call shr_log_error(subName//"ERROR: strm_Faxa_prec or (strm_Faxa_prrn and strm_Faxa_prsn) "//&
+               "must be associated for jra datamode", rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_swdn' , strm_Faxa_swdn  , requirePointer=.true., &
          errmsg=subname//'ERROR: strm_Faxa_swdn must be associated for jra datamode', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -233,6 +247,7 @@ contains
     ! local variables
     integer           :: n
     integer           :: lsize
+    logical           :: jra55do
     real(R8)          :: avg_alb            ! average albedo
     real(R8)          :: rday               ! elapsed day
     real(R8)          :: cosFactor          ! cosine factor
@@ -242,6 +257,12 @@ contains
     rc = ESMF_SUCCESS
 
     lsize = size(Sa_z)
+
+    if (associated(strm_Faxa_prrn) .and. associated(strm_Faxa_prsn)) then
+      jra55do = .true.
+    else
+      jra55do = .false.
+    endif
 
     call shr_cal_date2julian(target_ymd, target_tod, rday, model_calendar)
     rday = mod((rday - 1.0_R8),365.0_R8)
@@ -273,12 +294,17 @@ contains
        ! precipitation data
        Faxa_rainc(n) = 0.0_R8               ! default zero
        Faxa_snowc(n) = 0.0_R8
-       if (Sa_tbot(n) < tKFrz ) then        ! assign precip to rain/snow components
-          Faxa_rainl(n) = 0.0_R8
-          Faxa_snowl(n) = strm_Faxa_prec(n)
+       if (jra55do) then
+          Faxa_snowl(n) = strm_Faxa_prsn(n)         ! Snowfall flux
+          Faxa_rainl(n) = strm_Faxa_prrn(n)         ! Rainfall flux
        else
-          Faxa_rainl(n) = strm_Faxa_prec(n)
-          Faxa_snowl(n) = 0.0_R8
+          if (Sa_tbot(n) < tKFrz ) then        ! assign precip to rain/snow components
+               Faxa_rainl(n) = 0.0_R8
+               Faxa_snowl(n) = strm_Faxa_prec(n)
+          else
+               Faxa_rainl(n) = strm_Faxa_prec(n)
+               Faxa_snowl(n) = 0.0_R8
+          endif
        endif
 
        ! radiation data - fabricate required swdn components from net swdn

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -49,7 +49,7 @@ module datm_datamode_jra_mod
   real(r8), pointer :: strm_Sa_shum(:)   => null()
   real(r8), pointer :: strm_Faxa_prec(:) => null()   ! Jra provides one precip flux
   real(r8), pointer :: strm_Faxa_prrn(:) => null()   ! Jra55do provides rainfall flux
-  real(r8), pointer :: strm_Faxa_prsn(:) => null()   ! and Snowfall flux seperately
+  real(r8), pointer :: strm_Faxa_prsn(:) => null()   ! and Snowfall flux separately
   real(r8), pointer :: strm_Faxa_lwdn(:) => null()
   real(r8), pointer :: strm_Faxa_swdn(:) => null()
 
@@ -247,7 +247,7 @@ contains
     ! local variables
     integer           :: n
     integer           :: lsize
-    logical           :: strm_seperates_rain_snow
+    logical           :: strm_separates_rain_snow
     real(R8)          :: avg_alb            ! average albedo
     real(R8)          :: rday               ! elapsed day
     real(R8)          :: cosFactor          ! cosine factor
@@ -259,9 +259,9 @@ contains
     lsize = size(Sa_z)
 
     if (associated(strm_Faxa_prrn) .and. associated(strm_Faxa_prsn)) then
-      strm_seperates_rain_snow = .true.
+      strm_separates_rain_snow = .true.
     else
-      strm_seperates_rain_snow = .false.
+      strm_separates_rain_snow = .false.
     endif
 
     call shr_cal_date2julian(target_ymd, target_tod, rday, model_calendar)
@@ -294,7 +294,7 @@ contains
        ! precipitation data
        Faxa_rainc(n) = 0.0_R8               ! default zero
        Faxa_snowc(n) = 0.0_R8
-       if (strm_seperates_rain_snow) then
+       if (strm_separates_rain_snow) then
           Faxa_snowl(n) = strm_Faxa_prsn(n)         ! Snowfall flux
           Faxa_rainl(n) = strm_Faxa_prrn(n)         ! Rainfall flux
        else

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -247,7 +247,7 @@ contains
     ! local variables
     integer           :: n
     integer           :: lsize
-    logical           :: jra55do
+    logical           :: strm_seperates_rain_snow
     real(R8)          :: avg_alb            ! average albedo
     real(R8)          :: rday               ! elapsed day
     real(R8)          :: cosFactor          ! cosine factor
@@ -259,9 +259,9 @@ contains
     lsize = size(Sa_z)
 
     if (associated(strm_Faxa_prrn) .and. associated(strm_Faxa_prsn)) then
-      jra55do = .true.
+      strm_seperates_rain_snow = .true.
     else
-      jra55do = .false.
+      strm_seperates_rain_snow = .false.
     endif
 
     call shr_cal_date2julian(target_ymd, target_tod, rday, model_calendar)
@@ -294,7 +294,7 @@ contains
        ! precipitation data
        Faxa_rainc(n) = 0.0_R8               ! default zero
        Faxa_snowc(n) = 0.0_R8
-       if (jra55do) then
+       if (strm_seperates_rain_snow) then
           Faxa_snowl(n) = strm_Faxa_prsn(n)         ! Snowfall flux
           Faxa_rainl(n) = strm_Faxa_prrn(n)         ! Rainfall flux
        else

--- a/doc/source/datm.rst
+++ b/doc/source/datm.rst
@@ -53,6 +53,13 @@ CORE_IAF_JRA (``datm_datamode_jra_mod.F90``)
     forcing. This mode and associated data sets implement the JRA-55
     v1.3 forcing data.
 
+JRA55do (``datm_datamode_jra_mod.F90``)
+  - Provides the JRA55-do forcing developed for driving ocean - sea ice models, 
+    when coupling an active ocean model with reanalysis surface
+    forcing. This mode and associated data sets implement the JRA-55do v1.4 to 
+    v1.6 forcing data. Note that `CORE_IAF_JRA` and `JRA55do` work exactly the
+    same way.
+
 ERA5 (``datm_datamode_era5_mod.F90``)
   - Fifth generation ECMWF atmospheric reanalysis of the global climate.
     This mode is mainly used by NOAA's UFS Weather model to support


### PR DESCRIPTION
### Description of changes

This adds support for JRA55do within `datm` - namely, rain and snow can be seperate forcing variables (currently assumed to be the same forcing variable)

### Specific notes

Contributors other than yourself, if any:

- CDEPS Issues Fixed (include github issue #): #406

Are there dependencies on other component PRs (if so list): None

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes):

 No namelist changes
- adds `JRA55do` to existing options for `datamode` in `datm_in`
- allows use of `Faxa_prsn` (snow) and `Faxa_prrn` (rain) in datm.streams.xml files

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

- We've been running ACCESS-OM3 with this change for a couple of months

Hashes used for testing:

https://github.com/ESCOMP/CDEPS/commit/0b2d3bddbe881ba381fb1fba54d0dd27e706c752
