### PR TITLE
Confirm that nx*ny matches the number of elements in the model mesh

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -450,7 +450,7 @@ contains
 
     ! Initialize mesh, restart flag, compid, and logunit
     call ESMF_TraceRegionEnter('datm_strdata_init')
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ATM', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ATM', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -459,7 +459,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'ATM', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ATM', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_init')
 

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -433,6 +433,7 @@ contains
     integer                 :: current_mon   ! model month
     integer                 :: current_day   ! model day
     integer                 :: current_tod   ! model sec into model date
+    logical                 :: is_scol       ! true if this is a single-column run
     integer(i8)             :: stepno        ! step number
     real(r8)                :: nextsw_cday   ! calendar of next atm sw
     character(CL)           :: cvalue        ! character string for input config
@@ -451,7 +452,7 @@ contains
     ! Initialize mesh, restart flag, compid, and logunit
     call ESMF_TraceRegionEnter('datm_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ATM', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -459,7 +460,8 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ATM', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+         clock, 'ATM', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_init')
 

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -433,7 +433,6 @@ contains
     integer                 :: current_mon   ! model month
     integer                 :: current_day   ! model day
     integer                 :: current_tod   ! model sec into model date
-    logical                 :: is_scol       ! true if this is a single-column run
     integer(i8)             :: stepno        ! step number
     real(r8)                :: nextsw_cday   ! calendar of next atm sw
     character(CL)           :: cvalue        ! character string for input config
@@ -452,7 +451,7 @@ contains
     ! Initialize mesh, restart flag, compid, and logunit
     call ESMF_TraceRegionEnter('datm_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ATM', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -460,8 +459,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-         clock, 'ATM', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ATM', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_init')
 

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -400,7 +400,8 @@ contains
 
        ! Initialize stream data type
        if (trim(datamode) /= 'noevolve') then
-          call shr_strdata_init_from_config(sdat(ns), streamfilename, model_meshes(ns), clock, 'GLC', logunit, rc=rc)
+          call shr_strdata_init_from_config(sdat(ns), streamfilename, model_meshes(ns), nx_global(ns), ny_global(ns), &
+               clock, 'GLC', logunit, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -401,7 +401,7 @@ contains
        ! Initialize stream data type
        if (trim(datamode) /= 'noevolve') then
           call shr_strdata_init_from_config(sdat(ns), streamfilename, model_meshes(ns), nx_global(ns), ny_global(ns), &
-               clock, 'GLC', logunit, rc=rc)
+               is_scol=.false., clock=clock, compname='GLC', logunit=logunit, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -401,7 +401,7 @@ contains
        ! Initialize stream data type
        if (trim(datamode) /= 'noevolve') then
           call shr_strdata_init_from_config(sdat(ns), streamfilename, model_meshes(ns), nx_global(ns), ny_global(ns), &
-               is_scol=.false., clock=clock, compname='GLC', logunit=logunit, rc=rc)
+               clock, 'GLC', logunit, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -310,6 +310,7 @@ contains
     integer                     :: current_mon   ! model month
     integer                     :: current_day   ! model day
     integer                     :: current_tod   ! model sec into model date
+    logical                     :: is_scol       ! true if this is a single-column run
     real(R8)                    :: cosarg        ! for setting ice temp pattern
     real(R8)                    :: jday, jday0   ! elapsed day counters
     integer                     :: model_dt      ! integer model timestep
@@ -327,7 +328,7 @@ contains
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('dice_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ICE', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -335,7 +336,8 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ICE', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+         clock, 'ICE', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dice_strdata_init')
 

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -326,7 +326,7 @@ contains
 
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('dice_strdata_init')
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ICE', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ICE', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -335,7 +335,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'ICE', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ICE', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dice_strdata_init')
 

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -310,7 +310,6 @@ contains
     integer                     :: current_mon   ! model month
     integer                     :: current_day   ! model day
     integer                     :: current_tod   ! model sec into model date
-    logical                     :: is_scol       ! true if this is a single-column run
     real(R8)                    :: cosarg        ! for setting ice temp pattern
     real(R8)                    :: jday, jday0   ! elapsed day counters
     integer                     :: model_dt      ! integer model timestep
@@ -328,7 +327,7 @@ contains
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('dice_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ICE', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -336,8 +335,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-         clock, 'ICE', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ICE', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dice_strdata_init')
 

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -288,7 +288,7 @@ contains
 
     ! Initialize sdat
     call ESMF_TraceRegionEnter('dlnd_strdata_init')
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'LND', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'LND', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
 
     ! Initialize stream data type
@@ -296,7 +296,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'LND', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'LND', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dlnd_strdata_init')
 

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -280,6 +280,7 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
+    logical         :: is_scol      ! true if this is a single-column run
     character(len=cl) :: rpfile     ! restart pointer file name
     character(len=*),parameter :: subname=trim(modName)//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
@@ -289,14 +290,15 @@ contains
     ! Initialize sdat
     call ESMF_TraceRegionEnter('dlnd_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'LND', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
 
     ! Initialize stream data type
     streamfilename = 'dlnd.streams'//trim(inst_suffix)
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'LND', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+         clock, 'LND', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dlnd_strdata_init')
 

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -280,7 +280,6 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
-    logical         :: is_scol      ! true if this is a single-column run
     character(len=cl) :: rpfile     ! restart pointer file name
     character(len=*),parameter :: subname=trim(modName)//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
@@ -290,15 +289,14 @@ contains
     ! Initialize sdat
     call ESMF_TraceRegionEnter('dlnd_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'LND', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
 
     ! Initialize stream data type
     streamfilename = 'dlnd.streams'//trim(inst_suffix)
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-         clock, 'LND', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'LND', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dlnd_strdata_init')
 

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -370,6 +370,7 @@ contains
     integer                :: current_mon  ! model month
     integer                :: current_day  ! model day
     integer                :: current_tod  ! model sec into model date
+    logical                :: is_scol      ! true if this is a single-column run
     type(ESMF_Field)       :: lfield
     character(CL) ,pointer :: lfieldnamelist(:) => null()
     integer                :: fieldcount
@@ -399,7 +400,7 @@ contains
     end if
 
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'OCN', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type if not aqua planet
@@ -408,7 +409,8 @@ contains
 #ifndef DISABLE_FoX
        streamfilename = trim(streamfilename)//'.xml'
 #endif
-       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'OCN', logunit, rc=rc)
+       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+            clock, 'OCN', logunit, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
     call ESMF_TraceRegionExit('docn_strdata_init')

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -398,7 +398,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'OCN', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'OCN', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -408,7 +408,7 @@ contains
 #ifndef DISABLE_FoX
        streamfilename = trim(streamfilename)//'.xml'
 #endif
-       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'OCN', logunit, rc=rc)
+       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'OCN', logunit, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
     call ESMF_TraceRegionExit('docn_strdata_init')

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -370,7 +370,6 @@ contains
     integer                :: current_mon  ! model month
     integer                :: current_day  ! model day
     integer                :: current_tod  ! model sec into model date
-    logical                :: is_scol      ! true if this is a single-column run
     type(ESMF_Field)       :: lfield
     character(CL) ,pointer :: lfieldnamelist(:) => null()
     integer                :: fieldcount
@@ -400,7 +399,7 @@ contains
     end if
 
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'OCN', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type if not aqua planet
@@ -409,8 +408,7 @@ contains
 #ifndef DISABLE_FoX
        streamfilename = trim(streamfilename)//'.xml'
 #endif
-       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-            clock, 'OCN', logunit, rc=rc)
+       call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'OCN', logunit, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
     call ESMF_TraceRegionExit('docn_strdata_init')

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -287,7 +287,7 @@ contains
 
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('drof_strdata_init')
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ROF', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ROF', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -296,7 +296,7 @@ contains
 #ifndef DISABLE_FOX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'ROF', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ROF', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('drof_strdata_init')
 

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -280,6 +280,7 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
+    logical         :: is_scol      ! true if this is a single-column run
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
     !--------------------------------
 
@@ -288,7 +289,7 @@ contains
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('drof_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ROF', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -296,7 +297,8 @@ contains
 #ifndef DISABLE_FOX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ROF', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+         clock, 'ROF', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('drof_strdata_init')
 

--- a/drof/rof_comp_nuopc.F90
+++ b/drof/rof_comp_nuopc.F90
@@ -280,7 +280,6 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
-    logical         :: is_scol      ! true if this is a single-column run
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
     !--------------------------------
 
@@ -289,7 +288,7 @@ contains
     ! Initialize mesh, restart flag, logunit
     call ESMF_TraceRegionEnter('drof_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ROF', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type
@@ -297,8 +296,7 @@ contains
 #ifndef DISABLE_FOX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-         clock, 'ROF', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'ROF', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('drof_strdata_init')
 

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -235,7 +235,7 @@ contains
   end subroutine dshr_init
 
   !===============================================================================
-  subroutine dshr_mesh_init(gcomp, sdat, nullstr, logunit, compname, model_nxg, model_nyg, &
+  subroutine dshr_mesh_init(gcomp, sdat, nullstr, logunit, compname, &
        model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, read_restart, rc)
 
     ! ----------------------------------------------
@@ -248,8 +248,6 @@ contains
     integer                    , intent(in)    :: logunit
     character(len=*)           , intent(in)    :: compname  !e.g. ATM, OCN, ...
     character(len=*)           , intent(in)    :: nullstr
-    integer                    , intent(in)    :: model_nxg
-    integer                    , intent(in)    :: model_nyg
     character(len=*)           , intent(in)    :: model_meshfile
     character(len=*)           , intent(in)    :: model_maskfile
     type(ESMF_Mesh)            , intent(out)   :: model_mesh

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -236,7 +236,7 @@ contains
 
   !===============================================================================
   subroutine dshr_mesh_init(gcomp, sdat, nullstr, logunit, compname, &
-       model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, read_restart, rc)
+       model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, read_restart, is_scol, rc)
 
     ! ----------------------------------------------
     ! Initialize model mesh
@@ -254,6 +254,7 @@ contains
     integer , pointer          , intent(out)   :: model_mask(:)
     real(r8), pointer          , intent(out)   :: model_frac(:)
     logical                    , intent(out)   :: read_restart
+    logical                    , intent(out)   :: is_scol   ! true if this is a single-column run
     integer                    , intent(out)   :: rc
 
     ! local variables
@@ -320,10 +321,13 @@ contains
     if (scol_lon > scol_spval .and. scol_lat > scol_spval) then
 
        ! This is simply a single point run
+       is_scol = .true.
        call dshr_mesh_create_scol(gcomp, compname, scol_lon, scol_lat, model_mesh, model_mask, model_frac, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     else
+
+       is_scol = .false.
 
        ! check that model_meshfile and model_maskfile exists
        if (my_task == main_task) then

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -236,7 +236,7 @@ contains
 
   !===============================================================================
   subroutine dshr_mesh_init(gcomp, sdat, nullstr, logunit, compname, &
-       model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, read_restart, is_scol, rc)
+       model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, read_restart, rc)
 
     ! ----------------------------------------------
     ! Initialize model mesh
@@ -254,7 +254,6 @@ contains
     integer , pointer          , intent(out)   :: model_mask(:)
     real(r8), pointer          , intent(out)   :: model_frac(:)
     logical                    , intent(out)   :: read_restart
-    logical                    , intent(out)   :: is_scol   ! true if this is a single-column run
     integer                    , intent(out)   :: rc
 
     ! local variables
@@ -321,13 +320,10 @@ contains
     if (scol_lon > scol_spval .and. scol_lat > scol_spval) then
 
        ! This is simply a single point run
-       is_scol = .true.
        call dshr_mesh_create_scol(gcomp, compname, scol_lon, scol_lat, model_mesh, model_mask, model_frac, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     else
-
-       is_scol = .false.
 
        ! check that model_meshfile and model_maskfile exists
        if (my_task == main_task) then

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -271,6 +271,7 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
+    logical         :: is_scol      ! true if this is a single-column run
     character(len=CL):: rpfile
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
@@ -280,7 +281,7 @@ contains
     ! Initialize sdat - create the model domain mesh and intialize the sdat clock
     call ESMF_TraceRegionEnter('dwav_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'WAV', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type if not aqua planet
@@ -288,7 +289,8 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'WAV', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
+         clock, 'WAV', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dwav_strdata_init')
 

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -279,7 +279,7 @@ contains
 
     ! Initialize sdat - create the model domain mesh and intialize the sdat clock
     call ESMF_TraceRegionEnter('dwav_strdata_init')
-    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'WAV', nx_global, ny_global, &
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'WAV', &
          model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -288,7 +288,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'WAV', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'WAV', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dwav_strdata_init')
 

--- a/dwav/wav_comp_nuopc.F90
+++ b/dwav/wav_comp_nuopc.F90
@@ -271,7 +271,6 @@ contains
     integer         :: current_mon  ! model month
     integer         :: current_day  ! model day
     integer         :: current_tod  ! model sec into model date
-    logical         :: is_scol      ! true if this is a single-column run
     character(len=CL):: rpfile
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
@@ -281,7 +280,7 @@ contains
     ! Initialize sdat - create the model domain mesh and intialize the sdat clock
     call ESMF_TraceRegionEnter('dwav_strdata_init')
     call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'WAV', &
-         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, is_scol, rc=rc)
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Initialize stream data type if not aqua planet
@@ -289,8 +288,7 @@ contains
 #ifndef DISABLE_FoX
     streamfilename = trim(streamfilename)//'.xml'
 #endif
-    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, is_scol, &
-         clock, 'WAV', logunit, rc=rc)
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, nx_global, ny_global, clock, 'WAV', logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dwav_strdata_init')
 

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -127,8 +127,6 @@ module dshr_strdata_mod
      type(ESMF_Mesh)                :: model_mesh                      ! model mesh
      real(r8), pointer              :: model_lon(:) => null()          ! model longitudes
      real(r8), pointer              :: model_lat(:) => null()          ! model latitudes
-     integer                        :: model_nxg                       ! model global domain lon size
-     integer                        :: model_nyg                       ! model global domain lat size
      integer                        :: model_nzg                       ! model global domain vertical size
      integer                        :: model_lsize                     ! model local domain size
      integer, pointer               :: model_gindex(:)                 ! model global index spzce
@@ -188,12 +186,15 @@ contains
   end function shr_strdata_get_stream_fieldbundle
 
   !===============================================================================
-  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, compname, logunit, rc)
+  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, model_nxg, model_nyg, &
+       clock, compname, logunit, rc)
 
     ! input/output variables
     type(shr_strdata_type)     , intent(inout) :: sdat
     character(len=*)           , intent(in)    :: streamfilename
     type(ESMF_Mesh)            , intent(in)    :: model_mesh
+    integer                    , intent(in)    :: model_nxg           ! model global domain lon size
+    integer                    , intent(in)    :: model_nyg           ! model global domain lat size
     type(ESMF_Clock)           , intent(in)    :: clock
     character(len=*)           , intent(in)    :: compname
     integer                    , intent(in)    :: logunit
@@ -249,6 +250,16 @@ contains
     sdat%model_mesh = model_mesh
     call shr_strdata_init_model_domain(sdat, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Verify that the declared global grid dimensions are consistent with the total number of points
+    ! in the model mesh (model_gsize was just computed by shr_strdata_init_model_domain).
+    if (model_nxg * model_nyg /= sdat%model_gsize) then
+       call shr_log_error(subname//' ERROR: for component '//trim(compname)// &
+            ', nx*ny ('//toString(model_nxg*model_nyg)// &
+            ') does not equal the total number of points in the model mesh ('// &
+            toString(sdat%model_gsize)//')', rc=rc)
+       return
+    end if
 
     ! Now finish initializing sdat
     call shr_strdata_init(sdat, clock, rc=rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -186,7 +186,7 @@ contains
   end function shr_strdata_get_stream_fieldbundle
 
   !===============================================================================
-  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, model_nxg, model_nyg, &
+  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, model_nxg, model_nyg, is_scol, &
        clock, compname, logunit, rc)
 
     ! input/output variables
@@ -195,6 +195,7 @@ contains
     type(ESMF_Mesh)            , intent(in)    :: model_mesh
     integer                    , intent(in)    :: model_nxg           ! model global domain lon size
     integer                    , intent(in)    :: model_nyg           ! model global domain lat size
+    logical                    , intent(in)    :: is_scol             ! true if this is a single-column run
     type(ESMF_Clock)           , intent(in)    :: clock
     character(len=*)           , intent(in)    :: compname
     integer                    , intent(in)    :: logunit
@@ -251,14 +252,25 @@ contains
     call shr_strdata_init_model_domain(sdat, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Verify that the declared global grid dimensions are consistent with the total number of points
-    ! in the model mesh (model_gsize was just computed by shr_strdata_init_model_domain).
-    if (model_nxg * model_nyg /= sdat%model_gsize) then
-       call shr_log_error(subname//' ERROR: for component '//trim(compname)// &
-            ', nx*ny ('//toString(model_nxg*model_nyg)// &
-            ') does not equal the total number of points in the model mesh ('// &
-            toString(sdat%model_gsize)//')', rc=rc)
-       return
+    ! Verify that the declared global grid dimensions are consistent with the total number
+    ! of points in the model mesh (model_gsize was just computed by
+    ! shr_strdata_init_model_domain).
+    !
+    ! This check is bypassed for single-column runs as a workaround for a bug in the
+    ! single-column logic (https://github.com/ESCOMP/CDEPS/issues/419): in single-column
+    ! runs, model_nxg and model_nyg incorrectly keep their full global grid sizes while
+    ! the single-column mesh has exactly 1 point.
+    !
+    ! TODO: remove the is_scol bypass (and possibly the is_scol argument) once
+    ! single-column runs set nx_global and ny_global correctly (i.e., to 1).
+    if (.not. is_scol) then
+       if (model_nxg * model_nyg /= sdat%model_gsize) then
+          call shr_log_error(subname//' ERROR: for component '//trim(compname)// &
+               ', nx*ny ('//toString(model_nxg*model_nyg)// &
+               ') does not equal the total number of points in the model mesh ('// &
+               toString(sdat%model_gsize)//')', rc=rc)
+          return
+       end if
     end if
 
     ! Now finish initializing sdat

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -186,7 +186,7 @@ contains
   end function shr_strdata_get_stream_fieldbundle
 
   !===============================================================================
-  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, model_nxg, model_nyg, is_scol, &
+  subroutine shr_strdata_init_from_config(sdat, streamfilename, model_mesh, model_nxg, model_nyg, &
        clock, compname, logunit, rc)
 
     ! input/output variables
@@ -195,7 +195,6 @@ contains
     type(ESMF_Mesh)            , intent(in)    :: model_mesh
     integer                    , intent(in)    :: model_nxg           ! model global domain lon size
     integer                    , intent(in)    :: model_nyg           ! model global domain lat size
-    logical                    , intent(in)    :: is_scol             ! true if this is a single-column run
     type(ESMF_Clock)           , intent(in)    :: clock
     character(len=*)           , intent(in)    :: compname
     integer                    , intent(in)    :: logunit
@@ -252,25 +251,14 @@ contains
     call shr_strdata_init_model_domain(sdat, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Verify that the declared global grid dimensions are consistent with the total number
-    ! of points in the model mesh (model_gsize was just computed by
-    ! shr_strdata_init_model_domain).
-    !
-    ! This check is bypassed for single-column runs as a workaround for a bug in the
-    ! single-column logic (https://github.com/ESCOMP/CDEPS/issues/419): in single-column
-    ! runs, model_nxg and model_nyg incorrectly keep their full global grid sizes while
-    ! the single-column mesh has exactly 1 point.
-    !
-    ! TODO: remove the is_scol bypass (and possibly the is_scol argument) once
-    ! single-column runs set nx_global and ny_global correctly (i.e., to 1).
-    if (.not. is_scol) then
-       if (model_nxg * model_nyg /= sdat%model_gsize) then
-          call shr_log_error(subname//' ERROR: for component '//trim(compname)// &
-               ', nx*ny ('//toString(model_nxg*model_nyg)// &
-               ') does not equal the total number of points in the model mesh ('// &
-               toString(sdat%model_gsize)//')', rc=rc)
-          return
-       end if
+    ! Verify that the declared global grid dimensions are consistent with the total number of points
+    ! in the model mesh (model_gsize was just computed by shr_strdata_init_model_domain).
+    if (model_nxg * model_nyg /= sdat%model_gsize) then
+       call shr_log_error(subname//' ERROR: for component '//trim(compname)// &
+            ', nx*ny ('//toString(model_nxg*model_nyg)// &
+            ') does not equal the total number of points in the model mesh ('// &
+            toString(sdat%model_gsize)//')', rc=rc)
+       return
     end if
 
     ! Now finish initializing sdat


### PR DESCRIPTION
### Description of changes

Confirm that the model's specified nx*ny matches the number of elements in the model mesh.

At least in CESM, NX and NY come from XML variables like ATM_NX and ATM_NY. These are specified for pre-defined grids, but can be incorrect in some workflows with user-defined grids. Prior to this PR, this would sometimes be okay, but would sometimes cause hard-to-diagnose errors upon restart because fields on the CMEPS restart file would have incorrect sizes, leading to data corruption upon restart. This PR adds an explicit error check of this condition.

This currently bypasses the check for single-column runs because variables like ATM_NX and ATM_NY are currently set improperly for single-column runs due to #419 .

Code was written by Claude and thoroughly reviewed by myself.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):
- Resolves #418 

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
- aux_cdeps: tests pass and bit-for-bit (but with a few BFAILs due to missing baselines)
- aux_cime_baselines derecho tests: tests pass (except for two expected failures), didn't do baseline comparisons

Hashes used for testing: cesm3_0_alpha09d but with cmeps1.1.50