### PR TITLE
Add DATM_YR_END_FILENAME xml variable for PLUMBER2

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -326,6 +326,15 @@
     <desc>Start year listed in PLUMBER2 filenames for certain datm_modes. Currently only used in PLUMBER2; leave as the default value (9999) for other cases.</desc>
   </entry>
 
+  <entry id="DATM_YR_END_FILENAME">
+    <type>integer</type>
+    <valid_values></valid_values>
+    <default_value>9999</default_value>
+    <group>run_component_datm</group>
+    <file>env_run.xml</file>
+    <desc>End year listed in PLUMBER2 filenames for certain datm_modes. Currently only used in PLUMBER2; leave as the default value (9999) for other cases.</desc>
+  </entry>
+
   <entry id="DATM_YR_END">
     <type>integer</type>
     <valid_values></valid_values>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -394,7 +394,8 @@
       <taxmode compset="HIST">limit</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
-      <dtlimit>1.5</dtlimit>
+      <dtlimit compset="2000">50.0</dtlimit>
+      <dtlimit compset="HIST">1.5</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -365,7 +365,7 @@
       <meshfile>none</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/PLUMBER2/${PLUMBER2SITE}/CLM1PT_data/CTSM_DATM_${PLUMBER2SITE}_${DATM_YR_START_FILENAME}-${DATM_YR_END}.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/PLUMBER2/${PLUMBER2SITE}/CLM1PT_data/CTSM_DATM_${PLUMBER2SITE}_${DATM_YR_START_FILENAME}-${DATM_YR_END_FILENAME}.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>ZBOT   Sa_z</var>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -391,11 +391,11 @@
     </stream_tintalgo>
     <stream_taxmode>
       <taxmode               >cycle</taxmode>
-      <taxmode compset="HIST">limit</taxmode>
+      <taxmode compset="HIST">extend</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit compset="2000">50.0</dtlimit>
-      <dtlimit compset="HIST">1.5</dtlimit>
+      <dtlimit compset="HIST">1.e30</dtlimit>
     </stream_dtlimit>
     <stream_readmode>single</stream_readmode>
   </stream_entry>

--- a/doc/source/datm.rst
+++ b/doc/source/datm.rst
@@ -196,6 +196,9 @@ DATM_YR_START
 DATM_YR_START_FILENAME
    -  Start year listed in PLUMBER2 filename
 
+DATM_YR_END_FILENAME
+   -  End year listed in PLUMBER2 filename
+
 DATM_YR_END
    -  Ending year to loop data over
 


### PR DESCRIPTION
### Description of changes
PLUMBER2 site simulations need an xml variable similar to DATM_YR_START_FILENAME to identify the end year of the datm forcing file.
We also need changes to taxmode and dtlimit for the PLUMBER2 HIST compsets.

### Specific notes


Contributors other than yourself, if any: NA

CDEPS Issues Fixed (include github issue):
   see CTSM PR https://github.com/ESCOMP/CTSM/pull/4092
  Fixes #423

Are there dependencies on other component PRs (if so list): https://github.com/ESCOMP/CTSM/pull/4092

Are changes expected to change answers (bfb, different to roundoff, more substantial): No, bfb

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): Tested within the context of https://github.com/ESCOMP/CTSM/pull/4092

Hashes used for testing: NA

