### PR TITLE
add stream field specific unit conversions in stream_defintion_MODEL.xml

### DIFF
--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4933,8 +4933,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4966,8 +4966,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4998,8 +4998,8 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5031,8 +5031,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5064,8 +5064,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5097,8 +5097,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5130,8 +5130,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5164,8 +5164,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5274,7 +5274,11 @@
       <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>a2x1d_Faxa_ndep  Faxa_ndep</var>
+      <!-- the mediator writes the two ungridded elements of Faxa_ndep as
+           separate variables, index 1 being NHx and index 2 NOy.
+           These are already in kgN/m2/s, so no conversion factor is given. -->
+      <var>atmImp_Faxa_ndep1  Faxa_ndep_nhx</var>
+      <var>atmImp_Faxa_ndep2  Faxa_ndep_noy</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -5271,7 +5271,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.hx.atm.24h.avrg.%ymd.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <!-- the mediator writes the two ungridded elements of Faxa_ndep as

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4933,8 +4933,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4966,8 +4966,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -4998,8 +4998,9 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5031,8 +5032,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5064,8 +5065,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5097,8 +5098,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5130,8 +5131,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>
@@ -5164,8 +5165,8 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
-      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
-      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0e-3</var>
+      <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0d-3</var>
+      <var>NDEP_NOy_month  Faxa_ndep_noy  1.0d-3</var>
     </stream_datavars>
     <stream_lev_dimname>null</stream_lev_dimname>
     <stream_mapalgo>

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -26,7 +26,6 @@ module datm_pres_ndep_mod
   real(r8), pointer :: strm_Faxa_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
   real(r8), pointer :: strm_Faxa_ndep_noy(:)     => null() ! pre-cmip7 ndep data
 
-  logical :: use_cmip7_ndep
 
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
@@ -82,14 +81,11 @@ contains
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_Faxa_ndep_noy, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! determine use_cmip_ndep module variable
-    if (associated(strm_Faxa_ndep_nhx_dry) .and. associated(strm_Faxa_ndep_nhx_wet) .and. &
-        associated(strm_Faxa_ndep_noy_dry) .and. associated(strm_Faxa_ndep_noy_wet)) then
-       use_cmip7_ndep = .true.
-    else if (associated(strm_Faxa_ndep_nhx) .and. associated(strm_Faxa_ndep_noy)) then
-       use_cmip7_ndep = .false.
-    else
-       call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing', rc=rc)
+    ! Check that one of the two supported field sets was found.
+    if (.not. ((associated(strm_Faxa_ndep_nhx_dry) .and. associated(strm_Faxa_ndep_nhx_wet) .and.  &
+                associated(strm_Faxa_ndep_noy_dry) .and. associated(strm_Faxa_ndep_noy_wet)) .or. &
+               (associated(strm_Faxa_ndep_nhx)     .and. associated(strm_Faxa_ndep_noy)))) then
+       call shr_log_error('datm_pres_ndep: ERROR: no associated stream pointers for ndep forcing', rc=rc)
        return
     end if
 
@@ -98,14 +94,21 @@ contains
   !===============================================================================
   subroutine datm_pres_ndep_advance()
 
-    if (use_cmip7_ndep) then
-       ! assume data is in kgN/m2/s
+    ! Separate dry and wet deposition fields are summed where the stream provides
+    ! them; otherwise the combined fields are used.
+    !
+    ! No unit conversion happens here.  Streams whose data is not already in
+    ! kgN/m2/s declare a stream_scale_factor in the stream definition xml, and
+    ! the conversion is applied as the data is read.  Doing it here was wrong:
+    ! the same two field names are supplied in gN/m2/s by the CMIP6 forcing
+    ! datasets and in kgN/m2/s by cplhist output, so the field names cannot say
+    ! which conversion, if any, is needed.
+    if (associated(strm_Faxa_ndep_nhx_dry)) then
        Faxa_ndep(1,:) = strm_Faxa_ndep_nhx_dry(:) + strm_Faxa_ndep_nhx_wet(:)
        Faxa_ndep(2,:) = strm_Faxa_ndep_noy_dry(:) + strm_Faxa_ndep_noy_wet(:)
     else
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx(:) / 1000._r8
-       Faxa_ndep(2,:) = strm_Faxa_ndep_noy(:) / 1000._r8
+       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx(:)
+       Faxa_ndep(2,:) = strm_Faxa_ndep_noy(:)
     end if
 
   end subroutine datm_pres_ndep_advance

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -23,8 +23,8 @@ module datm_pres_ndep_mod
   real(r8), pointer :: strm_Faxa_ndep_noy_dry(:) => null() ! stream cmip7 ndep data
   real(r8), pointer :: strm_Faxa_ndep_noy_wet(:) => null() ! stream cmip7 ndep data
 
-  real(r8), pointer :: strm_Faxa_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
-  real(r8), pointer :: strm_Faxa_ndep_noy(:)     => null() ! pre-cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_nhx(:)     => null() ! pre-cmip7 ndep data and cplhist
+  real(r8), pointer :: strm_Faxa_ndep_noy(:)     => null() ! pre-cmip7 ndep data and cplhist
 
 
   character(len=*), parameter :: u_FILE_u = &
@@ -75,7 +75,7 @@ contains
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_wet', strm_Faxa_ndep_noy_wet, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! cmip6 ndep forcing
+    ! cmip6 ndep forcing and cplhist
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_nhx', strm_Faxa_ndep_nhx, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_Faxa_ndep_noy, rc)

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -96,13 +96,6 @@ contains
 
     ! Separate dry and wet deposition fields are summed where the stream provides
     ! them; otherwise the combined fields are used.
-    !
-    ! No unit conversion happens here.  Streams whose data is not already in
-    ! kgN/m2/s declare a stream_scale_factor in the stream definition xml, and
-    ! the conversion is applied as the data is read.  Doing it here was wrong:
-    ! the same two field names are supplied in gN/m2/s by the CMIP6 forcing
-    ! datasets and in kgN/m2/s by cplhist output, so the field names cannot say
-    ! which conversion, if any, is needed.
     if (associated(strm_Faxa_ndep_nhx_dry)) then
        Faxa_ndep(1,:) = strm_Faxa_ndep_nhx_dry(:) + strm_Faxa_ndep_nhx_wet(:)
        Faxa_ndep(2,:) = strm_Faxa_ndep_noy_dry(:) + strm_Faxa_ndep_noy_wet(:)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -34,6 +34,7 @@ module dshr_strdata_mod
   use shr_string_mod   , only : shr_string_listgetname, shr_string_listisvalid, shr_string_listgetnum
 
   use dshr_stream_mod  , only : shr_stream_streamtype, shr_stream_getModelFieldList, shr_stream_getStreamFieldList
+  use dshr_stream_mod  , only : shr_stream_getFieldScaleFactors
   use dshr_stream_mod  , only : shr_stream_taxis_cycle, shr_stream_taxis_extend, shr_stream_findBounds
   use dshr_stream_mod  , only : shr_stream_getCurrFile, shr_stream_setCurrFile, shr_stream_getMeshFilename
   use dshr_stream_mod  , only : shr_stream_init_from_inline, shr_stream_init_from_esmfconfig
@@ -98,6 +99,7 @@ module dshr_strdata_mod
      type(ESMF_RouteHandle)              :: routehandle                     ! stream n -> model mesh mapping
      character(len=CL), allocatable      :: fldlist_stream(:)               ! names of stream file fields
      character(len=CL), allocatable      :: fldlist_model(:)                ! names of stream model fields
+     real(r8), allocatable               :: fldlist_scale(:)                ! per-field unit conversion applied on read
      integer                             :: stream_nlev                     ! number of vertical levels in stream
      real(r8), allocatable               :: stream_vlevs(:)                 ! values of vertical levels in stream
      integer                             :: stream_lb                       ! index of the Lowerbound (LB) in fldlist_stream
@@ -554,6 +556,13 @@ contains
           return
        end if
        call shr_stream_getStreamFieldList(sdat%stream(ns), sdat%pstrm(ns)%fldlist_stream)
+       allocate(sdat%pstrm(ns)%fldlist_scale(nvars), stat=istat)
+       if ( istat /= 0 ) then
+          call shr_log_error(subName//&
+               ': allocation error for sdat%pstrm('//toString(ns)//')%fldlist_scale with nvars '//toString(nvars), rc=rc)
+          return
+       end if
+       call shr_stream_getFieldScaleFactors(sdat%stream(ns), sdat%pstrm(ns)%fldlist_scale)
 
        ! Create field bundles on model mesh
        if (sdat%stream(ns)%readmode=='single') then
@@ -2130,6 +2139,22 @@ contains
           call shr_log_error(subName//"ERROR: only double, real and short types are supported for stream read", rc=rc)
           return
 
+       end if
+
+       ! Apply this field's unit conversion, if the stream definition gave one as
+       ! a third token on its <var> line.  Units belong to the field rather than
+       ! the stream, so each field carries its own factor and a stream may mix
+       ! converted and unconverted fields.
+       !
+       ! Fill values are left alone: they are markers, not measurements.  This is
+       ! separate from the CF scale_factor/add_offset unpacking above, which
+       ! undoes on-disk packing and has already been applied by this point.
+       if (per_stream%fldlist_scale(nf) /= 1.0_r8) then
+          if (stream_nlev > 1) then
+             where (dataptr2d /= r8fill) dataptr2d = dataptr2d * per_stream%fldlist_scale(nf)
+          else
+             where (dataptr1d /= r8fill) dataptr1d = dataptr1d * per_stream%fldlist_scale(nf)
+          end if
        end if
 
        if(associated(dataptr2d_src) .and. trim(per_stream%fldlist_model(nf)) .eq. uname) then

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -52,7 +52,8 @@ module dshr_stream_mod
   public :: shr_stream_findBounds        ! return lower/upper bounding date info
   public :: shr_stream_getMeshFileName   ! return stream filename
   public :: shr_stream_getModelFieldList ! return model field name list
-  public :: shr_stream_getStreamFieldList! return stream file field name list
+  public :: shr_stream_getStreamFieldList ! return stream file field name list
+  public :: shr_stream_getFieldScaleFactors ! return per-field unit conversion factors
   public :: shr_stream_getPrevFileName   ! return previous file in sequence
   public :: shr_stream_getNextFileName   ! return next file in sequence
   public :: shr_stream_getNFiles         ! get the number of files in a stream
@@ -99,6 +100,11 @@ module dshr_stream_mod
   type shr_stream_data_variable
      character(len=CS) :: nameinfile
      character(len=CS) :: nameinmodel
+     ! Optional unit conversion, applied to this field as it is read.  Given as
+     ! a third token on the <var> line in the stream definition xml; absent
+     ! means 1.0.  Units are a property of the field, not of the stream, so a
+     ! stream may mix converted and unconverted fields.
+     real(r8)          :: scale_factor = 1.0_r8
   end type shr_stream_data_variable
 
   type shr_stream_streamType
@@ -350,8 +356,7 @@ contains
           do n = 1, streamdat(i)%nvars
              p => item(varlist, n-1)
              call extractDataContent(p, tmpstr)
-             streamdat(i)%varlist(n)%nameinfile = tmpstr(1:index(tmpstr, " "))
-             streamdat(i)%varlist(n)%nameinmodel = tmpstr(index(trim(tmpstr), " ", .true.)+1:)
+             call parse_var_entry(tmpstr, streamdat(i)%varlist(n))
           enddo
 
        enddo
@@ -413,6 +418,10 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           call ESMF_VMBroadCast(vm, streamdat(i)%varlist(n)%nameinmodel, CS, 0, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          rtmp(1) = streamdat(i)%varlist(n)%scale_factor
+          call ESMF_VMBroadCast(vm, rtmp, 1, 0, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          streamdat(i)%varlist(n)%scale_factor = rtmp(1)
        enddo
        call ESMF_VMBroadCast(vm, streamdat(i)%meshfile,     CL, 0, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1612,6 +1621,70 @@ contains
     enddo
 
   end subroutine shr_stream_getModelFieldList
+
+  !===============================================================================
+  subroutine parse_var_entry(entry, var)
+
+    ! Parse one <var> line into its two or three whitespace-separated tokens:
+    !
+    !     <var>drynhx  Faxa_ndep_nhx_dry</var>
+    !     <var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
+    !
+    ! The optional third token is a unit-conversion factor applied to this field
+    ! as it is read.  Absent leaves the default of 1.0.
+
+    ! input/output parameters:
+    character(len=*)                ,intent(in)    :: entry
+    type(shr_stream_data_variable)  ,intent(inout) :: var
+
+    integer           :: pos, next, ios
+    character(len=CX) :: rest, third
+    character(len=*),parameter :: subName = '(parse_var_entry) '
+    !-------------------------------------------------------------------------------
+
+    rest = adjustl(entry)
+
+    pos = index(trim(rest), " ")
+    if (pos == 0) then
+       call shr_sys_abort(subName//" stream var entry needs at least two fields: "//trim(entry))
+    end if
+    var%nameinfile = rest(1:pos-1)
+
+    rest = adjustl(rest(pos+1:))
+    next = index(trim(rest), " ")
+    if (next == 0) then
+       ! two tokens: no conversion
+       var%nameinmodel  = trim(rest)
+       var%scale_factor = 1.0_r8
+       return
+    end if
+    var%nameinmodel = rest(1:next-1)
+
+    third = adjustl(rest(next+1:))
+    read(third, *, iostat=ios) var%scale_factor
+    if (ios /= 0) then
+       call shr_sys_abort(subName//" could not read scale factor from stream var entry: "//trim(entry))
+    end if
+
+  end subroutine parse_var_entry
+
+  !===============================================================================
+  subroutine shr_stream_getFieldScaleFactors(stream, factors)
+
+    ! Get the per-field unit-conversion factors, in the same order as
+    ! shr_stream_getStreamFieldList and shr_stream_getModelFieldList.
+
+    !input/output parameters:
+    type(shr_stream_streamType) ,intent(in)  :: stream
+    real(r8)                    ,intent(out) :: factors(:)
+    !-------------------------------------------------------------------------------
+    integer :: i
+
+    do i=1,stream%nvars
+       factors(i) = stream%varlist(i)%scale_factor
+    enddo
+
+  end subroutine shr_stream_getFieldScaleFactors
 
   !===============================================================================
   subroutine shr_stream_getStreamFieldList(stream, list)

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -1646,7 +1646,8 @@ contains
 
     pos = index(trim(rest), " ")
     if (pos == 0) then
-       call shr_sys_abort(subName//" stream var entry needs at least two fields: "//trim(entry))
+       call shr_sys_abort(subName//" stream var entry needs at least two fields: "//trim(entry), &
+            file=u_FILE_u, line=__LINE__)
     end if
     var%nameinfile = rest(1:pos-1)
 
@@ -1663,7 +1664,8 @@ contains
     third = adjustl(rest(next+1:))
     read(third, *, iostat=ios) var%scale_factor
     if (ios /= 0) then
-       call shr_sys_abort(subName//" could not read scale factor from stream var entry: "//trim(entry))
+       call shr_sys_abort(subName//" could not read scale factor from stream var entry: "//trim(entry), &
+            file=u_FILE_u, line=__LINE__)
     end if
 
   end subroutine parse_var_entry


### PR DESCRIPTION
### Summary
Allow a unit conversion factor on stream variables

### Description of changes
Adds an optional third token to a `<var>` line in a stream definition, giving a factor applied to that field as it is read. Uses it to fix nitrogen deposition, where the conversion was previously inferred from field names and got cplhist forcing wrong by a factor of 1000.

`datm_pres_ndep_mod` decided whether to convert nitrogen deposition from gN/m2/s to kgN/m2/s by looking at which stream fields were present: four fields meant no conversion, two fields meant divide by 1000.

A `<var>` line may now carry a conversion factor:

```xml
<var>drynhx  Faxa_ndep_nhx_dry</var>
<var>NDEP_NHx_month  Faxa_ndep_nhx  1.0e-3</var>
```

- The factor is applied in `dshr_strdata_mod` as the field is read, so the data enters the system already in the units the model expects and no component carries conversion logic of its own.
- Existing two-token entries are unaffected 
- **The factor sits on the variable rather than the stream because units are a property of the field.** A single stream may carry some fields needing conversion and others not, which a stream-wide factor could not express.
- `datm_pres_ndep_mod` now only sums the fields it is given.


### Specific notes

Contributors other than yourself, if any: claude

CDEPS Issues Fixed: #437 

Are there dependencies on other component PRs:

Are changes expected to change answers: different to roundoff
- Since we are now multiply by 1.0e-3 rather than dividing by 1000 - the answers are round off different
- Testing was done in NorESM for the following compset/resolution:
COMPSET: 1850_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_MOSART_CISM2%GRIS-EVOLVE_SWAV_SESP
GRID: a%1.9x2.5_l%1.9x2.5_oi%null_r%r05_w%null_z%null_g%gris4_m%tnx1v4
And the following was obtained for the diffs:
 ```
atmImp_Faxa_ndep1   (atmImp_nx,atmImp_ny,time)  t_index =      1     1
       6630    13824  (    43,    55,     1) (    23,     6,     1) (    43,    56,     1) (   123,    15,     1)
               13824   3.338589824444479E-11   3.220082898594232E-16 6.5E-27  2.973562882264960E-11 8.1E-17  2.278254265933821E-13
               13824   3.338589824444479E-11   3.220082898594232E-16          2.973562882264959E-11          2.278254265933820E-13
               13824  (    43,    55,     1) (    23,     6,     1)
          avg abs field values:    6.873940049853111E-13    rms diff: 1.9E-28   avg rel diff(npos):  8.1E-17
                                   6.873940049853111E-13                        avg decimal digits(ndif): 15.8 worst: 15.4
 RMS atmImp_Faxa_ndep1                1.8978E-28            NORMALIZED  2.7609E-16

 atmImp_Faxa_ndep2   (atmImp_nx,atmImp_ny,time)  t_index =      1     1
       6683    13824  (     5,    50,     1) (    50,     8,     1) (    13,    50,     1) (   117,    28,     1)
               13824   6.316566797644321E-11   9.343714994332430E-15 1.3E-26  4.566923188557707E-11 8.1E-17  9.105195619604070E-13
               13824   6.316566797644321E-11   9.343714994332428E-15          4.566923188557706E-11          9.105195619604066E-13
               13824  (     5,    50,     1) (    50,     8,     1)
          avg abs field values:    6.168908270901164E-13    rms diff: 3.2E-28   avg rel diff(npos):  8.1E-17
                                   6.168908270901162E-13                        avg decimal digits(ndif): 15.8 worst: 15.4
 RMS atmImp_Faxa_ndep2                3.1973E-28            NORMALIZED  5.1829E-16
```


Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

