### PR TITLE
Fix single_column logic

### DIFF
--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -173,8 +173,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         scol_lat = float(case.get_value('PTS_LAT'))
     else:
         scol_lat = -999.
-    if case.get_value('ATM_DOMAIN_FILE'):
-        if scol_lon > -999. and scol_lat > -999. and case.get_value("ATM_DOMAIN_FILE") != "UNSET":
+    if case.get_value('PTS_DOMAINFILE'):
+        if scol_lon > -999. and scol_lat > -999. and case.get_value("PTS_DOMAINFILE") != "UNSET":
             config['single_column'] = 'true'
         else:
             config['single_column'] = 'false'

--- a/dice/cime_config/buildnml
+++ b/dice/cime_config/buildnml
@@ -73,8 +73,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         scol_lat = float(case.get_value('PTS_LAT'))
     else:
         scol_lat = -999.
-    if case.get_value('ATM_DOMAIN_FILE'):
-        if scol_lon > -999. and scol_lat >= -999. and case.get_value("ATM_DOMAIN_FILE") != "UNSET":
+    if case.get_value('PTS_DOMAINFILE'):
+        if scol_lon > -999. and scol_lat >= -999. and case.get_value("PTS_DOMAINFILE") != "UNSET":
             config['single_column'] = 'true'
         else:
             config['single_column'] = 'false'

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -77,8 +77,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         scol_lat = float(case.get_value('PTS_LAT'))
     else:
         scol_lat = -999.
-    if case.get_value('ATM_DOMAIN_FILE'):
-        if scol_lon > -999. and scol_lat > -999. and case.get_value("ATM_DOMAIN_FILE") != "UNSET":
+    if case.get_value('PTS_DOMAINFILE'):
+        if scol_lon > -999. and scol_lat > -999. and case.get_value("PTS_DOMAINFILE") != "UNSET":
             config['single_column'] = 'true'
         else:
             config['single_column'] = 'false'


### PR DESCRIPTION
### Description of changes

There is no ATM_DOMAIN_FILE; this should be PTS_DOMAINFILE (as noted in https://github.com/ESCOMP/CMEPS/pull/164)

This will result in the following variables being set correctly in single_column mode, for datm, dice and docn:
- model_meshfile (null; I think this should have no impact)
- model_maskfile (null; I think this should have no impact)
- nx_global (this impacts cpl hist and rest files, but I think not in a critical way)
- ny_global (this impacts cpl hist and rest files, but I think not in a critical way)

Resolves ESCOMP/CDEPS#419

### Specific notes

Contributors other than yourself, if any: @mvertens 

CDEPS Issues Fixed (include github issue #):
- Resolves #419 

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb, but change in dimension sizes for some cpl hist fields in single-column tests will lead to baseline failures for these single-column tests

Any User Interface Changes (namelist or namelist defaults changes): For datm, dice and docn, in single_column mode, model_meshfile and model_maskfile are set to null, and nx_global and ny_global are set to 1

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Ran testing on these changes along with CMEPS changes to remove single-column logic (https://github.com/ESCOMP/CMEPS/pull/679). The following test results describe the results from testing these two changes together.

Ran the following, all with baseline comparisons:

(1) aux_cdeps

(2) aux_cime_baselines

(3) The two tests from the test_scam test list (but moved to derecho):
```
SCT_D_Ln7.ne3_ne3_mg37.QPC5.derecho_intel.cam-scm_prep
SCT_D_Ln7.ne3_ne3_mg37.QPC6.derecho_intel.cam-scm_prep_c6
```

(4) A G compset test (since G compsets weren't covered in the other testing):
```
SMS_D.TL319_t232.G_JRA_RYF.derecho_intel
```

(5) A selection of single-point tests from aux_clm - the derecho tests suggested in https://github.com/ESCOMP/CMEPS/issues/676#issuecomment-4972844919 (not the izumi tests from there, though):
```
ERS_D_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PtClm60SpRs.derecho_gnu.clm-CLM1PTStartDate
ERS_D_Mmpi-serial_Ld5.1x1_brazil.I2000Clm50FatesRs.derecho_gnu.clm-FatesCold
ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropQianRs.derecho_gnu.clm-cropMonthOutput
ERS_Ly5_Mmpi-serial.1x1_smallvilleIA.I1850Clm50BgcCrop.derecho_gnu.clm-ciso_monthly
ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropQianRs.derecho_intel.clm-cropMonthOutput
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_gnu.clm-ptsRLA
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_gnu.clm-ptsROA
SMS_D_Ld1_Mmpi-serial.ne3_ne3_mg37.I2000Clm50SpRs.derecho_intel.clm-ptsRLA
SMS_D_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm45BgcCropQianRs.derecho_intel.clm-cropMonthOutput
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_intel.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60SpRs.derecho_intel.clm-default--clm-NEON-TOOL--clm-nofireemis
SMS_Lm3_D_Mmpi-serial.1x1_brazil.I2000Clm50FatesCruRsGs.derecho_intel.clm-FatesColdHydro
SMS_Ly3_Mmpi-serial.1x1_numaIA.I2000Clm50BgcDvCropQianRs.derecho_gnu.clm-ignor_warn_cropMonthOutputColdStart
SSPMATRIXCN_Ly5_Mmpi-serial.1x1_numaIA.I2000Clm60BgcCropQianRs.derecho_intel.clm-ciso_monthly
SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default
SUBSETDATAREGION_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default
```

All tests passed (other than expected failures) and were bit-for-bit. `SMS_Ln9_P1.T42_T42.2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV.derecho_intel.datm-scam` has different dimension sizes in the cpl hist file (as expected), but when I used ncks to extract just point 1 from the baseline cpl hist file, it's bit-for-bit.

For the two SCP tests, in the baseline, I subset the ocn dimensions to take just the first point (keeping the atm dimensions as is because there is apparently still an issue in nx/ny on the atm side when running with CAM), and then compared the atm & cpl files from case2 against baseline (since these aren't normally compared, and these are the important single-column files); these were bit-for-bit.

Differences in NLCOMP (all expected):
- I compset 1x1 tests now have mesh_mask UNSET instead of null
- I1Pt CLM_USRDAT tests now have mesh_mask UNSET instead of null
- I compset pts tests now have mesh_mask set to a file instead of null; datm model_maskfile and model_meshfile null instead of set, and nx_global and ny_global 1 instead of 0
- I compset SUBSETDATAPOINT CLM_USRDAT has mesh_mask UNSET instead of null (no substantive diffs in SUBSETDATAREGION namelists)
- `SMS_Ld5_P1.1x1_mexicocityMEX.2000_DATM%1PT_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP.derecho_intel.datm-1PT` has mesh_mask UNSET instead of null
- `SMS_Ln9_P1.T42_T42.2000_DATM%QIA_SLND_SICE_DOCN%DOM_SROF_SGLC_SWAV.derecho_intel.datm-scam` has mesh_mask set to a file rather than null; and for both docn_nml and datm_nml, model_maskfile and model_meshfile are now null rather than set, and nx_global and ny_global are 1 rather than 128/64
- `SCT_D_Ln7.ne3_ne3_mg37.QPC6.derecho_intel.cam-scm_prep_c6` and `SCT_D_Ln7.ne3_ne3_mg37.QPC5.derecho_intel.cam-scm_prep`: case2 has diffs: mesh_mask now set to a file instead of null; docn_in has model_meshfile null instnead of a file, and nx_global 1 instead of 488

Hashes used for testing: ctsm5.4.047 for the selected tests from aux_clm; cesm3_0_alpha09d for others