### PR TITLE
New directory location for PLUMBER2 datm forcing data

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -365,7 +365,7 @@
       <meshfile>none</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/PLUMBER2/${PLUMBER2SITE}/CLM1PT_data/CTSM_DATM_${PLUMBER2SITE}_${DATM_YR_START_FILENAME}-${DATM_YR_END_FILENAME}.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/PLUMBER2.c20260729/${PLUMBER2SITE}/CLM1PT_data/CTSM_DATM_${PLUMBER2SITE}_${DATM_YR_START_FILENAME}-${DATM_YR_END_FILENAME}.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>ZBOT   Sa_z</var>


### PR DESCRIPTION
### Description of changes

Point to a new directory location for PLUMBER2 datm forcing data.

### Specific notes

Contributors other than yourself, if any: @slevis-lmwg created the new directory and rimported the new data

CDEPS Issues Fixed (include github issue #): NA

Are there dependencies on other component PRs (if so list):  This PR completes a task in https://github.com/ESCOMP/CTSM/pull/4092

Are changes expected to change answers (bfb, different to roundoff, more substantial):  PLUMBER2 site simulations will change answers.

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):  Verified PLUMBER2 sites run

Hashes used for testing: NA

