### PR TITLE
Fix cplhist test

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -3839,7 +3839,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5217,7 +5217,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode></stream_entry>
 
@@ -5260,7 +5260,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5291,7 +5291,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5325,7 +5325,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5360,7 +5360,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5398,7 +5398,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>
@@ -5430,7 +5430,7 @@
       <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>3.0</dtlimit>
+      <dtlimit>1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>

--- a/datm/cime_config/testdefs/testlist_datm.xml
+++ b/datm/cime_config/testdefs/testlist_datm.xml
@@ -43,6 +43,15 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+  <test compset="1850_DATM%CPLHIST_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="SMS_Ld5" testmods="datm/cplhist">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cdeps"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+      <option name="comment">Make sure CPLHIST mode will run</option>
+    </options>
+  </test>
   <test compset="1850_DATM%CRUJRA2024b_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mt232" name="SMS_D_Ld5" testmods="datm/cplhist_create">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>


### PR DESCRIPTION
### Description of changes

Add back the cplhist test to aux_cdeps testlist after fixing it so that it actually works. It needed dtlimit increased to a large value so that it would work.

### Specific notes

Contributors other than yourself, if any: @billsacks 

CDEPS Issues Fixed (include github issue #):
  Fixes #408 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers (bfb, different to roundoff, more substantial): No

Any User Interface Changes (namelist or namelist defaults changes):
   Changes dtlimit for CPLHIST streams to 1.e30

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
   Running aux_cdeps compared to cesm3_0_alpha09c

Hashes used for testing:
   cesm: cesm3_0_alpha09c
   cdeps: 90978dfa6616d69e6b4fda1026525e014bd45e67
   cmeps: cmeps1.1.51

