### PR TITLE
No longer need to allow for C/E at end of time period

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -81,7 +81,7 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"   >clim_1850</value>
+      <value compset="^1850_"   >clim_1850</value>
       <value compset="^2000_"   >clim_2000</value>
       <value compset="^2010_"   >clim_2010</value>
       <value compset="^SSP119_" >SSP1-1.9</value>
@@ -92,7 +92,7 @@
       <value compset="^SSP460_" >SSP4-6.0</value>
       <value compset="^SSP534_" >SSP5-3.4</value>
       <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST[CE]?_"   >hist</value>
+      <value compset="^HIST_"   >hist</value>
       <value compset="^20TR_"   >hist</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
@@ -107,10 +107,10 @@
     <valid_values>none,clim_1850_cmip7,clim_2000_cmip7,clim_2010_cmip7,hist_cmip7,clim_1850_cmip6,clim_2000_cmip6,clim_2010_cmip6,hist_cmip6,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"  >clim_1850_cmip6</value>
+      <value compset="^1850_"       >clim_1850_cmip6</value>
       <value compset="^2000_"       >clim_2000_cmip6</value>
       <value compset="^2010_"       >clim_2010_cmip6</value>
-      <value compset="^HIST[CE]?_"  >hist_cmip6</value>
+      <value compset="^HIST_"       >hist_cmip6</value>
       <value compset="^20TR_"       >hist_cmip6</value>
       <value compset="^SSP126_"     >SSP1-2.6</value>
       <value compset="^SSP245_"     >SSP2-4.5</value>
@@ -129,13 +129,13 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP2-4.5,SSP3-7.0,SSP5-8.5</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"   >clim_1850</value>
+      <value compset="^1850_"   >clim_1850</value>
       <value compset="^2000_"   >clim_2000</value>
       <value compset="^2010_"   >clim_2010</value>
       <value compset="^SSP245_" >SSP2-4.5</value>
       <value compset="^SSP370_" >SSP3-7.0</value>
       <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST[CE]?_"   >hist</value>
+      <value compset="^HIST_"   >hist</value>
       <value compset="^20TR_"   >hist</value>
       <!-- Only needed for compsets with active land; only in DATM CLMNCEP mode -->
       <value compset="_SLND">none</value>
@@ -174,7 +174,7 @@
       <value compset="^SSP460_">SSP4-6.0</value>
       <value compset="^SSP534_">SSP5-3.4</value>
       <value compset="^SSP585_">SSP5-8.5</value>
-      <value compset="^HIST[CE]?_">cmip6_20tr</value>
+      <value compset="^HIST_"  >cmip6_20tr</value>
       <value compset="^20TR"   >cmip6_20tr</value>
       <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">omip.iaf</value>
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">omip.jra</value>


### PR DESCRIPTION
### Description of changes

We are changing the compset specification to no longer have C/E at the end of the time period, so we can remove the parsing of this from compset regexes.

Needs to wait for the compset changes in
https://github.com/ESCOMP/CESM/pull/407 and
https://github.com/ESCOMP/CAM/pull/1584.

### Specific notes

Contributors other than yourself, if any: none

CDEPS Issues Fixed (include github issue #): none

Are there dependencies on other component PRs (if so list):
- https://github.com/ESCOMP/CESM/pull/407
- https://github.com/ESCOMP/CAM/pull/1584

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): none yet

Hashes used for testing:

