### PR TITLE
Fix some MPI broadcast issues in DGLC and other data models

### DIFF
--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -595,7 +595,7 @@ contains
 
   !===============================================================================
   subroutine dglc_datamode_noevolve_restart_read(model_meshes, restfilem, rpfile, &
-       logunit, my_task, main_task, mpicom, &
+       logunit, my_task, main_task, &
        pio_subsystem, io_type, nx_global, ny_global, rc)
 
     ! input/output arguments
@@ -605,7 +605,6 @@ contains
     integer                , intent(in)    :: logunit
     integer                , intent(in)    :: my_task
     integer                , intent(in)    :: main_task
-    integer                , intent(in)    :: mpicom
     type(iosystem_desc_t)  , pointer       :: pio_subsystem   ! pio info
     integer                , intent(in)    :: io_type         ! pio info
     integer                , intent(in)    :: nx_global(:)

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -630,13 +630,16 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     ! Determine restart file
-
-
+    !
+    ! Note that we first determine existence only on the main task, then broadcast this to
+    ! other tasks.
+    exists = .false.
     if (trim(restfilem) == trim(nullstr)) then
-       exists = .false.
-       call ESMF_VMGetCurrent(vm, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        if (my_task == main_task) then
           write(logunit,'(a)') subname//' restart filename from rpointer '//trim(rpfile)
           open(newunit=nu, file=trim(rpfile), form='formatted')
@@ -655,9 +658,13 @@ contains
     endif
     tmp = 0
     if(exists) tmp=1
+    call ESMF_VMBroadCast(vm, tmp, 1, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     exists = (tmp(1) == 1)
-    if (.not. exists .and. my_task == main_task) then
-       write(logunit, '(a)') subname//' file not found, skipping '//trim(restfilem)
+    if (.not. exists) then
+       if (my_task == main_task) then
+          write(logunit, '(a)') subname//' file not found, skipping '//trim(restfilem)
+       end if
        return
     end if
 

--- a/dglc/dglc_datamode_noevolve_mod.F90
+++ b/dglc/dglc_datamode_noevolve_mod.F90
@@ -646,7 +646,7 @@ contains
           close(nu)
           inquire(file=trim(restfilem), exist=exists)
        endif
-       call ESMF_VMBroadCast(vm, restfilem, CL, main_task, rc=rc)
+       call ESMF_VMBroadCast(vm, restfilem, len(restfilem), main_task, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
        ! use namelist already read

--- a/dglc/glc_comp_nuopc.F90
+++ b/dglc/glc_comp_nuopc.F90
@@ -554,7 +554,7 @@ contains
          call shr_get_rpointer_name(gcomp, 'glc', target_ymd, target_tod, rpfile, 'read', rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
          call dglc_datamode_noevolve_restart_read(model_meshes, restfilm, rpfile, &
-              logunit, my_task, main_task, mpicom, &
+              logunit, my_task, main_task, &
               sdat(1)%pio_subsystem, sdat(1)%io_type, nx_global, ny_global, rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if

--- a/dshr/dshr_mod.F90
+++ b/dshr/dshr_mod.F90
@@ -616,7 +616,7 @@ contains
           close(nu)
           inquire(file=trim(rest_filem), exist=exists)
        endif
-       call ESMF_VMBroadCast(vm, rest_filem, CL, main_task, rc=rc)
+       call ESMF_VMBroadCast(vm, rest_filem, len(rest_filem), main_task, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
        ! use namelist already read


### PR DESCRIPTION
### Description of changes

This PR fixes a few issues related to broadcasts, mainly in DGLC, but one fix applies to all data models:

(1) In DGLC restart read, check file existence on all tasks

Previously, the dglc restart read was only returning from the main task
if the restart file didn't exist. Other tasks would proceed into the
pio_openfile with a non-existent file.

There were two specific problems behind this:
- 'exists' (or its 'tmp' equivalent) was not being broadcast
- The return for '.not. exists' was only done for the main task

This PR fixes the logic to broadcast 'exists' and return on all tasks
if 'exists' is false. This makes the logic more similar to what's in
dshr_restart_read.

(2) Remove unused mpicom argument

(3) Fix broadcasts of restart file name to broadcast full file name

Previously, broadcasts of the restart file name incorrectly limited the number of characters broadcast. This one is fixed for all data models (in two places: one specific to DGLC and one in the data model share code).

### Specific notes

Contributors other than yourself, if any: All of these issues were identified by Claude and fixed by a combination of Claude and myself. For any changes made by Claude, I have carefully reviewed them.

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): no

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Ran these three modified tests from the aux_cdeps test suite (the originals are SMS tests; changed to ERS to test the restart code):
```
ERS_Ly3.f10_f10_ais8gris4_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
ERS_Ly3.f10_f10_ais8_mg37.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
ERS_Ly3.f19_g17_gris4.2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV.derecho_intel
```

Hashes used for testing: cesm3_0_beta09