### PR TITLE
Reduce the memory usage that is important for ne1024 simulation

### DIFF
--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -263,7 +263,7 @@ contains
        stream_filenames, stream_fldlistFile, stream_fldListModel, &
        stream_yearFirst, stream_yearLast, stream_yearAlign, &
        stream_offset, stream_taxmode, stream_dtlimit, stream_tintalgo, &
-       stream_src_mask, stream_dst_mask, stream_name, rc)
+       stream_src_mask, stream_dst_mask, stream_name, rc, stream_mesh_in)
 
     ! input/output variables
     type(shr_strdata_type)      , intent(inout) :: sdat                   ! stream data type
@@ -289,6 +289,9 @@ contains
     integer          , optional , intent(in)    :: stream_dst_mask        ! destination mask value
     character(len=*) , optional , intent(in)    :: stream_name            ! name of stream
     integer          , optional , intent(out)   :: rc                     ! error code
+    type(ESMF_Mesh)  , optional , intent(in)    :: stream_mesh_in         ! reuse this mesh instead of reading
+                                                                          ! stream_meshfile (e.g. model_mesh for a
+                                                                          ! same-grid 'redist' stream)
 
     ! local variables
     integer       :: src_mask = 0
@@ -344,7 +347,7 @@ contains
          sdat%logunit, trim(compname), sdat%mainproc, src_mask, dst_mask)
 
     ! Now finish initializing sdat
-    call shr_strdata_init(sdat, model_clock, stream_name, rc)
+    call shr_strdata_init(sdat, model_clock, stream_name, rc, stream_mesh_in=stream_mesh_in)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine shr_strdata_init_from_inline
@@ -446,13 +449,15 @@ contains
   end subroutine shr_strdata_init_model_domain
 
   !===============================================================================
-  subroutine shr_strdata_init(sdat, model_clock, stream_name, rc)
+  subroutine shr_strdata_init(sdat, model_clock, stream_name, rc, stream_mesh_in)
 
     ! input/output variables
     type(shr_strdata_type)     , intent(inout), target :: sdat
     type(ESMF_Clock)           , intent(in)            :: model_clock
     character(len=*), optional , intent(in)            :: stream_name
     integer                    , intent(out)           :: rc
+    type(ESMF_Mesh) , optional , intent(in)            :: stream_mesh_in  ! reuse this mesh instead of reading the
+                                                                          ! stream mesh file (same-grid 'redist' streams)
 
     ! local variables
     type(ESMF_Mesh), pointer     :: stream_mesh
@@ -500,7 +505,14 @@ contains
        endif
 
        ! We do not yet have mask information, but we are required to set it here and change it later.
-       if (filename /= 'none') then
+       if (present(stream_mesh_in)) then
+          ! Reuse a caller-provided mesh (e.g. the model mesh for a same-grid
+          ! 'redist' stream) instead of building a duplicate full ESMF mesh from
+          ! file. Avoids the mesh-create cost (file read + mesh build) at high
+          ! resolution. Safe: this routine only reads stream_mesh (no MeshSet/
+          ! MeshDestroy), so the shared handle is never mutated or freed here.
+          stream_mesh = stream_mesh_in
+       else if (filename /= 'none') then
           stream_mesh = ESMF_MeshCreate(trim(filename), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        endif

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -263,7 +263,7 @@ contains
        stream_filenames, stream_fldlistFile, stream_fldListModel, &
        stream_yearFirst, stream_yearLast, stream_yearAlign, &
        stream_offset, stream_taxmode, stream_dtlimit, stream_tintalgo, &
-       stream_src_mask, stream_dst_mask, stream_name, stream_mesh_in, rc)
+       stream_src_mask, stream_dst_mask, stream_name, rc)
 
     ! input/output variables
     type(shr_strdata_type)      , intent(inout) :: sdat                   ! stream data type
@@ -288,9 +288,6 @@ contains
     integer          , optional , intent(in)    :: stream_src_mask        ! source mask value
     integer          , optional , intent(in)    :: stream_dst_mask        ! destination mask value
     character(len=*) , optional , intent(in)    :: stream_name            ! name of stream
-    type(ESMF_Mesh)  , optional , intent(in)    :: stream_mesh_in         ! reuse this mesh instead of reading
-                                                                          ! stream_meshfile (e.g. model_mesh for a
-                                                                          ! same-grid 'redist' stream)
     integer          , optional , intent(out)   :: rc                     ! error code
 
     ! local variables
@@ -347,7 +344,7 @@ contains
          sdat%logunit, trim(compname), sdat%mainproc, src_mask, dst_mask)
 
     ! Now finish initializing sdat
-    call shr_strdata_init(sdat, model_clock, stream_name, stream_mesh_in=stream_mesh_in, rc=rc)
+    call shr_strdata_init(sdat, model_clock, stream_name, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine shr_strdata_init_from_inline
@@ -449,14 +446,12 @@ contains
   end subroutine shr_strdata_init_model_domain
 
   !===============================================================================
-  subroutine shr_strdata_init(sdat, model_clock, stream_name, stream_mesh_in, rc)
+  subroutine shr_strdata_init(sdat, model_clock, stream_name, rc)
 
     ! input/output variables
     type(shr_strdata_type)     , intent(inout), target :: sdat
     type(ESMF_Clock)           , intent(in)            :: model_clock
     character(len=*), optional , intent(in)            :: stream_name
-    type(ESMF_Mesh) , optional , intent(in)            :: stream_mesh_in  ! reuse this mesh instead of reading the
-                                                                          ! stream mesh file (same-grid 'redist' streams)
     integer                    , intent(out)           :: rc
 
     ! local variables
@@ -505,13 +500,16 @@ contains
        endif
 
        ! We do not yet have mask information, but we are required to set it here and change it later.
-       if (present(stream_mesh_in)) then
-          ! Reuse a caller-provided mesh (e.g. the model mesh for a same-grid
-          ! 'redist' stream) instead of building a duplicate full ESMF mesh from
-          ! file. Avoids the mesh-create cost (file read + mesh build) at high
-          ! resolution. Safe: this routine only reads stream_mesh (no MeshSet/
-          ! MeshDestroy), so the shared handle is never mutated or freed here.
-          stream_mesh = stream_mesh_in
+       if (trim(sdat%stream(ns)%mapalgo) == 'redist' .and. filename /= 'none') then
+          ! A 'redist' stream is on the same grid as the model: the stream->model mapping is a 1-to-1 index copy,
+          ! so the stream mesh and the model mesh are identical. Reuse the already-built model mesh instead of reading
+          ! the stream mesh file and constructing a duplicate full ESMF mesh -- that duplicate is a large init memory
+          ! and time cost at high resolution.
+          ! Only stream_mesh is read below (no MeshSet/MeshDestroy), so sharing the model-mesh handle is safe.
+          ! First verify the grids really match (redist requires identical global sizes) and error clearly if not.
+          call shr_strdata_check_redist_size(sdat, ns, trim(filename), rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          stream_mesh = sdat%model_mesh
        else if (filename /= 'none') then
           stream_mesh = ESMF_MeshCreate(trim(filename), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -765,6 +763,63 @@ contains
        write(sdat%logunit,'(2a)') subname,' successfully initialized sdat'
     endif
   end subroutine shr_strdata_init
+
+  !===============================================================================
+  subroutine shr_strdata_check_redist_size(sdat, ns, meshfile, rc)
+
+    ! Verify that a 'redist' stream really is on the model grid before reusing the
+    ! model mesh in place of the stream mesh file. 'redist' is a 1-to-1 index copy,
+    ! so the stream mesh file and the model mesh must have the same global element
+    ! count; otherwise the redistribution is invalid. Only the elementCount
+    ! dimension of the (ESMF-format) mesh file is read here -- cheap metadata, not
+    ! the full mesh, so the memory/time saving of reusing the model mesh is kept.
+
+    ! input/output variables
+    type(shr_strdata_type) , intent(in)  :: sdat
+    integer                , intent(in)  :: ns         ! stream index
+    character(len=*)       , intent(in)  :: meshfile   ! stream mesh filename
+    integer                , intent(out) :: rc
+
+    ! local variables
+    type(file_desc_t) :: pioid
+    integer           :: rcode
+    integer           :: dimid
+    integer           :: stream_gsize
+    integer           :: old_handle    ! previous setting of pio error handling
+    character(len=*), parameter :: subname = '(shr_strdata_check_redist_size) '
+    ! ----------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Nothing to verify against if there is no mesh file.
+    if (len_trim(meshfile) == 0 .or. trim(meshfile) == 'none') return
+
+    ! Read the global element count from the mesh file (collective over the pio
+    ! subsystem; all ranks already hold the same meshfile and model_gsize, so the
+    ! comparison below is identical on every rank).
+    rcode = pio_openfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(meshfile), pio_nowrite)
+    call pio_seterrorhandling(pioid, PIO_BCAST_ERROR, old_handle)
+    rcode = pio_inq_dimid(pioid, 'elementCount', dimid)
+    if (rcode == PIO_NOERR) then
+       rcode = pio_inq_dimlen(pioid, dimid, stream_gsize)
+    end if
+    call pio_seterrorhandling(pioid, old_handle)
+    call pio_closefile(pioid)
+
+    ! If the mesh file is not in ESMF format (no elementCount dimension) we cannot
+    ! verify the size here; leave any problem for the downstream data read to catch.
+    if (rcode /= PIO_NOERR) return
+
+    if (stream_gsize /= sdat%model_gsize) then
+       call shr_log_error(subname//"ERROR: mapalgo='redist' for stream "//toString(ns)// &
+            " requires the model grid and the stream mesh file to be the same size, but the model"// &
+            " grid has "//toString(sdat%model_gsize)//" elements while the stream mesh file '"// &
+            trim(meshfile)//"' has elementCount = "//toString(stream_gsize)//". Use a non-redist"// &
+            " mapalgo (e.g. consf, consd, nn or bilinear) when the stream is on a different grid.", rc=rc)
+       return
+    end if
+
+  end subroutine shr_strdata_check_redist_size
 
   !===============================================================================
   subroutine shr_strdata_get_stream_nlev(sdat, stream_index, rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -501,11 +501,17 @@ contains
 
        ! We do not yet have mask information, but we are required to set it here and change it later.
        if (trim(sdat%stream(ns)%mapalgo) == 'redist' .and. filename /= 'none') then
-          ! A 'redist' stream is on the same grid as the model: the stream->model mapping is a 1-to-1 index copy,
-          ! so the stream mesh and the model mesh are identical. Reuse the already-built model mesh instead of reading
-          ! the stream mesh file and constructing a duplicate full ESMF mesh -- that duplicate is a large init memory
-          ! and time cost at high resolution.
-          ! Only stream_mesh is read below (no MeshSet/MeshDestroy), so sharing the model-mesh handle is safe.
+          ! A 'redist' stream is on the same grid as the model, so reuse the already-built model mesh here
+          ! instead of reading the stream mesh file and constructing a duplicate full ESMF mesh -- that
+          ! duplicate is a large init-time memory and time cost at high resolution.
+          !
+          ! Why this is safe (subtle): we call the stream->model mapping a 'redist', but in fact the stream
+          ! decomposition is the same as the model decomposition, so the redist ends up simply being a copy.
+          ! That is what makes it safe to set the stream mesh equal to the model mesh -- both the underlying
+          ! grids/meshes and their decompositions are the same, so the result is identical to building a
+          ! separate stream mesh from the file. (Only stream_mesh is read below -- no MeshSet/MeshDestroy --
+          ! so sharing the model-mesh handle is also safe.)
+          !
           ! First verify the grids really match (redist requires identical global sizes) and error clearly if not.
           call shr_strdata_check_redist_size(sdat, ns, trim(filename), rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -263,7 +263,7 @@ contains
        stream_filenames, stream_fldlistFile, stream_fldListModel, &
        stream_yearFirst, stream_yearLast, stream_yearAlign, &
        stream_offset, stream_taxmode, stream_dtlimit, stream_tintalgo, &
-       stream_src_mask, stream_dst_mask, stream_name, rc, stream_mesh_in)
+       stream_src_mask, stream_dst_mask, stream_name, stream_mesh_in, rc)
 
     ! input/output variables
     type(shr_strdata_type)      , intent(inout) :: sdat                   ! stream data type
@@ -288,10 +288,10 @@ contains
     integer          , optional , intent(in)    :: stream_src_mask        ! source mask value
     integer          , optional , intent(in)    :: stream_dst_mask        ! destination mask value
     character(len=*) , optional , intent(in)    :: stream_name            ! name of stream
-    integer          , optional , intent(out)   :: rc                     ! error code
     type(ESMF_Mesh)  , optional , intent(in)    :: stream_mesh_in         ! reuse this mesh instead of reading
                                                                           ! stream_meshfile (e.g. model_mesh for a
                                                                           ! same-grid 'redist' stream)
+    integer          , optional , intent(out)   :: rc                     ! error code
 
     ! local variables
     integer       :: src_mask = 0
@@ -347,7 +347,7 @@ contains
          sdat%logunit, trim(compname), sdat%mainproc, src_mask, dst_mask)
 
     ! Now finish initializing sdat
-    call shr_strdata_init(sdat, model_clock, stream_name, rc, stream_mesh_in=stream_mesh_in)
+    call shr_strdata_init(sdat, model_clock, stream_name, stream_mesh_in=stream_mesh_in, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine shr_strdata_init_from_inline
@@ -449,15 +449,15 @@ contains
   end subroutine shr_strdata_init_model_domain
 
   !===============================================================================
-  subroutine shr_strdata_init(sdat, model_clock, stream_name, rc, stream_mesh_in)
+  subroutine shr_strdata_init(sdat, model_clock, stream_name, stream_mesh_in, rc)
 
     ! input/output variables
     type(shr_strdata_type)     , intent(inout), target :: sdat
     type(ESMF_Clock)           , intent(in)            :: model_clock
     character(len=*), optional , intent(in)            :: stream_name
-    integer                    , intent(out)           :: rc
     type(ESMF_Mesh) , optional , intent(in)            :: stream_mesh_in  ! reuse this mesh instead of reading the
                                                                           ! stream mesh file (same-grid 'redist' streams)
+    integer                    , intent(out)           :: rc
 
     ! local variables
     type(ESMF_Mesh), pointer     :: stream_mesh


### PR DESCRIPTION
This PR introduces some changes in CDEPS that will be used in CTSM later and are critical to reduce memory usage of a simulation at ne1024 resolution. All the changes are done by Claude under my supervisory.

The goal is to avoid the construction of a duplicate ESMF mesh for streams whose data already live on the model grid. When a stream uses `mapalgo = 'redist'` the stream→model mapping is a 1-to-1 index copy, so the stream mesh and the model mesh are necessarily identical. Previously `shr_strdata_init` always read the stream mesh file and called `ESMF_MeshCreate` to build a second, full ESMF mesh — at `ne1024` resolution that duplicate (NetCDF mesh-file read + ESMF mesh build) is a large initialization memory and time cost.

All edits are in `streams/dshr_strdata_mod.F90`:

1. Reuse the model mesh for `redist` streams. At the mesh-creation site in `shr_strdata_init`, when `mapalgo == 'redist'` (and the stream has a mesh file) the stream mesh is set to the already-built model mesh (`sdat%model_mesh`) instead of building a new one from file:
```
if (trim(sdat%stream(ns)%mapalgo) == 'redist' .and. filename /= 'none') then
   call shr_strdata_check_redist_size(sdat, ns, trim(filename), rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
   stream_mesh = sdat%model_mesh
else if (filename /= 'none') then
   stream_mesh = ESMF_MeshCreate(trim(filename), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
endif
```
This is a handle copy (the same assignment already used for the file-built mesh), so no second ESMF mesh is constructed. The per-stream `stream_mesh` is only ever read downstream (there is no `ESMF_MeshSet/ESMF_MeshDestroy` anywhere in the streams code), so sharing the model-mesh handle is safe — it is never mutated or freed through the stream slot.

2. New guard `shr_strdata_check_redist_size`. `redist` requires the stream and model grids to have the same global size. The new routine opens the stream mesh file and reads only its `elementCount` dimension — cheap metadata, not the full mesh, so the memory/time saving is preserved — and compares it to the model mesh global size (`sdat%model_gsize`). On a mismatch it aborts with a clear message stating that `mapalgo='redist'` requires matching grids and to use a non-redist mapalgo (consf/consd/nn/bilinear) for a different stream grid. If the mesh file is not in ESMF format (no `elementCount` dimension) the check is skipped and any problem is left to the downstream read. The PIO calls mirror the existing `shr_strdata_get_stream_nlev` idiom and are collective over the PIO subsystem; every rank holds the same `model_gsize` and reads the same `elementCount`, so the comparison is identical on all ranks.